### PR TITLE
Fix cross-thread race condition on BLE connection maps

### DIFF
--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -734,13 +734,19 @@ void NimBLEPlatform::processPendingDisconnects() {
     while (_pending_disc_read != _pending_disc_write) {
         PendingDisconnect& pd = _pending_disc_queue[_pending_disc_read];
 
-        // Hold _conn_mutex while modifying _connections/_clients/_cached_rx_chars
+        // Hold _conn_mutex while modifying _connections/_clients/_cached_*_chars
         // to prevent races with write() called from the main loop task.
         ConnectionHandle conn;
         bool found = false;
         bool is_peripheral = pd.is_peripheral;
 
         NimBLEClient* client_to_delete = nullptr;
+
+        // If GATT ops are in flight, defer this disconnect to avoid blocking
+        // the loop task. It will be retried on the next iteration.
+        if (hasActiveWriteOperations()) {
+            break;
+        }
 
         if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
             auto conn_it = _connections.find(pd.conn_handle);
@@ -759,6 +765,8 @@ void NimBLEPlatform::processPendingDisconnects() {
                         _clients.erase(client_it);
                     }
                     _cached_rx_chars.erase(pd.conn_handle);
+                    _cached_tx_chars.erase(pd.conn_handle);
+                    _cached_identity_chars.erase(pd.conn_handle);
                 }
             }
             xSemaphoreGive(_conn_mutex);
@@ -767,14 +775,9 @@ void NimBLEPlatform::processPendingDisconnects() {
             break;  // Retry next loop iteration
         }
 
-        // Delete client AFTER releasing mutex — wait for any in-flight
-        // write() calls that may still hold a child characteristic pointer.
+        // Delete client AFTER releasing mutex. GATT ops were checked above,
+        // so no in-flight operations should be holding child pointers.
         if (client_to_delete) {
-            int wait_ms = 0;
-            while (hasActiveWriteOperations() && wait_ms < 5000) {
-                vTaskDelay(pdMS_TO_TICKS(10));
-                wait_ms += 10;
-            }
             NimBLEDevice::deleteClient(client_to_delete);
         }
 
@@ -1480,15 +1483,23 @@ bool NimBLEPlatform::discoverServices(uint16_t conn_handle) {
         return false;
     }
 
-    // Update connection with characteristic handles
-    auto conn_it = _connections.find(conn_handle);
-    if (conn_it != _connections.end()) {
-        conn_it->second.rx_char_handle = rxChar->getHandle();
-        conn_it->second.tx_char_handle = txChar->getHandle();
-        if (idChar) {
-            conn_it->second.identity_handle = idChar->getHandle();
+    // Update connection with characteristic handles and cache char pointers
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(200))) {
+        auto conn_it = _connections.find(conn_handle);
+        if (conn_it != _connections.end()) {
+            conn_it->second.rx_char_handle = rxChar->getHandle();
+            conn_it->second.tx_char_handle = txChar->getHandle();
+            if (idChar) {
+                conn_it->second.identity_handle = idChar->getHandle();
+            }
+            conn_it->second.state = ConnectionState::READY;
         }
-        conn_it->second.state = ConnectionState::READY;
+        _cached_rx_chars[conn_handle] = rxChar;
+        _cached_tx_chars[conn_handle] = txChar;
+        if (idChar) {
+            _cached_identity_chars[conn_handle] = idChar;
+        }
+        xSemaphoreGive(_conn_mutex);
     }
 
     DEBUG("NimBLEPlatform: Services discovered for " + std::to_string(conn_handle));
@@ -1698,21 +1709,10 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
             return false;
         }
 
-        // Use cached RX characteristic pointer to avoid repeated service/char lookups
+        // Use cached RX characteristic pointer (populated by discoverServices())
         auto cached_it = _cached_rx_chars.find(conn_handle);
         if (cached_it != _cached_rx_chars.end()) {
             rxChar = cached_it->second;
-        } else {
-            NimBLERemoteService* service = client->getService(UUID::SERVICE);
-            if (!service) {
-                xSemaphoreGive(_conn_mutex);
-                WARNING("NimBLEPlatform::write: service not found for handle " + std::to_string(conn_handle));
-                return false;
-            }
-            rxChar = service->getCharacteristic(UUID::RX_CHAR);
-            if (rxChar) {
-                _cached_rx_chars[conn_handle] = rxChar;
-            }
         }
 
         // Register active op BEFORE releasing mutex so processPendingDisconnects()
@@ -1744,7 +1744,7 @@ bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_han
         return false;
     }
 
-    // Resolve pointers under _conn_mutex, release before blocking writeValue()
+    // Resolve pointers under _conn_mutex using cached chars, release before blocking writeValue()
     NimBLERemoteCharacteristic* chr = nullptr;
     {
         if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
@@ -1763,20 +1763,19 @@ bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_han
             return false;
         }
 
