### PR TITLE
Add architecture documentation and Pyxis parity plan

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,493 @@
+# Pyxis Architecture
+
+## Overview
+
+Pyxis is embedded firmware for the LilyGO T-Deck Plus built with PlatformIO, Arduino, and ESP32-S3 libraries. It combines:
+
+- T-Deck hardware support
+- Reticulum transport and routing
+- LXMF messaging
+- LXST voice calling
+- An LVGL-based device UI
+
+At a high level, `src/main.cpp` assembles a set of transport adapters, storage layers, and UI screens around a single Reticulum identity. The device can carry Reticulum traffic over TCP, LoRa, WiFi peer discovery, and BLE, then expose messaging and voice features through the T-Deck screen, keyboard, touch input, and audio hardware.
+
+## Build and platform model
+
+The project is configured in `platformio.ini` for ESP32-S3-based T-Deck hardware. There are two main build environments:
+
+- `env:tdeck`: default build using NimBLE to reduce RAM use
+- `env:tdeck-bluedroid`: fallback BLE build using Bluedroid
+
+Important build-time characteristics:
+
+- Arduino framework on `espressif32`
+- PSRAM enabled for LVGL buffers and large runtime objects
+- SPIFFS-backed persistence via a custom filesystem wrapper
+- Optional instrumentation for boot profiling and memory monitoring
+- OTA update support
+
+## Top-level runtime architecture
+
+```mermaid
+flowchart TD
+    A["ESP32-S3 / T-Deck hardware"] --> B["Bootstrap in src/main.cpp"]
+    B --> C["Hardware services
+    SPIFFS, I2C, display, input, GPS, SD, tone"]
+    B --> D["Reticulum core"]
+    D --> E["Transport adapters
+    TCP / LoRa / AutoInterface / BLE"]
+    D --> F["LXMF router + message store"]
+    F --> G["Propagation node manager"]
+    F --> H["UI manager"]
+    H --> I["LVGL screens
+    conversations, chat, compose, status, settings, calls"]
+    H --> J["LXST audio pipeline"]
+    C --> H
+```
+
+## Repository structure
+
+The main architectural areas are:
+
+- `src/main.cpp`: application composition root, startup, and main event loop
+- `src/TCPClientInterface.*`: Reticulum-compatible TCP client transport
+- `lib/sx1262_interface`: LoRa transport implementation for the T-Deck radio
+- `lib/auto_interface`: IPv6 multicast peer discovery and data transport
+- `lib/ble_interface`: BLE mesh-style Reticulum transport
+- `lib/tdeck_ui`: T-Deck hardware drivers, LVGL bootstrap, and application UI
+- `lib/lxst_audio`: microphone capture, speaker playback, and Codec2 voice pipeline
+- `lib/universal_filesystem`: abstraction that mounts platform storage for Reticulum
+- `lib/tone`: simple notification audio support
+- `tests/interop`: Python interoperability tests, mainly for LXST wire/audio behavior
+- `deps/microReticulum`: modified Reticulum implementation used by the firmware
+
+## Composition root: `src/main.cpp`
+
+`src/main.cpp` owns most long-lived objects as globals:
+
+- Reticulum core objects:
+  - `Reticulum* reticulum`
+  - `Identity* identity`
+  - `LXMRouter* router`
+  - `MessageStore* message_store`
+  - `PropagationNodeManager* propagation_manager`
+- UI:
+  - `UI::LXMF::UIManager* ui_manager`
+- Transport implementations and wrappers:
+  - `TCPClientInterface* tcp_interface_impl`
+  - `SX1262Interface* lora_interface_impl`
+  - `AutoInterface* auto_interface_impl`
+  - `BLEInterface* ble_interface_impl`
+  - paired `RNS::Interface*` wrappers for registration with Reticulum
+- Device/application state:
+  - persisted `AppSettings`
+  - announce/sync timers
+  - WiFi reconnect flags
+  - screen and keyboard backlight timeout state
+  - GPS state
+
+This file is the orchestrator rather than a thin entry point. Most subsystems are initialized here and then serviced from the main loop.
+
+## Startup sequence
+
+Boot is intentionally staged to get visible feedback on-screen early and to avoid hardware contention.
+
+### 1. Early power and splash
+
+`setup()` first:
+
+- starts serial logging
+- powers the peripheral rail
+- initializes the display hardware early
+- shows a splash before slower startup work begins
+
+This reduces perceived boot time and avoids display-reset timing issues.
+
+### 2. Core hardware services
+
+`setup_hardware()`:
+
+- mounts SPIFFS through `UniversalFileSystem`
+- registers the filesystem with Reticulum OS utilities
+- initializes I2C for keyboard and touch peripherals
+
+This establishes the persistence and control buses required by later layers.
+
+### 3. Tone and settings
+
+Before networking is configured, boot loads:
+
+- notification tone support
+- persisted `AppSettings` from ESP32 `Preferences`/NVS
+
+Settings include WiFi credentials, TCP endpoint, enabled transports, LoRa radio parameters, display behavior, propagation settings, announce intervals, and GPS time-sync preferences.
+
+### 4. GPS and time synchronization
+
+GPS initialization happens before WiFi. The firmware:
+
+- probes supported GPS modules
+- attempts time sync from GPS first
+- derives a timezone from longitude when location is available
+- falls back to NTP after WiFi comes up if GPS sync fails
+
+Time is also bridged into Reticulum's `Utilities::OS::time()` via an uptime-based offset.
+
+### 5. WiFi, OTA, and log broadcasting
+
+If WiFi credentials exist, `setup_wifi()`:
+
+- connects in station mode
+- optionally completes time sync via NTP
+- enables ArduinoOTA for wireless firmware updates
+- configures multicast UDP log broadcasting
+
+OTA temporarily suspends BLE and TCP to reduce radio contention during update transfer.
+
+### 6. Shared SPI coordination
+
+The T-Deck display, SD card, and LoRa radio share SPI resources. `setup()` creates a shared mutex and passes it into:
+
+- SD card access
+- display driver
+- SX1262 LoRa interface
+
+This is a key hardware constraint in the system design.
+
+### 7. LVGL and UI task bootstrap
+
+`setup_lvgl_and_ui()`:
+
+- initializes LVGL
+- aligns the initial screen background with the splash
+- starts LVGL on a dedicated FreeRTOS task
+- optionally registers the LVGL task with memory instrumentation
+
+The UI is therefore not rendered exclusively from the Arduino loop task.
+
+### 8. Reticulum core and transport adapters
+
+`setup_reticulum()`:
+
+- creates the `Reticulum` instance
+- loads or generates the node identity from NVS
+- creates and starts enabled transport adapters
+- registers each started interface with Reticulum `Transport`
+
+Supported interfaces are described below.
+
+### 9. LXMF services
+
+`setup_lxmf()`:
+
+- creates `MessageStore` rooted at `/lxmf`
+- creates `LXMRouter`
+- creates and registers `PropagationNodeManager`
+- applies propagation-related settings
+- sets the display name used in announces
+- performs an initial announce when TCP is online
+
+This is the messaging service layer of the device.
+
+### 10. UI manager binding
+
+`setup_ui_manager()` creates `UIManager`, then wires it to:
+
+- Reticulum and LXMF services
+- propagation manager
+- LoRa interface for signal metrics
+- BLE interface for peer counts
+- GPS for status displays
+- settings callbacks for brightness, WiFi reconnect, and runtime config changes
+
+Delivery callbacks are also registered so network events update both persistence and UI state.
+
+## Transport architecture
+
+Pyxis uses Reticulum's interface model. Each transport implementation derives from `RNS::InterfaceImpl`, then gets wrapped by `RNS::Interface` and registered with `Transport`.
+
+### TCP client transport
+
+Defined in `src/TCPClientInterface.*`.
+
+Responsibilities:
+
+- connect to a Python RNS TCP server
+- use HDLC framing for compatibility
+- reconnect automatically
+- apply TCP keepalive and stale-connection handling
+
+This is the primary WAN or infrastructure-backed Reticulum path when WiFi is available.
+
+### LoRa transport
+
+Defined in `lib/sx1262_interface`.
+
+Responsibilities:
+
+- control the SX1262 radio through RadioLib
+- use T-Deck-specific radio pins and shared SPI
+- expose link quality values such as RSSI and SNR
+- apply LoRa settings from persisted app configuration
+
+This is the local long-range path and is designed to be air-compatible with RNode-style settings.
+
+### AutoInterface
+
+Defined in `lib/auto_interface`.
+
+Responsibilities:
+
+- discover peers over IPv6 multicast
+- maintain a live peer list
+- handle reverse peering
+- deduplicate packets
+- detect carrier/echo state changes
+
+This is the zero-config local network Reticulum path when WiFi is connected.
+
+### BLE interface
+
+Defined in `lib/ble_interface`.
+
+Responsibilities:
+
+- run a BLE Reticulum protocol implementation
+- support central, peripheral, or dual roles
+- manage discovery, handshake, MTU changes, and keepalives
+- fragment and reassemble packets for BLE transport
+- optionally run on its own FreeRTOS task
+
+The default build uses NimBLE to reduce internal RAM pressure. The BLE implementation is large enough that the firmware explicitly allocates it in PSRAM.
+
+## Messaging and propagation architecture
+
+LXMF functionality is built around three main objects:
+
+- `Identity`: persistent node identity
+- `LXMRouter`: delivery destination, announce, inbound/outbound queues, sync
+- `MessageStore`: on-device message persistence under `/lxmf`
+
+`PropagationNodeManager` listens for network announces and tracks propagation nodes. The router can be configured to:
+
+- auto-select a propagation node
+- use a manually selected node
+- fall back to propagation when direct delivery fails
+- force propagation-only delivery
+
+The main loop periodically:
+
+- processes router inbound/outbound/sync queues
+- announces the local destination
+- requests messages from the selected propagation node
+
+## UI architecture
+
+The UI lives under `lib/tdeck_ui` and has three layers.
+
+### 1. Hardware access layer
+
+`lib/tdeck_ui/Hardware/TDeck` contains device-specific wrappers for:
+
+- display
+- keyboard
+- touch
+- trackball
+- SD access and SD logging
+- board pin configuration
+
+This isolates most T-Deck hardware knowledge from application logic.
+
+### 2. LVGL bootstrap layer
+
+`lib/tdeck_ui/UI/LVGL` contains:
+
+- LVGL initialization
+- task startup
+- locking helpers for cross-task UI access
+
+Because LVGL runs in its own task, application code uses an LVGL lock around UI mutations.
+
+### 3. LXMF application screens
+
+`lib/tdeck_ui/UI/LXMF` contains screen objects for:
+
+- conversation list
+- chat
+- compose
+- announce list
+- status
+- QR sharing
+- settings
+- propagation nodes
+- call UI
+
+`UIManager` is the coordinator for these screens. It is responsible for:
+
+- creating all screens
+- wiring screen callbacks
+- switching active screens
+- forwarding LXMF delivery events into the UI
+- refreshing status indicators
+- bridging settings changes back into system services
+- managing LXST call lifecycle
+
+The UI layer depends on Reticulum and LXMF services; the reverse dependency is minimal except for event callbacks registered from `main.cpp`.
+
+## Voice call architecture
+
+Voice support is split between UI-level call control and a lower-level audio pipeline.
+
+### Call control
+
+`UIManager` owns the LXST call state machine. It creates an LXST destination, registers announce handlers, reacts to incoming links, and coordinates:
+
+- outgoing call setup
+- incoming call answer/hangup
+- mute state
+- call screen state
+- audio packet TX/RX pumping
+
+### Audio pipeline
+
+`lib/lxst_audio` provides `LXSTAudio`, which coordinates:
+
+- ES7210 microphone setup
+- I2S capture
+- I2S playback
+- Codec2 encoder/decoder lifecycle
+- ring buffers for encoded and playback data
+- coexistence with the tone generator
+
+The design supports capture-only, playback-only, and full-duplex operation. The main loop calls `ui_manager->pump_call_tx()` immediately after `reticulum->loop()` to minimize voice transmit latency.
+
+## Storage architecture
+
+There are two persistent storage mechanisms.
+
+### NVS / Preferences
+
+ESP32 `Preferences` is used for small, critical configuration and identity data:
+
+- app settings
+- Reticulum private identity key
+- propagation node selection
+- crash breadcrumbs and diagnostic data
+
+This is used for data that must survive reflashing and power cycles.
+
+### SPIFFS via `UniversalFileSystem`
+
+`UniversalFileSystem` adapts platform storage to Reticulum's filesystem abstraction. It is used for larger structured data such as:
+
+- LXMF message store contents
+- Reticulum persistence files
+- cached transport/identity metadata
+
+The code also supports SD card access separately for logging.
+
+## Event loop model
+
+After startup, `loop()` acts as a cooperative scheduler. Its major phases are:
+
+1. feed the watchdog
+2. service OTA
+3. handle serial commands for flasher tooling
+4. run LVGL task handling hooks
+5. process deferred WiFi reconnect requests
+6. run `reticulum->loop()`
+7. pump voice TX immediately after Reticulum
+8. persist Reticulum and identity data when dirty
+9. run transport-specific loops for TCP, LoRa, and BLE
+10. process LXMF router queues
+11. update UI manager
+12. poll memory instrumentation
+13. run periodic announce and propagation-sync tasks
+14. react to transport reconnection and connection-state changes
+
+This is not a message-bus architecture or RTOS-heavy actor model. It is a mostly centralized event loop with a few dedicated tasks for LVGL and, optionally, BLE.
+
+## Concurrency model
+
+The firmware uses a hybrid concurrency approach:
+
+- Arduino `loop()` remains the main orchestrator
+- LVGL runs in its own FreeRTOS task
+- BLE may run in its own FreeRTOS task
+- shared hardware resources, especially SPI, are protected with a mutex
+- UI mutations use an LVGL lock
+- some work is deferred from UI callbacks into the main loop to avoid blocking LVGL
+
+Examples of deferred work include WiFi reconnect requests initiated from settings UI callbacks.
+
+## Diagnostics and operational concerns
+
+The codebase contains several operational safeguards:
+
+- boot profiling markers for slow startup phases
+- memory instrumentation hooks
+- watchdog resets during long operations
+- UDP multicast log broadcasting for remote observation
+- reset-reason logging
+- crash breadcrumbs for LXST diagnostics
+- SD logging when a card is present
+
+These features are important because the system runs on constrained hardware with multiple competing radios, display workloads, and audio workloads.
+
+## Test coverage shape
+
+The `tests/interop` suite is Python-based and focused on interoperability rather than unit testing the firmware directly. The visible tests emphasize LXST audio behavior:
+
+- wire format compatibility
+- codec round-trips
+- full pipeline simulation
+
+This suggests the highest-risk integration area is cross-implementation voice compatibility with other LXST/Reticulum tools.
+
+## Key architectural characteristics
+
+The most important things to understand about Pyxis are:
+
+- `src/main.cpp` is the composition root and operational scheduler
+- Reticulum is the networking core, with Pyxis-specific adapters around it
+- LXMF messaging and LXST calling are service layers on top of Reticulum
+- the UI is a first-class subsystem with its own task and locking model
+- hardware constraints, especially shared SPI and limited RAM, strongly shape design choices
+- configuration is intended to be user-editable at runtime through the settings UI
+
+## Typical end-to-end flow
+
+For a received message:
+
+1. a transport adapter receives bytes from TCP, LoRa, WiFi peer discovery, or BLE
+2. Reticulum processes the packet
+3. LXMF router identifies and persists the message
+4. delivery callbacks notify application code
+5. `UIManager` updates the relevant screen state
+6. optional tone notification plays
+
+For a voice call:
+
+1. LXST announce or link activity is observed by `UIManager`
+2. call state transitions are driven from the UI manager
+3. microphone audio is captured and encoded by `LXSTAudio`
+4. encoded packets are transmitted over Reticulum links
+5. received audio packets are decoded and played back through the speaker path
+
+## Architectural tradeoffs
+
+The current design favors:
+
+- direct control from one central composition file
+- predictable cooperative scheduling
+- low-overhead embedded abstractions
+- interoperability with existing Reticulum/LXMF/LXST implementations
+
+The cost is that:
+
+- `src/main.cpp` carries a large amount of orchestration responsibility
+- runtime state is fairly global
+- subsystem coupling is managed procedurally rather than through narrower service boundaries
+
+That tradeoff is common in embedded firmware, especially when startup order, hardware ownership, and memory placement matter as much as clean layering.