-        NimBLERemoteService* service = client->getService(UUID::SERVICE);
-        if (!service) {
-            xSemaphoreGive(_conn_mutex);
-            return false;
-        }
-
-        // Find characteristic by handle
+        // Use cached characteristic pointers — populated after service discovery
         auto conn_it = _connections.find(conn_handle);
         if (conn_it != _connections.end() && char_handle == conn_it->second.identity_handle) {
-            chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+            auto id_it = _cached_identity_chars.find(conn_handle);
+            if (id_it != _cached_identity_chars.end()) {
+                chr = id_it->second;
+            }
         }
-        // Fall through to RX_CHAR if not identity
         if (!chr) {
-            chr = service->getCharacteristic(UUID::RX_CHAR);
+            auto rx_it = _cached_rx_chars.find(conn_handle);
+            if (rx_it != _cached_rx_chars.end()) {
+                chr = rx_it->second;
+            }
         }
 
         if (chr) {
@@ -1800,7 +1799,7 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
         return false;
     }
 
-    // Resolve pointers under _conn_mutex, release before blocking readValue()
+    // Resolve pointers under _conn_mutex using cached chars, release before blocking readValue()
     NimBLERemoteCharacteristic* chr = nullptr;
     {
         if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
@@ -1822,17 +1821,13 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
             return false;
         }
 
-        NimBLERemoteService* service = client->getService(UUID::SERVICE);
-        if (!service) {
-            xSemaphoreGive(_conn_mutex);
-            if (callback) callback(OperationResult::NOT_FOUND, Bytes());
-            return false;
-        }
-
-        // Find characteristic by handle
+        // Use cached identity characteristic pointer
         auto conn_it = _connections.find(conn_handle);
         if (conn_it != _connections.end() && char_handle == conn_it->second.identity_handle) {
-            chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+            auto id_it = _cached_identity_chars.find(conn_handle);
+            if (id_it != _cached_identity_chars.end()) {
+                chr = id_it->second;
+            }
         }
 
         if (chr) {
@@ -1862,7 +1857,7 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
         return false;
     }
 
-    // Resolve pointers under _conn_mutex, release before blocking subscribe()
+    // Resolve pointers under _conn_mutex using cached chars, release before blocking subscribe()
     NimBLERemoteCharacteristic* txChar = nullptr;
     BLEAddress expected_peer;
     {
@@ -1882,13 +1877,11 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
             return false;
         }
 
-        NimBLERemoteService* service = client->getService(UUID::SERVICE);
-        if (!service) {
-            xSemaphoreGive(_conn_mutex);
-            return false;
+        // Use cached TX characteristic pointer
+        auto tx_it = _cached_tx_chars.find(conn_handle);
+        if (tx_it != _cached_tx_chars.end()) {
+            txChar = tx_it->second;
         }
-
-        txChar = service->getCharacteristic(UUID::TX_CHAR);
         if (!txChar) {
             xSemaphoreGive(_conn_mutex);
             return false;
@@ -1958,6 +1951,8 @@ std::vector<ConnectionHandle> NimBLEPlatform::getConnections() const {
             result.push_back(kv.second);
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::getConnections: mutex timeout");
     }
     return result;
 }
@@ -1970,6 +1965,8 @@ ConnectionHandle NimBLEPlatform::getConnection(uint16_t handle) const {
             result = it->second;
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::getConnection: mutex timeout for handle " + std::to_string(handle));
     }
     return result;
 }
@@ -1979,6 +1976,8 @@ size_t NimBLEPlatform::getConnectionCount() const {
     if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
         count = _connections.size();
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::getConnectionCount: mutex timeout");
     }
     return count;
 }
@@ -1993,6 +1992,8 @@ bool NimBLEPlatform::isConnectedTo(const BLEAddress& address) const {
             }
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::isConnectedTo: mutex timeout");
     }
     return found;
 }