--- a/docs/plans/pyxis-parity-plan.md
+++ b/docs/plans/pyxis-parity-plan.md
@@ -1,0 +1,606 @@
+# Pyxis Functional-Parity Plan vs. Meshtastic Standalone UI / device-ui
+
+## Goal
+Bring `torlando-tech/pyxis` to **functional parity at the UX/product level** with the Meshtastic Standalone UI experience on T-Deck-class hardware, while **preserving Pyxis-native Reticulum strengths**:
+- LXMF direct and propagated messaging
+- LXST voice calling
+- Reticulum transports (LoRa, AutoInterface, TCP, BLE)
+- QR-based identity sharing
+
+This is **not** a literal code port. The Meshtastic codebase is protocol-specific and centered on the Meshtastic Client API; Pyxis owns its own application stack around Reticulum/LXMF/LXST.
+
+## Product Parity Definition
+Treat parity as:
+- First-boot setup wizard
+- Home dashboard
+- Peer/node directory with filtering and highlighting
+- Channel-equivalent navigation surface
+- Threaded chats with delivery states
+- Offline map with peers + own location
+- Settings + tools/diagnostics
+- Lock/sleep/system actions
+- Status bar / hardware indicators
+- SD-card-centered offline workflows
+
+Do **not** treat parity as:
+- Meshtastic protobuf compatibility
+- Meshtastic radio-region/channel-key semantics
+- Booting into Meshtastic BaseUI
+- Multi-device support in phase 1
+
+## Interpretation of Meshtastic Concepts for Reticulum
+Because Pyxis is Reticulum/LXMF-based, some MUI concepts must be adapted:
+- **Nodes list** -> **Peers / announces / known routes / known contacts**
+- **Channels** -> **Destinations / interfaces / conversation classes** (not literal PSK channels)
+- **Trace route** -> **Route inspection / path lookup / hop/interface diagnostics**
+- **Mesh detector** -> **Announce scanner / nearby-peer discovery**
+- **Signal scanner** -> **Interface/link quality monitor**
+- **Packet log** -> **Reticulum TX/RX + announce + propagation event log**
+
+## Current State Summary
+Pyxis already has:
+- A T-Deck-only PlatformIO firmware target
+- Existing LVGL UI stack with screens for conversations, chat, compose, announces, status, settings, QR, propagation nodes, and calls
+- Reticulum/LXMF/LXST core already integrated in firmware
+- Multiple transport interfaces: TCP, LoRa, AutoInterface, BLE
+- Existing PR build workflow and firmware release/flasher workflow
+- Existing Python interop tests around LXST/Codec2 wire format and pipeline behavior
+
+Pyxis does **not yet expose** the following MUI-equivalent surfaces as first-class UI modules:
+- First-boot setup wizard
+- Dashboard/home screen
+- Peer/node explorer with rich filters/highlights/details
+- Offline map UI
+- Tools/diagnostics suite
+- Lock/sleep/system action experience on par with MUI
+- Multi-screen app shell that feels like a cohesive handheld client rather than a messaging-first tool
+
+## Recommended Delivery Strategy
+1. **Refactor just enough first** to support rapid feature delivery.
+2. Build parity in **small vertical slices**.
+3. Keep all work **T-Deck first** until parity is reached.
+4. Preserve existing messaging/call flows during refactor.
+5. Reuse MUI ideas at the **product and architecture level**, not protocol level.
+
+## Architecture Recommendation
+### 1) Separate firmware bootstrap from app logic
+Shrink `src/main.cpp` into a bootstrap/composition root only.
+
+Create service-layer modules:
+- `AppStateStore`
+- `SettingsService`
+- `PeerDirectoryService`
+- `RouteDiagnosticsService`
+- `MapService`
+- `StatsService`
+- `PacketLogService`
+- `IdentityShareService`
+- `SystemActionsService`
+
+### 2) Add an event-driven UI model
+Create a unidirectional flow:
+- transport/router/interfaces emit events
+- reducers/services update state snapshots
+- screens render from snapshot state
+
+Recommended primitives:
+- `EventBus`
+- `AppState` snapshot structs
+- reducers / updaters
+- polling adapters only where necessary for hardware APIs
+
+### 3) Formalize UI shell + navigation
+Create a reusable shell layer:
+- `ScreenBase`
+- `NavController`
+- `StatusBar`
+- `BottomNav`
+- `ModalManager`
+- `FormComponents`
+- `ListCell` variants
+- `MapCanvas`
+
+### 4) Create persistence boundaries
+Persist separately:
+- NVS: settings, toggles, onboarding completion, lock preferences
+- filesystem/SD: offline maps, packet logs, export files, future cached peer metadata
+
+### 5) Standardize shared models
+Create explicit models instead of screen-local ad hoc structs:
+- `PeerSummary`
+- `PeerDetails`
+- `ConversationSummary`
+- `InterfaceStatus`
+- `RouteSummary`
+- `MapMarker`
+- `SystemHealth`
+- `ToolStats`
+
+## Target UI Information Architecture
+### Primary surfaces
+1. **Home**
+2. **Peers**
+3. **Messages**
+4. **Map**
+5. **Settings & Tools**
+
+### Secondary screens
+- Peer details
+- Compose / new chat
+- Propagation nodes
+- Call screen
+- Identity QR / import/export
+- Packet log
+- Route diagnostics
+- Signal monitor
+- Maintenance/system actions
+
+## Delivery Phases
+
+### Phase 0 — Parity Contract + Refactor Guardrails
+**Objective:** define the product boundary and prevent architecture drift.
+
+Deliverables:
+- `docs/parity/README.md` with scope, mapping, non-goals
+- screen inventory of current Pyxis vs target parity
+- state/data-flow diagram
+- branch/PR strategy
+
+Acceptance:
+- no code behavior change yet
+- written architecture doc exists
+- all contributors align on UX parity interpretation
+
+### Phase 1 — App Shell Foundation
+**Objective:** make future screens cheap to build.
+
+Implement:
+- `ScreenBase`
+- `NavController`
+- shared header/status bar/footer components
+- central `AppStateStore`
+- event bus adapters for:
+  - conversations/messages
+  - announces/known peers
+  - interface statuses
+  - battery/GPS/WiFi/BLE
+  - propagation state
+
+Acceptance:
+- existing conversation/status/settings/announces screens run through new shell without regression
+- both `tdeck` and `tdeck-bluedroid` still compile
+
+### Phase 2 — First-Boot Setup Wizard
+**Objective:** match MUI’s “device usable without external client” feeling.
+
+Implement wizard steps:
+- display name / identity label
+- WiFi credentials
+- transport enablement defaults
+- LoRa interface defaults if enabled
+- announce/privacy defaults
+- optional GPS time sync default
+- storage/SD check
+
+Behavior:
+- show only on first boot or after factory reset
+- save once, avoid multiple reboot cycles
+- deep-link to advanced settings later
+
+Acceptance:
+- onboarding completion flag persisted
+- clean recovery path if WiFi or SD init fails
+
+### Phase 3 — Home Dashboard
+**Objective:** create the MUI-equivalent landing surface.
+
+Dashboard cards/widgets:
+- unread conversations
+- known peers count
+- routes / reachable peers
+- current interfaces summary (TCP, LoRa, Auto, BLE)
+- selected propagation node / sync health
+- GPS state / position lock / satellite count
+- battery / uptime / storage
+- current time
+
+Actions:
+- tap to open peers/messages/map/settings
+- long-press for quick actions where appropriate
+
+Acceptance:
+- dashboard becomes default post-onboarding entry point
+- state refresh feels live but does not fragment heap or block UI
+
+### Phase 4 — Peer Directory (Nodes List Equivalent)
+**Objective:** turn the existing announce list into a real node browser.
+
+Implement:
+- merged data source from announces + conversations + known paths + propagation nodes
+- peer list rows showing:
+  - name / truncated hash
+  - availability / last heard
+  - hops
+  - best interface
+  - propagation capability
+  - unread / recent activity markers
+  - optional location badge
+- detail screen with:
+  - identity / address
+  - last heard
+  - route summary
+  - interface seen on
+  - BLE RSSI or WiFi RSSI if relevant
+  - location/time if shared
+  - direct message / call / select propagation / copy hash / show QR
+
+Acceptance:
+- users can discover peers without already having a conversation
+- current announce screen can be retired or downgraded to a filtered subview
+
+### Phase 5 — Filters, Highlights, and Search
+**Objective:** reach MUI’s node-list usability.
+
+Implement filter dimensions:
+- online/recent/offline
+- interface type
+- hop count range
+- has path / no path
+- propagation capable
+- has location
+- has unread
+- direct-only vs propagated-capable
+
+Implement highlight modes:
+- best RSSI / nearest hop count
+- recently heard
+- unread
+- located peers
+- favorites / pinned peers
+
+Acceptance:
+- filters are fast on-device
+- state survives navigation; optional persistence is fine
+
+### Phase 6 — Channel-Equivalent Surface
+**Objective:** solve the “Channels” parity gap honestly.
+
+Create a new **Networks** or **Destinations** screen with tabs:
+- **Interfaces** — TCP / LoRa / Auto / BLE state and controls
+- **Peers** — direct destinations
+- **Propagation** — propagation nodes / strategy
+- **Saved destinations/groups** — future-compatible bucket
+
+Do **not** fake Meshtastic channels. Instead, expose the real Reticulum/LXMF concepts clearly.
+
+Optional future extension:
+- support named group destinations or broadcast-style abstractions if microReticulum capabilities allow it
+
+Acceptance:
+- users understand how traffic leaves the device
+- screen serves the same navigational role MUI channels serve
+
+### Phase 7 — Chat Parity Hardening
+**Objective:** polish the messaging UX to parity level.
+
+Keep existing conversation/chat/compose stack, but add:
+- richer delivery states (queued, path resolving, delivered, propagation fallback, failed)
+- contact cards in header
+- faster jump from peer list -> compose -> chat
+- unread badges across shell
+- message action sheet (copy, delete local, retry)
+- better empty states
+- clearer propagation indicators for delayed/offline delivery
+
+Acceptance:
+- no regression in existing messaging or calling
+- chat status is understandable without logs
+
+### Phase 8 — Offline Map (High-Value Gap)
+**Objective:** add one of MUI’s biggest differentiators.
+
+Implement:
+- SD-backed tile loader
+- MUI-compatible tile layout if possible:
+  - `/map`
+  - `/maps/{STYLE}/`
+- pan / zoom
+- own-position centering
+- home recentering
+- map style selection
+- brightness/contrast options
+- peer markers
+- marker details / quick-open peer
+
+Needed protocol/data work:
+- define or extend announce payload/app data to optionally carry position
+- add privacy toggle for location sharing
+- cache peer positions separately from transient route state
+
+Performance constraints:
+- tile cache must be bounded
+- SD I/O must not stall UI thread
+- prefer background decode/preload where possible
+
+Acceptance:
+- map remains responsive on T-Deck memory budget
+- works with no network once tiles exist on SD
+
+### Phase 9 — Tools & Diagnostics Suite
+**Objective:** build the MUI “Settings & Tools” parity layer.
+
+Tools screen should include:
+- **Announce Scanner** (MUI Mesh Detector equivalent)
+- **Signal Monitor** (MUI Signal Scanner equivalent)
+- **Route Inspector** (rnpath-style path/hop/interface summary)
+- **Statistics** (messages, announces, calls, propagation sync, transport counters)
+- **Packet Log** (TX/RX events and important state transitions)
+- **Storage / export** (optional text export to SD)
+
+Important note:
+- a literal Meshtastic-style traceroute may not be possible; if per-hop detail is unavailable, ship route inspection first
+
+Acceptance:
+- tools are useful without serial logs
+- diagnostics are human-readable on-device
+
+### Phase 10 — Settings Redesign
+**Objective:** split configuration from status and reach MUI’s structure.
+
+Recommended tabs/sections:
+- Identity
+- Network interfaces
+- Messaging & propagation
+- Display & input
+- Sound & notifications
+- GPS & time
+- Storage & maps
+- Privacy & sharing
+- Maintenance
+
+Move current status-only data out of Settings into:
+- Home dashboard
+- Status bar
+- dedicated status/detail screens
+
+Acceptance:
+- settings screen is no longer overloaded
+- save/reconnect flows are predictable
+
+### Phase 11 — System Actions / Lock / Sleep / Maintenance
+**Objective:** match MUI’s handheld behavior.
+
+Implement:
+- lock screen
+- sleep action
+- reboot action
+- factory reset
+- quiet/radio-silent mode
+- maintenance mode (serial/flasher/OTA-oriented) as Pyxis equivalent to MUI’s programming/base-mode affordances
+
+Acceptance:
+- long-press actions are consistent
+- accidental destructive actions require confirmation
+
+### Phase 12 — Polish, Localization, and Future Portability
+**Objective:** finish the experience and prepare for broader hardware later.
+
+Add:
+- themes / visual polish
+- localization framework
+- text truncation / font fallback review
+- performance/heap tuning
+- optional future host simulator / SDL test target
+- hardware abstraction cleanup for eventual non-T-Deck ports
+
+Acceptance:
+- UI feels cohesive, not bolted-on
+- memory and uptime are stable for multi-day use
+
+## Suggested Repo Layout Changes
+Add new folders:
+- `lib/pyxis_app_core/`
+- `lib/pyxis_services/`
+- `lib/tdeck_ui/UI/Shell/`
+- `lib/tdeck_ui/UI/Shared/`
+- `lib/tdeck_ui/UI/Home/`
+- `lib/tdeck_ui/UI/Peers/`
+- `lib/tdeck_ui/UI/Map/`
+- `lib/tdeck_ui/UI/Tools/`
+- `docs/parity/`
+
+Keep existing:
+- `lib/tdeck_ui/UI/LXMF/` for messaging/call-specific screens
+
+Recommended file moves:
+- move non-UI orchestration out of `src/main.cpp`
+- create `src/bootstrap/` or `lib/pyxis_runtime/`
+
+## PR-by-PR Backlog (Recommended)
+### PR 1 — Architecture skeleton
+- add docs/parity
+- add AppState, EventBus, ScreenBase, NavController
+- wire existing screens through shell
+
+### PR 2 — Service extraction from `main.cpp`
+- create transport supervisor
+- create state update loop
+- move persistence concerns out of UI code
+
+### PR 3 — Setup wizard
+- first-boot flow
+- schema migration for settings
+
+### PR 4 — Dashboard v1
+- basic cards + quick actions
+
+### PR 5 — Peer directory core
+- merge announce/conversation/route data
+- peer detail screen
+
+### PR 6 — Filters/highlights/search
+- persistent filter state
+- favorites/pins
+
+### PR 7 — Networks/Destinations surface
+- interface health + controls
+- route overview
+
+### PR 8 — Messaging parity polish
+- delivery state badges
+- retry/delete/action sheet
+- unread integration across shell
+
+### PR 9 — Offline map core
+- tile loader, marker model, map canvas
+
+### PR 10 — Map polish + location sharing
+- style selection
+- privacy toggle
+- recenter/home controls
+
+### PR 11 — Tools suite
+- announce scanner
+- signal monitor
+- route inspector
+- statistics
+- packet log
+
+### PR 12 — Settings redesign
+- tabs/sections
+- maintenance actions
+
+### PR 13 — Lock/sleep/maintenance mode
+- lock UI
+- sleep/reboot/reset
+
+### PR 14 — CI/test hardening
+- run Python interop tests in CI
+- add unit tests for state/services
+- add docs + screenshots
+
+### PR 15 — Polish + localization scaffold
+- strings extraction
+- theming cleanup
+- memory tuning
+
+## Testing Strategy
+### Must-pass on every PR
+- `pio run -e tdeck`
+- `pio run -e tdeck-bluedroid`
+- Python interop test suite under `tests/interop`
+
+### Add new tests for parity work
+- settings migration tests
+- peer directory reducer tests
+- route summary tests
+- map tile coordinate math tests
+- packet log ring buffer tests
+- dashboard snapshot rendering tests (model-level)
+
+### Hardware validation checklist
+- 24h idle soak
+- 2h mixed UI navigation soak
+- message send/receive direct
+- message send/receive via propagation
+- incoming/outgoing call sanity
+- WiFi reconnect stress
+- BLE enable/disable stress
+- SD card insert/remove map refresh
+- low battery + resume behavior
+
+## Definition of Done for “Parity Beta”
+Pyxis reaches parity beta when a T-Deck user can, from the device alone:
+- complete first-time setup
+- browse peers and inspect details
+- read/send messages comfortably
+- see delivery/route state clearly
+- select and inspect propagation nodes
+- use an offline map with peer markers
+- access diagnostics without serial logs
+- manage display/network/privacy settings
+- lock/sleep/reboot from UI
+
+while preserving:
+- voice calls
+- QR identity sharing
+- existing transports
+- flasher/release flows
+
+## Explicit Non-Goals for the First Parity Push
+- porting MUI code directly
+- Meshtastic protocol compatibility
+- multi-device support before T-Deck parity
+- perfect one-to-one cloning of Meshtastic terminology
+- advanced remote management beyond what Reticulum APIs safely expose
+
+## Risks and Mitigations
+### Risk: giant rewrite stalls progress
+Mitigation:
+- force PR-sized slices
+- keep old screens alive until replacements are ready
+
+### Risk: map feature blows memory budget
+Mitigation:
+- bounded tile cache
+- staged implementation
+- T-Deck profiling before polish
+
+### Risk: route diagnostics exceed microReticulum capability
+Mitigation:
+- ship route summary first
+- treat per-hop trace as optional enhancement
+
+### Risk: UI thread blocking from storage/network work
+Mitigation:
+- event queue + background-ish service loops
+- no SD tile decode on synchronous input path
+
+### Risk: feature creep into desktop/multi-device support
+Mitigation:
+- T-Deck-only parity milestone
+- portability after parity beta
+
+## Working Instructions for Codex / Claude
+Use this as the execution contract:
+
+1. Do not port Meshtastic protocol code.
+2. Use Meshtastic MUI as a UX and architecture reference only.
+3. Preserve existing Pyxis messaging, propagation, QR sharing, and voice-call behavior.
+4. Work in PR-sized increments; no mega-commits.
+5. Keep `src/main.cpp` shrinking over time, not growing.
+6. Build both `tdeck` and `tdeck-bluedroid` before concluding each task.
+7. Run Python interop tests whenever touching call/audio/wire code.
+8. Prefer additive refactors with compatibility shims over destructive rewrites.
+9. T-Deck first. No multi-device abstractions unless they reduce code, not add complexity.
+10. Every new screen must be wired through shared shell/navigation primitives.
+11. Every user-visible feature must have a state model, not screen-local hidden logic.
+12. Update `docs/parity/` after each major milestone.
+
+## Starter Prompt for Codex / Claude
+You are implementing MUI-inspired functional parity in `torlando-tech/pyxis` for T-Deck hardware. This is a Reticulum/LXMF/LXST project, not a Meshtastic project. Do not port Meshtastic protocol code. Use Meshtastic MUI as a product and UI architecture reference only.
+
+Constraints:
+- Preserve existing messaging, propagation, QR sharing, and voice-call flows.
+- Work in small, reviewable PR-sized steps.
+- Build both PlatformIO environments: `tdeck` and `tdeck-bluedroid`.
+- When touching voice/call/audio code, also run the Python interop tests in `tests/interop`.
+- Shrink `src/main.cpp` over time by extracting services and app state.
+- T-Deck first; do not generalize for other hardware unless it makes the code simpler.
+
+Current milestone:
+[PASTE CURRENT PR/PHASE HERE]
+
+Required output:
+1. brief design note
+2. file-by-file plan
+3. implementation
+4. build/test results
+5. follow-up risks
+
+## Best First Task
+Start with **PR 1 — Architecture skeleton**:
+- add `docs/parity/README.md`
+- add `ScreenBase`, `NavController`, `StatusBar`, `AppStateStore`, and `EventBus`
+- route existing screens through the new shell without changing product behavior
+- keep builds green


### PR DESCRIPTION
## Summary
- add docs/architecture.md describing the firmware runtime architecture, startup flow, transport layers, UI stack, persistence, and event loop
- include docs/plans/pyxis-parity-plan.md outlining the product and UI parity roadmap for Pyxis on T-Deck hardware
- keep the change docs-only so the current implementation remains untouched

## Notes
- the architecture doc is based on the current embedded firmware composition in src/main.cpp and the transport/UI/audio libraries under lib/
- the parity plan frames Meshtastic-style standalone UX parity as a product-level target, not a protocol port

## Testing
- not run (docs-only change)