@@ -2007,6 +2008,8 @@ bool NimBLEPlatform::isDeviceConnected(const std::string& addrKey) const {
             }
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::isDeviceConnected: mutex timeout");
     }
     return found;
 }

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -2576,6 +2576,9 @@ void NimBLEPlatform::updateConnectionMTU(uint16_t conn_handle, uint16_t mtu) {
             it->second.mtu = mtu - MTU::ATT_OVERHEAD;
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::updateConnectionMTU: mutex timeout for handle " +
+                std::to_string(conn_handle));
     }
 }
 

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1513,7 +1513,8 @@ bool NimBLEPlatform::discoverServices(uint16_t conn_handle) {
         WARNING("NimBLEPlatform::discoverServices: mutex timeout, handle=" +
                 std::to_string(conn_handle));
         if (_on_services_discovered) {
-            ConnectionHandle conn = getConnection(conn_handle);
+            ConnectionHandle conn;
+            conn.handle = conn_handle;
             _on_services_discovered(conn, false);
         }
         return false;

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -749,6 +749,13 @@ void NimBLEPlatform::processPendingDisconnects() {
         }
 
         if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
+            // Re-check under mutex: a write() on the other core may have
+            // called beginWriteOperation() between our check above and
+            // this mutex acquisition.
+            if (hasActiveWriteOperations()) {
+                xSemaphoreGive(_conn_mutex);
+                break;
+            }
             auto conn_it = _connections.find(pd.conn_handle);
             if (conn_it != _connections.end()) {
                 conn = conn_it->second;
@@ -1493,11 +1500,13 @@ bool NimBLEPlatform::discoverServices(uint16_t conn_handle) {
                 conn_it->second.identity_handle = idChar->getHandle();
             }
             conn_it->second.state = ConnectionState::READY;
-        }
-        _cached_rx_chars[conn_handle] = rxChar;
-        _cached_tx_chars[conn_handle] = txChar;
-        if (idChar) {
-            _cached_identity_chars[conn_handle] = idChar;
+            // Only cache if connection still exists — if it was deleted
+            // during blocking discovery, caching would leave dangling pointers.
+            _cached_rx_chars[conn_handle] = rxChar;
+            _cached_tx_chars[conn_handle] = txChar;
+            if (idChar) {
+                _cached_identity_chars[conn_handle] = idChar;
+            }
         }
         xSemaphoreGive(_conn_mutex);
     }
@@ -2126,6 +2135,9 @@ void NimBLEPlatform::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) 
     if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
         _connections[conn_handle] = conn;
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform: onConnect(server): mutex timeout, handle=" +
+                std::to_string(conn_handle) + " not tracked");
     }
 
     DEBUG("NimBLEPlatform: Central connected: " + conn.peer_address.toString() +
@@ -2231,6 +2243,9 @@ void NimBLEPlatform::onConnect(NimBLEClient* pClient) {
         _connections[conn_handle] = conn;
         _clients[conn_handle] = pClient;
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform: onConnect(client): mutex timeout, handle=" +
+                std::to_string(conn_handle) + " not tracked");
     }
 
     DEBUG("NimBLEPlatform: Connected to peripheral: " + peer_addr.toString() +

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1780,7 +1780,10 @@ bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_han
 
     if (!chr) return false;
 
-    return chr->writeValue(data.data(), data.size(), response);
+    beginWriteOperation();
+    bool result = chr->writeValue(data.data(), data.size(), response);
+    endWriteOperation();
+    return result;
 }
 
 bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
@@ -1833,7 +1836,9 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
         return false;
     }
 
+    beginWriteOperation();
     NimBLEAttValue value = chr->readValue();
+    endWriteOperation();
     if (callback) {
         Bytes result(value.data(), value.size());
         callback(OperationResult::SUCCESS, result);
@@ -1903,9 +1908,15 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
             }
         };
 
-        return txChar->subscribe(true, notifyCb);
+        beginWriteOperation();
+        bool result = txChar->subscribe(true, notifyCb);
+        endWriteOperation();
+        return result;
     } else {
-        return txChar->unsubscribe();
+        beginWriteOperation();
+        bool result = txChar->unsubscribe();
+        endWriteOperation();
+        return result;
     }
 }
 

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -740,6 +740,8 @@ void NimBLEPlatform::processPendingDisconnects() {
         bool found = false;
         bool is_peripheral = pd.is_peripheral;
 
+        NimBLEClient* client_to_delete = nullptr;
+
         if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
             auto conn_it = _connections.find(pd.conn_handle);
             if (conn_it != _connections.end()) {
@@ -748,12 +750,12 @@ void NimBLEPlatform::processPendingDisconnects() {
                 found = true;
 
                 if (!pd.is_peripheral) {
-                    // Central mode: clean up client object and cached char pointer
+                    // Central mode: remove from maps, defer client deletion
+                    // until after mutex release to avoid use-after-free when
+                    // write() holds a pointer to a child characteristic.
                     auto client_it = _clients.find(pd.conn_handle);
                     if (client_it != _clients.end()) {
-                        if (client_it->second) {
-                            NimBLEDevice::deleteClient(client_it->second);
-                        }
+                        client_to_delete = client_it->second;
                         _clients.erase(client_it);
                     }
                     _cached_rx_chars.erase(pd.conn_handle);
@@ -763,6 +765,17 @@ void NimBLEPlatform::processPendingDisconnects() {
         } else {
             WARNING("NimBLEPlatform: Could not acquire mutex for disconnect processing");
             break;  // Retry next loop iteration
+        }
+
+        // Delete client AFTER releasing mutex — wait for any in-flight
+        // write() calls that may still hold a child characteristic pointer.
+        if (client_to_delete) {
+            int wait_ms = 0;
+            while (hasActiveWriteOperations() && wait_ms < 5000) {
+                vTaskDelay(pdMS_TO_TICKS(10));
+                wait_ms += 10;
+            }
+            NimBLEDevice::deleteClient(client_to_delete);
         }
 
         if (found) {
@@ -1942,25 +1955,40 @@ ConnectionHandle NimBLEPlatform::getConnection(uint16_t handle) const {
 }
 
 size_t NimBLEPlatform::getConnectionCount() const {
-    return _connections.size();
+    size_t count = 0;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        count = _connections.size();
+        xSemaphoreGive(_conn_mutex);
+    }
+    return count;
 }
 
 bool NimBLEPlatform::isConnectedTo(const BLEAddress& address) const {
-    for (const auto& kv : _connections) {
-        if (kv.second.peer_address == address) {
-            return true;
+    bool found = false;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        for (const auto& kv : _connections) {
+            if (kv.second.peer_address == address) {
+                found = true;
+                break;
+            }
         }
+        xSemaphoreGive(_conn_mutex);
     }
-    return false;
+    return found;
 }
 
 bool NimBLEPlatform::isDeviceConnected(const std::string& addrKey) const {
-    for (const auto& kv : _connections) {
-        if (kv.second.peer_address.toString() == addrKey) {
-            return true;
+    bool found = false;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        for (const auto& kv : _connections) {
+            if (kv.second.peer_address.toString() == addrKey) {
+                found = true;
+                break;
+            }
         }
+        xSemaphoreGive(_conn_mutex);
     }
-    return false;
+    return found;
 }
 
 //=============================================================================

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -734,31 +734,46 @@ void NimBLEPlatform::processPendingDisconnects() {
     while (_pending_disc_read != _pending_disc_write) {
         PendingDisconnect& pd = _pending_disc_queue[_pending_disc_read];
 
-        auto conn_it = _connections.find(pd.conn_handle);
-        if (conn_it != _connections.end()) {
-            ConnectionHandle conn = conn_it->second;
-            _connections.erase(conn_it);
+        // Hold _conn_mutex while modifying _connections/_clients/_cached_rx_chars
+        // to prevent races with write() called from the main loop task.
+        ConnectionHandle conn;
+        bool found = false;
+        bool is_peripheral = pd.is_peripheral;
 
+        if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
+            auto conn_it = _connections.find(pd.conn_handle);
+            if (conn_it != _connections.end()) {
+                conn = conn_it->second;
+                _connections.erase(conn_it);
+                found = true;
+
+                if (!pd.is_peripheral) {
+                    // Central mode: clean up client object and cached char pointer
+                    auto client_it = _clients.find(pd.conn_handle);
+                    if (client_it != _clients.end()) {
+                        if (client_it->second) {
+                            NimBLEDevice::deleteClient(client_it->second);
+                        }
+                        _clients.erase(client_it);
+                    }
+                    _cached_rx_chars.erase(pd.conn_handle);
+                }
+            }
+            xSemaphoreGive(_conn_mutex);
+        } else {
+            WARNING("NimBLEPlatform: Could not acquire mutex for disconnect processing");
+            break;  // Retry next loop iteration
+        }
+
+        if (found) {
             INFO("NimBLEPlatform: Processing deferred disconnect for " +
                  conn.peer_address.toString() + " reason=" + std::to_string(pd.reason));
-
-            if (!pd.is_peripheral) {
-                // Central mode: clean up client object and cached char pointer
-                auto client_it = _clients.find(pd.conn_handle);
-                if (client_it != _clients.end()) {
-                    if (client_it->second) {
-                        NimBLEDevice::deleteClient(client_it->second);
-                    }
-                    _clients.erase(client_it);
-                }
-                _cached_rx_chars.erase(pd.conn_handle);
-            }
 
             // Clear operation queue for this connection
             clearForConnection(pd.conn_handle);
 
-            // Notify higher layers
-            if (pd.is_peripheral) {
+            // Notify higher layers (outside mutex — callbacks may re-enter)
+            if (is_peripheral) {
                 if (_on_central_disconnected) {
                     _on_central_disconnected(conn);
                 }
@@ -1630,36 +1645,54 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
         return false;
     }
 
-    auto conn_it = _connections.find(conn_handle);
-    if (conn_it == _connections.end()) {
-        DEBUG("NimBLEPlatform::write: no connection for handle " + std::to_string(conn_handle));
-        return false;
-    }
+    // Resolve characteristic pointer under _conn_mutex, then release before
+    // the blocking writeValue() call.  This prevents a race with
+    // processPendingDisconnects() which erases from these maps on the BLE task
+    // while send_outgoing() calls write() from the main loop task.
+    NimBLERemoteCharacteristic* rxChar = nullptr;
+    {
+        if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+            DEBUG("NimBLEPlatform::write: could not acquire mutex");
+            return false;
+        }
 
-    ConnectionHandle& conn = conn_it->second;
+        auto conn_it = _connections.find(conn_handle);
+        if (conn_it == _connections.end()) {
+            xSemaphoreGive(_conn_mutex);
+            DEBUG("NimBLEPlatform::write: no connection for handle " + std::to_string(conn_handle));
+            return false;
+        }
 
-    if (conn.local_role == Role::CENTRAL) {
-        // We are central - write to peripheral's RX characteristic
+        ConnectionHandle& conn = conn_it->second;
+
+        if (conn.local_role != Role::CENTRAL) {
+            xSemaphoreGive(_conn_mutex);
+            WARNING("NimBLEPlatform: write() called in peripheral mode, use notify()");
+            return false;
+        }
+
         auto client_it = _clients.find(conn_handle);
         if (client_it == _clients.end() || !client_it->second) {
+            xSemaphoreGive(_conn_mutex);
             WARNING("NimBLEPlatform::write: no client for handle " + std::to_string(conn_handle));
             return false;
         }
 
         NimBLEClient* client = client_it->second;
         if (!client->isConnected()) {
+            xSemaphoreGive(_conn_mutex);
             WARNING("NimBLEPlatform::write: client not connected for handle " + std::to_string(conn_handle));
             return false;
         }
 
         // Use cached RX characteristic pointer to avoid repeated service/char lookups
-        NimBLERemoteCharacteristic* rxChar = nullptr;
         auto cached_it = _cached_rx_chars.find(conn_handle);
         if (cached_it != _cached_rx_chars.end()) {
             rxChar = cached_it->second;
         } else {
             NimBLERemoteService* service = client->getService(UUID::SERVICE);
             if (!service) {
+                xSemaphoreGive(_conn_mutex);
                 WARNING("NimBLEPlatform::write: service not found for handle " + std::to_string(conn_handle));
                 return false;
             }
@@ -1668,24 +1701,24 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
                 _cached_rx_chars[conn_handle] = rxChar;
             }
         }
-        if (!rxChar) {
-            WARNING("NimBLEPlatform::write: RX char not found for handle " + std::to_string(conn_handle));
-            return false;
-        }
 
-        // CONC-H4: Track active write for graceful shutdown
-        beginWriteOperation();
-        bool result = rxChar->writeValue(data.data(), data.size(), response);
-        endWriteOperation();
-        if (!result) {
-            WARNING("NimBLEPlatform::write: writeValue failed for handle " + std::to_string(conn_handle));
-        }
-        return result;
-    } else {
-        // We are peripheral - this shouldn't be used, use notify instead
-        WARNING("NimBLEPlatform: write() called in peripheral mode, use notify()");
+        xSemaphoreGive(_conn_mutex);
+    }
+
+    if (!rxChar) {
+        WARNING("NimBLEPlatform::write: RX char not found for handle " + std::to_string(conn_handle));
         return false;
     }
+
+    // CONC-H4: Track active write for graceful shutdown
+    // writeValue() is a blocking GATT op — must NOT hold _conn_mutex here
+    beginWriteOperation();
+    bool result = rxChar->writeValue(data.data(), data.size(), response);
+    endWriteOperation();
+    if (!result) {
+        WARNING("NimBLEPlatform::write: writeValue failed for handle " + std::to_string(conn_handle));
+    }
+    return result;
 }
 
 bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_handle,
@@ -1694,27 +1727,44 @@ bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_han
         return false;
     }
 
-    auto client_it = _clients.find(conn_handle);
-    if (client_it == _clients.end() || !client_it->second) {
-        return false;
-    }
-
-    NimBLEClient* client = client_it->second;
-    if (!client->isConnected()) return false;
-
-    NimBLERemoteService* service = client->getService(UUID::SERVICE);
-    if (!service) return false;
-
-    // Find characteristic by handle
+    // Resolve pointers under _conn_mutex, release before blocking writeValue()
     NimBLERemoteCharacteristic* chr = nullptr;
-    auto conn_it = _connections.find(conn_handle);
-    if (conn_it != _connections.end() && char_handle == conn_it->second.identity_handle) {
-        chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+    {
+        if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+            return false;
+        }
+
+        auto client_it = _clients.find(conn_handle);
+        if (client_it == _clients.end() || !client_it->second) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        NimBLEClient* client = client_it->second;
+        if (!client->isConnected()) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        NimBLERemoteService* service = client->getService(UUID::SERVICE);
+        if (!service) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        // Find characteristic by handle
+        auto conn_it = _connections.find(conn_handle);
+        if (conn_it != _connections.end() && char_handle == conn_it->second.identity_handle) {
+            chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+        }
+        // Fall through to RX_CHAR if not identity
+        if (!chr) {
+            chr = service->getCharacteristic(UUID::RX_CHAR);
+        }
+
+        xSemaphoreGive(_conn_mutex);
     }
-    // Fall through to RX_CHAR if not identity
-    if (!chr) {
-        chr = service->getCharacteristic(UUID::RX_CHAR);
-    }
+
     if (!chr) return false;
 
     return chr->writeValue(data.data(), data.size(), response);
@@ -1727,28 +1777,42 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
         return false;
     }
 
-    auto client_it = _clients.find(conn_handle);
-    if (client_it == _clients.end() || !client_it->second) {
-        if (callback) callback(OperationResult::NOT_FOUND, Bytes());
-        return false;
-    }
-
-    NimBLEClient* client = client_it->second;
-    if (!client->isConnected()) {
-        if (callback) callback(OperationResult::DISCONNECTED, Bytes());
-        return false;
-    }
-
-    NimBLERemoteService* service = client->getService(UUID::SERVICE);
-    if (!service) {
-        if (callback) callback(OperationResult::NOT_FOUND, Bytes());
-        return false;
-    }
-
-    // Find characteristic by handle
+    // Resolve pointers under _conn_mutex, release before blocking readValue()
     NimBLERemoteCharacteristic* chr = nullptr;
-    if (char_handle == _connections[conn_handle].identity_handle) {
-        chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+    {
+        if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+            if (callback) callback(OperationResult::NOT_FOUND, Bytes());
+            return false;
+        }
+
+        auto client_it = _clients.find(conn_handle);
+        if (client_it == _clients.end() || !client_it->second) {
+            xSemaphoreGive(_conn_mutex);
+            if (callback) callback(OperationResult::NOT_FOUND, Bytes());
+            return false;
+        }
+
+        NimBLEClient* client = client_it->second;
+        if (!client->isConnected()) {
+            xSemaphoreGive(_conn_mutex);
+            if (callback) callback(OperationResult::DISCONNECTED, Bytes());
+            return false;
+        }
+
+        NimBLERemoteService* service = client->getService(UUID::SERVICE);
+        if (!service) {
+            xSemaphoreGive(_conn_mutex);
+            if (callback) callback(OperationResult::NOT_FOUND, Bytes());
+            return false;
+        }
+
+        // Find characteristic by handle
+        auto conn_it = _connections.find(conn_handle);
+        if (conn_it != _connections.end() && char_handle == conn_it->second.identity_handle) {
+            chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
+        }
+
+        xSemaphoreGive(_conn_mutex);
     }
 
     if (!chr) {
@@ -1770,25 +1834,50 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
         return false;
     }
 
-    auto client_it = _clients.find(conn_handle);
-    if (client_it == _clients.end() || !client_it->second) {
-        return false;
+    // Resolve pointers under _conn_mutex, release before blocking subscribe()
+    NimBLERemoteCharacteristic* txChar = nullptr;
+    BLEAddress expected_peer;
+    {
+        if (!xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+            return false;
+        }
+
+        auto client_it = _clients.find(conn_handle);
+        if (client_it == _clients.end() || !client_it->second) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        NimBLEClient* client = client_it->second;
+        if (!client->isConnected()) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        NimBLERemoteService* service = client->getService(UUID::SERVICE);
+        if (!service) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        txChar = service->getCharacteristic(UUID::TX_CHAR);
+        if (!txChar) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
+        }
+
+        auto conn_it = _connections.find(conn_handle);
+        if (conn_it != _connections.end()) {
+            expected_peer = conn_it->second.peer_address;
+        }
+
+        xSemaphoreGive(_conn_mutex);
     }
-
-    NimBLEClient* client = client_it->second;
-    if (!client->isConnected()) return false;
-
-    NimBLERemoteService* service = client->getService(UUID::SERVICE);
-    if (!service) return false;
-
-    NimBLERemoteCharacteristic* txChar = service->getCharacteristic(UUID::TX_CHAR);
-    if (!txChar) return false;
 
     if (enable) {
         // Subscribe to notifications.
         // Capture peer_address to guard against conn_handle reuse: if peer A disconnects
         // (handle=1) and peer B connects (handle=1), we must not deliver B's data as A's.
-        BLEAddress expected_peer = getConnection(conn_handle).peer_address;
         auto notifyCb = [this, conn_handle, expected_peer](NimBLERemoteCharacteristic* pChar,
                                              uint8_t* pData, size_t length, bool isNotify) {
             if (_on_data_received) {
@@ -1831,18 +1920,25 @@ bool NimBLEPlatform::notifyAll(const Bytes& data) {
 
 std::vector<ConnectionHandle> NimBLEPlatform::getConnections() const {
     std::vector<ConnectionHandle> result;
-    for (const auto& kv : _connections) {
-        result.push_back(kv.second);
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        for (const auto& kv : _connections) {
+            result.push_back(kv.second);
+        }
+        xSemaphoreGive(_conn_mutex);
     }
     return result;
 }
 
 ConnectionHandle NimBLEPlatform::getConnection(uint16_t handle) const {
-    auto it = _connections.find(handle);
-    if (it != _connections.end()) {
-        return it->second;
+    ConnectionHandle result;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        auto it = _connections.find(handle);
+        if (it != _connections.end()) {
+            result = it->second;
+        }
+        xSemaphoreGive(_conn_mutex);
     }
-    return ConnectionHandle();
+    return result;
 }
 
 size_t NimBLEPlatform::getConnectionCount() const {

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1743,7 +1743,8 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
     }
 
     if (!rxChar) {
-        WARNING("NimBLEPlatform::write: RX char not found for handle " + std::to_string(conn_handle));
+        WARNING("NimBLEPlatform::write: RX char not cached for handle " + std::to_string(conn_handle) +
+                " (discoverServices() not yet called or failed?)");
         return false;
     }
 

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1509,6 +1509,14 @@ bool NimBLEPlatform::discoverServices(uint16_t conn_handle) {
             }
         }
         xSemaphoreGive(_conn_mutex);
+    } else {
+        WARNING("NimBLEPlatform::discoverServices: mutex timeout, handle=" +
+                std::to_string(conn_handle));
+        if (_on_services_discovered) {
+            ConnectionHandle conn = getConnection(conn_handle);
+            _on_services_discovered(conn, false);
+        }
+        return false;
     }
 
     DEBUG("NimBLEPlatform: Services discovered for " + std::to_string(conn_handle));

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1906,9 +1906,11 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
         }
 
         auto conn_it = _connections.find(conn_handle);
-        if (conn_it != _connections.end()) {
-            expected_peer = conn_it->second.peer_address;
+        if (conn_it == _connections.end()) {
+            xSemaphoreGive(_conn_mutex);
+            return false;
         }
+        expected_peer = conn_it->second.peer_address;
 
         beginWriteOperation();
         xSemaphoreGive(_conn_mutex);

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1458,12 +1458,17 @@ bool NimBLEPlatform::discoverServices(uint16_t conn_handle) {
         return false;
     }
 
-    auto client_it = _clients.find(conn_handle);
-    if (client_it == _clients.end() || !client_it->second) {
+    NimBLEClient* client = nullptr;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
+        auto client_it = _clients.find(conn_handle);
+        if (client_it != _clients.end()) {
+            client = client_it->second;
+        }
+        xSemaphoreGive(_conn_mutex);
+    }
+    if (!client) {
         return false;
     }
-
-    NimBLEClient* client = client_it->second;
 
     // Get our service — blocking GATT operation
     NimBLERemoteService* service = client->getService(UUID::SERVICE);

--- a/lib/ble_interface/platforms/NimBLEPlatform.cpp
+++ b/lib/ble_interface/platforms/NimBLEPlatform.cpp
@@ -1715,6 +1715,12 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
             }
         }
 
+        // Register active op BEFORE releasing mutex so processPendingDisconnects()
+        // sees it when checking hasActiveWriteOperations() — closes TOCTOU gap.
+        if (rxChar) {
+            beginWriteOperation();
+        }
+
         xSemaphoreGive(_conn_mutex);
     }
 
@@ -1723,9 +1729,7 @@ bool NimBLEPlatform::write(uint16_t conn_handle, const Bytes& data, bool respons
         return false;
     }
 
-    // CONC-H4: Track active write for graceful shutdown
     // writeValue() is a blocking GATT op — must NOT hold _conn_mutex here
-    beginWriteOperation();
     bool result = rxChar->writeValue(data.data(), data.size(), response);
     endWriteOperation();
     if (!result) {
@@ -1775,12 +1779,15 @@ bool NimBLEPlatform::writeCharacteristic(uint16_t conn_handle, uint16_t char_han
             chr = service->getCharacteristic(UUID::RX_CHAR);
         }
 
+        if (chr) {
+            beginWriteOperation();
+        }
+
         xSemaphoreGive(_conn_mutex);
     }
 
     if (!chr) return false;
 
-    beginWriteOperation();
     bool result = chr->writeValue(data.data(), data.size(), response);
     endWriteOperation();
     return result;
@@ -1828,6 +1835,10 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
             chr = service->getCharacteristic(UUID::IDENTITY_CHAR);
         }
 
+        if (chr) {
+            beginWriteOperation();
+        }
+
         xSemaphoreGive(_conn_mutex);
     }
 
@@ -1836,7 +1847,6 @@ bool NimBLEPlatform::read(uint16_t conn_handle, uint16_t char_handle,
         return false;
     }
 
-    beginWriteOperation();
     NimBLEAttValue value = chr->readValue();
     endWriteOperation();
     if (callback) {
@@ -1889,6 +1899,7 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
             expected_peer = conn_it->second.peer_address;
         }
 
+        beginWriteOperation();
         xSemaphoreGive(_conn_mutex);
     }
 
@@ -1908,12 +1919,10 @@ bool NimBLEPlatform::enableNotifications(uint16_t conn_handle, bool enable) {
             }
         };
 
-        beginWriteOperation();
         bool result = txChar->subscribe(true, notifyCb);
         endWriteOperation();
         return result;
     } else {
-        beginWriteOperation();
         bool result = txChar->unsubscribe();
         endWriteOperation();
         return result;
@@ -2111,7 +2120,10 @@ void NimBLEPlatform::onConnect(NimBLEServer* pServer, NimBLEConnInfo& connInfo) 
         conn.rssi = rssi_val;
     }
 
-    _connections[conn_handle] = conn;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
+        _connections[conn_handle] = conn;
+        xSemaphoreGive(_conn_mutex);
+    }
 
     DEBUG("NimBLEPlatform: Central connected: " + conn.peer_address.toString() +
           " rssi=" + std::to_string(conn.rssi));
@@ -2212,8 +2224,11 @@ void NimBLEPlatform::onConnect(NimBLEClient* pClient) {
     conn.state = ConnectionState::CONNECTED;
     conn.mtu = pClient->getMTU() - MTU::ATT_OVERHEAD;
 
-    _connections[conn_handle] = conn;
-    _clients[conn_handle] = pClient;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(100))) {
+        _connections[conn_handle] = conn;
+        _clients[conn_handle] = pClient;
+        xSemaphoreGive(_conn_mutex);
+    }
 
     DEBUG("NimBLEPlatform: Connected to peripheral: " + peer_addr.toString() +
           " handle=" + std::to_string(conn_handle) + " mtu=" + std::to_string(conn.mtu));
@@ -2537,9 +2552,12 @@ void NimBLEPlatform::freeConnHandle(uint16_t handle) {
 }
 
 void NimBLEPlatform::updateConnectionMTU(uint16_t conn_handle, uint16_t mtu) {
-    auto it = _connections.find(conn_handle);
-    if (it != _connections.end()) {
-        it->second.mtu = mtu - MTU::ATT_OVERHEAD;
+    if (xSemaphoreTake(_conn_mutex, pdMS_TO_TICKS(50))) {
+        auto it = _connections.find(conn_handle);
+        if (it != _connections.end()) {
+            it->second.mtu = mtu - MTU::ATT_OVERHEAD;
+        }
+        xSemaphoreGive(_conn_mutex);
     }
 }
 

--- a/lib/ble_interface/platforms/NimBLEPlatform.h
+++ b/lib/ble_interface/platforms/NimBLEPlatform.h
@@ -302,8 +302,10 @@ private:
     // Client connections (as central)
     std::map<uint16_t, NimBLEClient*> _clients;
 
-    // Cached RX characteristic pointers (avoids repeated service/char lookups in write())
+    // Cached characteristic pointers (avoids repeated service/char lookups under mutex)
     std::map<uint16_t, NimBLERemoteCharacteristic*> _cached_rx_chars;
+    std::map<uint16_t, NimBLERemoteCharacteristic*> _cached_tx_chars;
+    std::map<uint16_t, NimBLERemoteCharacteristic*> _cached_identity_chars;
 
     // Connection tracking
     std::map<uint16_t, ConnectionHandle> _connections;


### PR DESCRIPTION
## Summary
- `send_outgoing()` on loopTask (core 1) calls `write()` which reads `_connections`, `_clients`, and `_cached_rx_chars` maps, while `processPendingDisconnects()` on the BLE task (core 0) erases from them with no synchronization
- This causes `std::map` red-black tree corruption → **LoadProhibited crash** (EXCVADDR=0x00000008) in `NimBLEPlatform::write()` called from `BLEInterface::sendKeepalives()`
- Added `_conn_mutex` protection around all map accesses in `write()`, `writeCharacteristic()`, `read()`, `enableNotifications()`, `getConnection()`, `getConnections()`, and `processPendingDisconnects()`
- Mutex is released before blocking GATT ops (`writeValue`, `readValue`, `subscribe`) to avoid holding it during 10-30s NimBLE timeouts

## Test plan
- [x] Build succeeds (Flash 80.3%, RAM 26.8%)
- [x] Pre-fix: 2 crashes (LoadProhibited + WDT) in 15 minutes of monitoring
- [x] Post-fix: 0 crashes across 30+ minutes of continuous monitoring
- [x] No mutex contention messages in logs
- [x] BLE connections and keepalives functioning normally
- [x] Heap stable (~33KB free, no leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)