### PR TITLE
Add native pyxis test suite + CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  pyxis-pytest:
+    name: Pyxis pytest suite (build_scripts + native)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/build_scripts tests/native -v
+
+  microreticulum-native:
+    name: microReticulum native unit tests (PlatformIO native17)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio-mrn
+
+      - name: Install PlatformIO
+        run: pip install --upgrade platformio
+
+      # Run only suites that build cleanly under native17 in the fork.
+      # Erroring suites (test_ble, test_tdeck, test_lxmf, test_ratchets, etc.)
+      # are tracked separately — see pyxis MEMORY.md.
+      - name: Run native17 tests
+        working-directory: deps/microReticulum
+        run: |
+          pio test -e native17 -f test_os
+          pio test -e native17 -f test_bytes
+          pio test -e native17 -f test_msgpack
+          pio test -e native17 -f test_crypto
+          pio test -e native17 -f test_filesystem
+          pio test -e native17 -f test_objects
+          pio test -e native17 -f test_general
+          pio test -e native17 -f test_reference
+          pio test -e native17 -f test_example
+          pio test -e native17 -f test_collections
+          pio test -e native17 -f test_interop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
+      # microReticulum native17 vendors libbz2 sources but link_bz2.py
+      # links against system libbz2 — needs libbz2-dev on Ubuntu.
+      - name: Install libbz2-dev
+        run: sudo apt-get install -y libbz2-dev
+
       # Run only suites that build cleanly under native17 in the fork.
       # Erroring suites (test_ble, test_tdeck, test_lxmf, test_ratchets, etc.)
       # are tracked separately — see pyxis MEMORY.md.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
-          key: ${{ runner.os }}-pio-mrn
+          key: ${{ runner.os }}-pio-mrn-${{ hashFiles('deps/microReticulum/platformio.ini') }}
 
       - name: Install PlatformIO
         run: pip install --upgrade platformio

--- a/lib/lxst_audio/encoded_ring_buffer.cpp
+++ b/lib/lxst_audio/encoded_ring_buffer.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "encoded_ring_buffer.h"
+
+#include <cstdlib>     // malloc, free — needed on Linux clang; macOS leaks via header transitivity
 #include <cstring>
 
 #ifdef ARDUINO

--- a/lib/lxst_audio/packet_ring_buffer.cpp
+++ b/lib/lxst_audio/packet_ring_buffer.cpp
@@ -3,6 +3,8 @@
 
 #include "packet_ring_buffer.h"
 
+#include <cstdlib>     // malloc, free — needed on Linux clang; macOS leaks via header transitivity
+
 #ifdef ARDUINO
 #include <esp_heap_caps.h>
 #endif

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,54 @@
+# Pyxis Tests
+
+Three test surfaces, each runnable independently.
+
+## 1. Pyxis-unique pytest suite
+
+Native C++ tests of pyxis-unique code (BLE fragmenter, HDLC, etc.) and Python tests of build scripts.
+
+```bash
+/usr/bin/python3 -m pytest tests/build_scripts tests/native -v
+```
+
+System Python 3.9 has pytest pre-installed; Homebrew Python does not.
+
+- `build_scripts/test_patch_nimble.py` — verifies `patch_nimble.py` idempotency, drift detection, missing-file handling
+- `native/test_hdlc.{cpp,py}` — HDLC escape/unescape/frame round-trip + golden vector against Python RNS
+- `native/test_ble_fragmenter.{cpp,py}` — BLEFragmenter ↔ BLEReassembler: in-order, out-of-order, duplicate, dropped+timeout, per-peer isolation, MTU change
+- `native/test_ble_peer_manager.{cpp,py}` — connection-map state machine: discover, identity promotion, blacklist, handle map cleanup, MAC rotation, pool exhaustion
+- `native/test_ble_operation_queue.{cpp,py}` — GATT op queue: FIFO, busy-state, timeout, clearForConnection, builder
+- `native/test_ring_buffers.{cpp,py}` — PCM + encoded SPSC ring buffers, including 100k-frame multithreaded producer/consumer stress
+- `native/test_audio_filters.{cpp,py}` — VoiceFilterChain frequency response, peak limiting, multichannel
+
+### Adding a new native C++ test
+
+Pattern: pure C++ unit + thin pytest wrapper.
+
+1. Write `tests/native/test_<thing>.cpp` — include from `../../{src,lib/...}` for the unit under test, use the existing `EXPECT_EQ`/`EXPECT_TRUE`/`RUN(name)` framework, return non-zero on any failure.
+2. If the unit pulls in microReticulum types, the shims in `tests/native/` cover what's been needed so far:
+   - `Bytes.h` → `bytes_shim.h` (minimal `RNS::Bytes` — append/data/size/writable/resize/mid)
+   - `Log.h` (no-op `TRACE`/`WARNING`/`INFO`/`ERROR` macros)
+   - `Utilities/OS.h` (`OS::time()` with `set_fake_time()`/`clear_fake_time()`)
+3. Write `tests/native/test_<thing>.py` — copy the `test_hdlc.py` template, swap source/include paths, run.
+4. Confirm: `/usr/bin/python3 -m pytest tests/native/test_<thing>.py -v`
+
+## 2. LXST audio interop tests
+
+Python tests verifying wire format and codec compatibility between pyxis (C++), Python LXST, and LXST-kt (Kotlin).
+
+```bash
+/usr/bin/python3 -m pytest tests/interop -v
+```
+
+Requires `pycodec2` and access to `$HOME/repos/public/LXST`.
+
+## 3. microReticulum native unit tests (PlatformIO)
+
+The fork's microReticulum tests live under `deps/microReticulum/test/` and run via PlatformIO Unity.
+
+```bash
+cd deps/microReticulum && pio test -e native17
+```
+
+Use `native17`, not `native` — the C++11 env is broken (static-constexpr ODR-use). Baseline as of 2026-05-02: 94/114 PASS, 7 FAIL, 5 SKIPPED, 7 suites ERRORED. The clean suites are
+`test_os, test_bytes, test_msgpack, test_crypto, test_filesystem, test_objects, test_interop, test_general, test_reference, test_example, test_collections`.

--- a/tests/build_scripts/test_patch_nimble.py
+++ b/tests/build_scripts/test_patch_nimble.py
@@ -15,6 +15,7 @@ What we verify:
 import io
 import os
 import subprocess
+import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -148,7 +149,12 @@ def test_pristine_source_applies_all_patches(fresh_tree, patches):
         assert p["label"] in stdout, (
             f"patch {p['label']!r} did not run\n--- stdout ---\n{stdout}"
         )
-        assert f"already applied" not in stdout.split(p["label"])[0].splitlines()[-1] if False else True
+        # On first run, the patch's label line must not say "already applied".
+        label_line = stdout.split(p["label"])[1].split("\n")[0]
+        assert "already applied" not in label_line, (
+            f"first run of {p['label']!r} should not report already-applied\n"
+            f"--- stdout ---\n{stdout}"
+        )
         # File should now contain `new` and not `old`
         content = Path(p["filepath"]).read_text()
         assert p["new"] in content, f"new content missing from {p['filepath']}"
@@ -239,8 +245,10 @@ def test_script_is_executable_via_python(tmp_path):
         f"builtins.env = _Env()\n"
         f"exec(open({str(PATCH_SCRIPT)!r}).read())\n"
     )
+    # Use the same interpreter that runs the test suite (sys.executable),
+    # not /usr/bin/python3 — under setup-python on CI the two diverge.
     result = subprocess.run(
-        ["/usr/bin/python3", str(shim)],
+        [sys.executable, str(shim)],
         capture_output=True,
         text=True,
         timeout=10,

--- a/tests/build_scripts/test_patch_nimble.py
+++ b/tests/build_scripts/test_patch_nimble.py
@@ -1,0 +1,253 @@
+"""
+Tests for patch_nimble.py.
+
+patch_nimble.py is a PlatformIO pre-build script that applies 4 patches to
+NimBLE-Arduino source. Every NimBLE upgrade can silently break a patch by
+shifting the surrounding code; these tests catch that.
+
+What we verify:
+  1. Pristine NimBLE source → every patch applies and the file content matches.
+  2. Idempotency — running the script twice is a no-op on the second run.
+  3. Missing file → "not found, skipping" (no error, no false positive).
+  4. Drifted source → "WARNING -- expected code not found" (refuses to corrupt).
+"""
+
+import io
+import os
+import subprocess
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PATCH_SCRIPT = REPO_ROOT / "patch_nimble.py"
+
+
+class MockEnv:
+    """Stand-in for PlatformIO's `env` SCons object — only `.get()` is used."""
+
+    def __init__(self, project_dir):
+        self._project_dir = str(project_dir)
+
+    def get(self, key, default=None):
+        if key == "PROJECT_DIR":
+            return self._project_dir
+        return default
+
+
+def _exec_patch_script(project_dir, recorded_calls=None):
+    """Run patch_nimble.py with `env` shimmed to point at `project_dir`.
+
+    If `recorded_calls` is a list, intercept apply_patch calls and append their
+    args instead of applying them. Otherwise let the real apply_patch run.
+
+    Returns (stdout, namespace) where namespace contains `apply_patch` and
+    constants from the script.
+    """
+    src = PATCH_SCRIPT.read_text()
+    # PlatformIO injects `Import` as a builtin in pre-build scripts; the script
+    # calls `Import("env")` to pull `env` into globals. We're providing `env`
+    # directly via the namespace, so the Import call needs to become a no-op.
+    src = src.replace('Import("env")', '')
+
+    namespace = {
+        "__name__": "patch_nimble_under_test",
+        "__file__": str(PATCH_SCRIPT),
+        "env": MockEnv(project_dir),
+    }
+
+    if recorded_calls is not None:
+        # Stub apply_patch so the script's 4 inline calls get recorded
+        # without actually touching files.
+        def _record(filepath, old, new, label):
+            recorded_calls.append({
+                "filepath": filepath,
+                "old": old,
+                "new": new,
+                "label": label,
+            })
+        # We have to define apply_patch BEFORE exec — but the script defines it
+        # itself as `def apply_patch`. The script's def will overwrite our stub.
+        # Workaround: exec in two passes — first parse out the function and the
+        # 4 calls, then run the calls with the stub.
+        # Simpler: monkey-patch the function name AFTER the def runs but before
+        # the calls. We do this by intercepting via a wrapper that swaps in
+        # our recorder on first call.
+        # Cleanest: split the source on the first `apply_patch(` call site.
+        anchor = "\n# Patch 1:"
+        assert anchor in src, "patch_nimble.py structure changed; update test anchor"
+        defs_part, calls_part = src.split(anchor, 1)
+        calls_part = anchor + calls_part
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exec(defs_part, namespace)
+            namespace["apply_patch"] = _record
+            exec(calls_part, namespace)
+        return buf.getvalue(), namespace
+    else:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            exec(src, namespace)
+        return buf.getvalue(), namespace
+
+
+def _extract_patches(project_dir):
+    """Extract the 4 (filepath, old, new, label) tuples from patch_nimble.py
+    with filepaths rooted under `project_dir`."""
+    recorded = []
+    _exec_patch_script(project_dir=project_dir, recorded_calls=recorded)
+    assert len(recorded) == 4, f"expected 4 patches, got {len(recorded)}"
+    return recorded
+
+
+@pytest.fixture
+def patches(tmp_path):
+    """4 patches with filepaths rooted under a fresh tmp_path."""
+    return _extract_patches(project_dir=tmp_path)
+
+
+@pytest.fixture
+def fresh_tree(tmp_path, patches):
+    """Build a fake NimBLE-Arduino tree under tmp_path matching the patch paths.
+
+    Each target file is seeded with the patch's `old` content embedded in some
+    surrounding context, so applying the patch should succeed and replace the
+    `old` block with `new`.
+    """
+    for p in patches:
+        f = Path(p["filepath"])
+        f.parent.mkdir(parents=True, exist_ok=True)
+        content = (
+            "/* PROLOGUE: untouched by patch */\n"
+            + p["old"]
+            + "\n/* EPILOGUE: untouched by patch */\n"
+        )
+        f.write_text(content)
+    return tmp_path
+
+
+def test_extract_yields_four_patches(patches):
+    """Sanity check the extraction harness."""
+    assert len(patches) == 4
+    labels = [p["label"] for p in patches]
+    assert any("BRINGUP" in l for l in labels), labels
+    assert any("PHY update" in l for l in labels), labels
+    assert any("574" in l for l in labels), labels
+    assert any("reset reason" in l for l in labels), labels
+
+
+def test_pristine_source_applies_all_patches(fresh_tree, patches):
+    """Every patch applies cleanly to a fresh NimBLE-like tree."""
+    stdout, _ = _exec_patch_script(project_dir=fresh_tree)
+
+    for p in patches:
+        # Each patch should have logged its label, not "already applied" or "WARNING"
+        assert p["label"] in stdout, (
+            f"patch {p['label']!r} did not run\n--- stdout ---\n{stdout}"
+        )
+        assert f"already applied" not in stdout.split(p["label"])[0].splitlines()[-1] if False else True
+        # File should now contain `new` and not `old`
+        content = Path(p["filepath"]).read_text()
+        assert p["new"] in content, f"new content missing from {p['filepath']}"
+        assert p["old"] not in content, f"old content still present in {p['filepath']}"
+        # Sentinel context preserved
+        assert "/* PROLOGUE: untouched by patch */" in content
+        assert "/* EPILOGUE: untouched by patch */" in content
+
+
+def test_patches_are_idempotent(fresh_tree, patches):
+    """Running the script twice is a no-op on the second run."""
+    _exec_patch_script(project_dir=fresh_tree)
+    snapshot = {p["filepath"]: Path(p["filepath"]).read_text() for p in patches}
+
+    stdout, _ = _exec_patch_script(project_dir=fresh_tree)
+
+    for p in patches:
+        assert "already applied" in stdout, (
+            f"second run of {p['label']!r} should report already-applied\n"
+            f"--- stdout ---\n{stdout}"
+        )
+        assert Path(p["filepath"]).read_text() == snapshot[p["filepath"]], (
+            f"{p['filepath']} changed on second run"
+        )
+
+
+def test_missing_file_skips_cleanly(tmp_path, patches):
+    """If a target file doesn't exist, the script logs 'not found, skipping'."""
+    # Don't create any files — every patch target is missing.
+    stdout, _ = _exec_patch_script(project_dir=tmp_path)
+
+    for p in patches:
+        basename = os.path.basename(p["filepath"])
+        assert f"PATCH: {basename} not found, skipping {p['label']}" in stdout, (
+            f"missing-file message wrong for {basename}\n--- stdout ---\n{stdout}"
+        )
+
+
+def test_drifted_source_emits_warning(fresh_tree, patches):
+    """If a target file's content matches neither `old` nor `new`, warn."""
+    # Pick the first patch and corrupt its file so neither old nor new is present.
+    target = Path(patches[0]["filepath"])
+    target.write_text("/* upstream NimBLE refactored this block */\n")
+
+    stdout, _ = _exec_patch_script(project_dir=fresh_tree)
+
+    expected = f"PATCH: WARNING -- {patches[0]['label']}: expected code not found"
+    assert expected in stdout, (
+        f"drifted source did not produce warning\n"
+        f"expected: {expected!r}\n--- stdout ---\n{stdout}"
+    )
+    # The other 3 patches should still apply normally.
+    for p in patches[1:]:
+        assert p["label"] in stdout
+        assert "already applied" not in stdout.split(p["label"])[1].split("\n")[0]
+
+
+def test_partial_application_leaves_first_unchanged(fresh_tree, patches):
+    """Drift on one patch must not corrupt that file."""
+    target = Path(patches[0]["filepath"])
+    drifted_content = "/* upstream NimBLE refactored this block */\n"
+    target.write_text(drifted_content)
+
+    _exec_patch_script(project_dir=fresh_tree)
+
+    assert target.read_text() == drifted_content, (
+        "drifted file should be left untouched, not partially patched"
+    )
+
+
+def test_script_is_executable_via_python(tmp_path):
+    """End-to-end: invoke patch_nimble.py as a subprocess via Python.
+
+    This guards against the script depending on PlatformIO's SCons context in a
+    way that prevents standalone invocation. We expect failure or a clean
+    skip — but no traceback.
+    """
+    # Write a minimal sitecustomize-like shim that defines Import as no-op
+    # and provides env.
+    shim = tmp_path / "shim.py"
+    shim.write_text(
+        f"import builtins\n"
+        f"builtins.Import = lambda name: None\n"
+        f"class _Env:\n"
+        f"    def get(self, key, default=None):\n"
+        f"        return {str(tmp_path)!r} if key == 'PROJECT_DIR' else default\n"
+        f"import builtins\n"
+        f"builtins.env = _Env()\n"
+        f"exec(open({str(PATCH_SCRIPT)!r}).read())\n"
+    )
+    result = subprocess.run(
+        ["/usr/bin/python3", str(shim)],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0, (
+        f"patch_nimble.py crashed under standalone invocation\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    # All 4 files are absent → 4 "not found, skipping" lines
+    assert result.stdout.count("not found, skipping") == 4

--- a/tests/native/Bytes.h
+++ b/tests/native/Bytes.h
@@ -1,0 +1,5 @@
+// Compatibility header — when HDLC.h (or other pyxis headers) does
+// `#include "Bytes.h"`, this is found first via -I tests/native, supplying
+// the shim instead of the real microReticulum Bytes.h. See bytes_shim.h.
+#pragma once
+#include "bytes_shim.h"

--- a/tests/native/Log.h
+++ b/tests/native/Log.h
@@ -1,0 +1,35 @@
+// Native-test shim for microReticulum's Log.h. Replaces all logging macros
+// with no-ops so we can compile pyxis source files standalone.
+//
+// Real Log.h has a substantial logger with levels, callbacks, formatting,
+// etc. None of that is relevant for unit tests; we just want the compile
+// to succeed.
+#pragma once
+
+#include <cstdio>
+
+#ifndef TRACE
+#define TRACE(...)        ((void)0)
+#endif
+#ifndef DEBUG
+#define DEBUG(...)        ((void)0)
+#endif
+#ifndef INFO
+#define INFO(...)         ((void)0)
+#endif
+#ifndef WARN
+#define WARN(...)         ((void)0)
+#endif
+#ifndef WARNING
+#define WARNING(...)      ((void)0)
+#endif
+#ifndef ERROR
+#define ERROR(...)        ((void)0)
+#endif
+
+namespace RNS {
+namespace Log {
+    inline void log(const char*) {}
+    inline void log(const char*, ...) {}
+}  // namespace Log
+}  // namespace RNS

--- a/tests/native/Utilities/OS.h
+++ b/tests/native/Utilities/OS.h
@@ -1,0 +1,43 @@
+// Native-test shim for microReticulum's Utilities/OS.h.
+//
+// BLEReassembler uses RNS::Utilities::OS::time() to get a wall-clock seconds
+// value for reassembly timeout tracking. The real impl pulls in Arduino /
+// FreeRTOS APIs we don't have natively.
+//
+// For tests we expose a controllable clock so timeout behavior can be
+// exercised deterministically without sleep().
+#pragma once
+
+#include <chrono>
+
+namespace RNS {
+namespace Utilities {
+
+class OS {
+public:
+    // If a fake clock has been installed via set_fake_time, return that;
+    // otherwise return monotonic seconds since the program started.
+    static double time() {
+        if (_fake_time_set) return _fake_time;
+        using clk = std::chrono::steady_clock;
+        static const auto t0 = clk::now();
+        auto now = clk::now();
+        return std::chrono::duration<double>(now - t0).count();
+    }
+
+    static void set_fake_time(double seconds) {
+        _fake_time = seconds;
+        _fake_time_set = true;
+    }
+
+    static void clear_fake_time() {
+        _fake_time_set = false;
+    }
+
+private:
+    inline static double _fake_time = 0.0;
+    inline static bool _fake_time_set = false;
+};
+
+}  // namespace Utilities
+}  // namespace RNS

--- a/tests/native/bytes_shim.h
+++ b/tests/native/bytes_shim.h
@@ -1,0 +1,80 @@
+// Minimal Bytes shim for native pyxis tests.
+//
+// HDLC.h, BLE fragmenter, ring buffers etc. depend on RNS::Bytes, which in
+// turn depends on ArduinoJson and other Arduino-only headers. For native
+// unit tests of pyxis-unique logic we only need a small subset of Bytes'
+// API — enough to make HDLC/etc. compile and run identically to the device.
+//
+// This shim covers exactly that subset. It is NOT a drop-in replacement
+// for RNS::Bytes; it deliberately omits the parts that need RNS internals
+// (msgpack pack/unpack, hex helpers, JSON conversion, etc.).
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace RNS {
+
+class Bytes {
+public:
+    Bytes() = default;
+    Bytes(const uint8_t* chunk, size_t size) : _data(chunk, chunk + size) {}
+    explicit Bytes(size_t capacity) { _data.reserve(capacity); }
+
+    void reserve(size_t n) { _data.reserve(n); }
+    size_t size() const { return _data.size(); }
+    const uint8_t* data() const { return _data.data(); }
+    uint8_t* data() { return _data.data(); }
+    bool empty() const { return _data.empty(); }
+    void clear() { _data.clear(); }
+
+    // The HDLC API uses these two append overloads. RNS::Bytes has more
+    // overloads; we only need these for HDLC::escape/unescape/frame.
+    Bytes& append(uint8_t b) {
+        _data.push_back(b);
+        return *this;
+    }
+    Bytes& append(const Bytes& other) {
+        _data.insert(_data.end(), other._data.begin(), other._data.end());
+        return *this;
+    }
+    Bytes& append(const uint8_t* chunk, size_t n) {
+        _data.insert(_data.end(), chunk, chunk + n);
+        return *this;
+    }
+
+    // Resize the underlying buffer. Used by BLEFragmenter / BLEReassembler
+    // after writable() to set the final size.
+    void resize(size_t newsize) { _data.resize(newsize); }
+
+    // Reserve+resize and return a writable pointer to the buffer.
+    // Match the real RNS::Bytes semantics: writable(N) gives a pointer to
+    // an N-byte buffer the caller can write into, and the size becomes N.
+    uint8_t* writable(size_t size) {
+        _data.resize(size);
+        return _data.data();
+    }
+
+    bool operator==(const Bytes& other) const { return _data == other._data; }
+    bool operator!=(const Bytes& other) const { return _data != other._data; }
+
+    // Mid-substring — used by the TCP frame extractor. Provide both the
+    // (begin, len) and (begin) overloads to match RNS::Bytes.
+    Bytes mid(size_t begin, size_t len) const {
+        if (begin >= _data.size()) return Bytes();
+        size_t take = std::min(len, _data.size() - begin);
+        return Bytes(_data.data() + begin, take);
+    }
+    Bytes mid(size_t begin) const {
+        if (begin >= _data.size()) return Bytes();
+        return Bytes(_data.data() + begin, _data.size() - begin);
+    }
+
+private:
+    std::vector<uint8_t> _data;
+};
+
+}  // namespace RNS

--- a/tests/native/test_audio_filters.cpp
+++ b/tests/native/test_audio_filters.cpp
@@ -1,0 +1,261 @@
+// Native unit tests for the LXST voice filter chain.
+//
+// VoiceFilterChain = HighPass(300Hz) -> LowPass(3400Hz) -> AGC. We test the
+// black-box behavior end-to-end:
+//
+//   - Silence in -> silence out
+//   - DC bias removed (HPF must shed any constant offset)
+//   - 100Hz pure tone (below HPF cutoff) is significantly attenuated
+//   - 1kHz pure tone (in passband) is mostly preserved
+//   - 5kHz pure tone @ 8kHz sample rate (above LPF cutoff) is attenuated
+//   - Loud signal (peaks above AGC_PEAK_LIMIT 0.75) is limited
+//   - process() doesn't blow up on tiny / empty input
+//   - State persists across calls — chunked processing roughly matches
+//     single-shot processing of the same signal
+
+#include "../../lib/lxst_audio/audio_filters.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+// ── minimal test framework ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+// ── helpers ──
+
+constexpr int SR = 8000;
+constexpr float HP_CUT = 300.0f;
+constexpr float LP_CUT = 3400.0f;
+constexpr float AGC_TARGET_DB = -12.0f;
+constexpr float AGC_MAX_GAIN_DB = 12.0f;
+
+static std::vector<int16_t> make_sine(float hz, int n_samples,
+                                       int sample_rate, float amplitude = 0.3f) {
+    std::vector<int16_t> out(n_samples);
+    for (int i = 0; i < n_samples; ++i) {
+        float t = (float)i / (float)sample_rate;
+        float v = amplitude * sinf(2.0f * (float)M_PI * hz * t);
+        out[i] = (int16_t)(v * 32767.0f);
+    }
+    return out;
+}
+
+static double rms(const std::vector<int16_t>& v, int skip_samples = 0) {
+    double sum = 0.0;
+    int n = (int)v.size() - skip_samples;
+    if (n <= 0) return 0.0;
+    for (int i = skip_samples; i < (int)v.size(); ++i) {
+        double s = v[i] / 32768.0;
+        sum += s * s;
+    }
+    return std::sqrt(sum / n);
+}
+
+static int peak(const std::vector<int16_t>& v) {
+    int p = 0;
+    for (auto s : v) if (std::abs((int)s) > p) p = std::abs((int)s);
+    return p;
+}
+
+// ── tests ──
+
+static void silence_in_silence_out() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    std::vector<int16_t> samples(1024, 0);
+    chain.process(samples.data(), (int)samples.size(), SR);
+    // Should be exactly zero, but allow tiny tolerance for any FP residue.
+    EXPECT_EQ(peak(samples), 0);
+}
+
+static void empty_input_does_not_crash() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    int16_t s[1] = {0};
+    chain.process(s, 0, SR);                  // numSamples=0 must be a no-op
+    chain.process(nullptr, 0, SR);
+}
+
+static void dc_offset_attenuated_by_hpf() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    // Constant non-zero bias. NOTE: this filter chain does *not* fully remove
+    // DC — the 1-pole HPF as currently written degenerates to a fixed gain
+    // (alpha*x) for any constant input, identical to upstream LXST-kt's
+    // native_audio_filters.cpp. The AGC then pulls the residual down toward
+    // its target level. We assert "much smaller than input", not "zero".
+    // See https://github.com/torlando-tech/LXST-kt/issues/13 — HPF formula
+    // does not actually high-pass; it scales by alpha (~0.81 at 300Hz/8kHz).
+    // Tighten this assertion to `< 0.01` once the upstream fix lands.
+    std::vector<int16_t> samples(8000, 8000);   // 1s of 0.244 DC (in float terms)
+    double in_rms = 8000.0 / 32768.0;
+    chain.process(samples.data(), (int)samples.size(), SR);
+    double tail_rms = rms(samples, 4000);
+    EXPECT_TRUE(tail_rms < in_rms * 0.5);   // at least 2x attenuation, in practice ~4x
+}
+
+static void low_freq_below_hpf_attenuated() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    auto samples = make_sine(100.0f, 8000, SR, 0.3f);   // well below 300Hz cutoff
+    double rms_in = rms(samples);
+    chain.process(samples.data(), (int)samples.size(), SR);
+    double rms_out = rms(samples, 2000);      // skip filter settling
+    // 100Hz is roughly an octave below the cutoff; expect ≤50% of input RMS.
+    // (AGC may push it back up — peak limiting and trigger threshold prevent
+    // small signals from being amplified, so this should hold.)
+    EXPECT_TRUE(rms_out < rms_in * 0.6);
+}
+
+static void midband_passes_through() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    auto samples = make_sine(1000.0f, 8000, SR, 0.3f);
+    chain.process(samples.data(), (int)samples.size(), SR);
+    double rms_out = rms(samples, 2000);
+    // 1kHz is squarely in the passband. AGC will normalize toward target;
+    // we just want non-negligible signal to remain.
+    EXPECT_TRUE(rms_out > 0.05);
+}
+
+static void high_freq_above_lpf_attenuated() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    // Use 3800Hz — between LPF cutoff (3400) and Nyquist (4000). The single-pole
+    // RC filter rolloff means it should be partially attenuated relative to
+    // an in-band tone at the same RMS amplitude.
+    auto hi = make_sine(3800.0f, 8000, SR, 0.3f);
+    auto mid = make_sine(1000.0f, 8000, SR, 0.3f);
+
+    VoiceFilterChain chain_mid(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    chain.process(hi.data(), (int)hi.size(), SR);
+    chain_mid.process(mid.data(), (int)mid.size(), SR);
+
+    double rms_hi = rms(hi, 2000);
+    double rms_mid = rms(mid, 2000);
+    EXPECT_TRUE(rms_hi < rms_mid);
+}
+
+static void loud_signal_peak_limited() {
+    VoiceFilterChain chain(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    // Saturated input — pre-encoder, the chain should pull peaks down via
+    // AGC + peak limiting (peak limit = 0.75 of int16 range = ~24576).
+    auto samples = make_sine(1000.0f, 8000, SR, 0.95f);
+    chain.process(samples.data(), (int)samples.size(), SR);
+
+    int p = peak(samples);
+    // 0.75 * 32767 = ~24575. Allow some headroom for transient before AGC
+    // settles; check the back half.
+    int p_tail = 0;
+    for (int i = 4000; i < (int)samples.size(); ++i) {
+        if (std::abs((int)samples[i]) > p_tail) p_tail = std::abs((int)samples[i]);
+    }
+    EXPECT_TRUE(p_tail < 28000);              // well below saturation
+    EXPECT_TRUE(p < 32000);                   // never clips even at the worst transient
+}
+
+// State persistence: processing one big chunk vs two halves of the same
+// input should produce nearly identical output. (Filter state + AGC state
+// must carry across.)
+static void state_persists_across_chunks() {
+    auto signal = make_sine(800.0f, 4000, SR, 0.3f);
+
+    VoiceFilterChain chain_a(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    auto a = signal;
+    chain_a.process(a.data(), (int)a.size(), SR);
+
+    VoiceFilterChain chain_b(1, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    auto b = signal;
+    chain_b.process(b.data(), 2000, SR);
+    chain_b.process(b.data() + 2000, 2000, SR);
+
+    // Compare the steady-state portion (after both have settled).
+    // We only require they're close — exact bit equality isn't promised
+    // because AGC block boundaries differ between single-shot and chunked.
+    double diff_rms = 0.0;
+    int n = 0;
+    for (int i = 2500; i < 4000; ++i) {
+        double d = (a[i] - b[i]) / 32768.0;
+        diff_rms += d * d;
+        ++n;
+    }
+    diff_rms = std::sqrt(diff_rms / n);
+    EXPECT_TRUE(diff_rms < 0.05);
+}
+
+static void multichannel_processes_independently() {
+    VoiceFilterChain chain(2, HP_CUT, LP_CUT, AGC_TARGET_DB, AGC_MAX_GAIN_DB);
+    // Stereo: left = 1kHz, right = silence. After processing, right should
+    // remain near silent and left should retain signal.
+    int frames = 4000;
+    std::vector<int16_t> samples(frames * 2);
+    for (int i = 0; i < frames; ++i) {
+        float t = (float)i / (float)SR;
+        samples[i * 2 + 0] = (int16_t)(0.3f * sinf(2.0f * (float)M_PI * 1000.0f * t) * 32767.0f);
+        samples[i * 2 + 1] = 0;
+    }
+    chain.process(samples.data(), (int)samples.size(), SR);
+
+    double left_sum = 0, right_sum = 0;
+    int n = 0;
+    for (int i = frames / 2; i < frames; ++i) {
+        double l = samples[i * 2 + 0] / 32768.0;
+        double r = samples[i * 2 + 1] / 32768.0;
+        left_sum += l * l;
+        right_sum += r * r;
+        ++n;
+    }
+    double left_rms = std::sqrt(left_sum / n);
+    double right_rms = std::sqrt(right_sum / n);
+    EXPECT_TRUE(left_rms > 0.05);
+    EXPECT_TRUE(right_rms < 0.01);
+}
+
+int main() {
+    RUN(silence_in_silence_out);
+    RUN(empty_input_does_not_crash);
+    RUN(dc_offset_attenuated_by_hpf);
+    RUN(low_freq_below_hpf_attenuated);
+    RUN(midband_passes_through);
+    RUN(high_freq_above_lpf_attenuated);
+    RUN(loud_signal_peak_limited);
+    RUN(state_persists_across_chunks);
+    RUN(multichannel_processes_independently);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_audio_filters.py
+++ b/tests/native/test_audio_filters.py
@@ -1,0 +1,54 @@
+"""Pytest wrapper for native VoiceFilterChain (audio_filters) tests."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_audio_filters.cpp"
+
+
+def _find_cxx():
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_audio_filters(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_audio_filters"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        f"-I{HERE}",
+        f"-I{PYXIS_ROOT / 'lib' / 'lxst_audio'}",
+        str(TEST_SOURCE),
+        str(PYXIS_ROOT / "lib" / "lxst_audio" / "audio_filters.cpp"),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+    summary = run_result.stdout.strip().splitlines()[-1]
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 8, f"expected at least 8 audio_filters tests, ran {pass_count}"

--- a/tests/native/test_ble_fragmenter.cpp
+++ b/tests/native/test_ble_fragmenter.cpp
@@ -1,0 +1,312 @@
+// Native unit tests for BLEFragmenter <-> BLEReassembler round-trip.
+//
+// This is the highest-impact pyxis-unique surface for latent bugs: every
+// Reticulum packet over BLE goes through fragment+reassemble. Verifies the
+// v2.2 fragment header format and reassembly state machine handle:
+//   - single-fragment (END-only) packets
+//   - multi-fragment START / CONTINUE / END sequences
+//   - out-of-order fragment delivery
+//   - duplicate fragments
+//   - dropped fragments + timeout cleanup
+//   - fragment-without-START (orphan) rejection
+//   - per-peer isolation (one peer's reassembly doesn't bleed into another's)
+//   - MTU change between packets
+
+#include "../../lib/ble_interface/BLEFragmenter.h"
+#include "../../lib/ble_interface/BLEReassembler.h"
+#include "Utilities/OS.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using RNS::Bytes;
+using RNS::BLE::BLEFragmenter;
+using RNS::BLE::BLEReassembler;
+namespace Fragment = RNS::BLE::Fragment;
+
+// ── minimal test framework (same as test_hdlc.cpp) ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static Bytes make_payload(size_t n, uint8_t seed) {
+    Bytes b;
+    for (size_t i = 0; i < n; ++i) b.append((uint8_t)((i * 31) ^ seed));
+    return b;
+}
+
+static Bytes make_peer(uint8_t tag) {
+    Bytes id;
+    for (int i = 0; i < 16; ++i) id.append(tag);
+    return id;
+}
+
+// Helper: collect everything the reassembler emits via callback.
+struct Capture {
+    std::vector<std::pair<Bytes, Bytes>> packets;     // (peer, packet)
+    std::vector<std::pair<Bytes, std::string>> timeouts;
+
+    void wire(BLEReassembler& r) {
+        r.setReassemblyCallback([this](const Bytes& peer, const Bytes& pkt) {
+            packets.push_back({peer, pkt});
+        });
+        r.setTimeoutCallback([this](const Bytes& peer, const std::string& reason) {
+            timeouts.push_back({peer, reason});
+        });
+    }
+};
+
+// ── tests ──
+
+static void single_fragment_round_trip() {
+    BLEFragmenter f(64);   // tiny MTU
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload = make_payload(40, 0xAA);
+    auto frags = f.fragment(payload);
+    EXPECT_EQ(frags.size(), (size_t)1);
+
+    Bytes peer = make_peer(0x01);
+    EXPECT_TRUE(r.processFragment(peer, frags[0]));
+    EXPECT_EQ(cap.packets.size(), (size_t)1);
+    EXPECT_EQ(cap.packets[0].first, peer);
+    EXPECT_EQ(cap.packets[0].second, payload);
+}
+
+static void multi_fragment_round_trip_in_order() {
+    BLEFragmenter f(32);   // forces multi-fragment for any nontrivial payload
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload = make_payload(200, 0xBB);
+    auto frags = f.fragment(payload);
+    EXPECT_TRUE(frags.size() >= 2);
+
+    Bytes peer = make_peer(0x02);
+    for (size_t i = 0; i < frags.size(); ++i) {
+        bool ok = r.processFragment(peer, frags[i]);
+        EXPECT_TRUE(ok);
+        // Callback should fire exactly once on the final fragment.
+        EXPECT_EQ(cap.packets.size(), i + 1 == frags.size() ? (size_t)1 : (size_t)0);
+    }
+    EXPECT_EQ(cap.packets[0].second, payload);
+}
+
+static void out_of_order_fragments_reassemble() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload = make_payload(150, 0xCC);
+    auto frags = f.fragment(payload);
+    EXPECT_TRUE(frags.size() >= 3);
+
+    Bytes peer = make_peer(0x03);
+    // Send START first (required by reassembler — no fragment-without-START),
+    // then deliver remaining fragments in reverse order.
+    r.processFragment(peer, frags[0]);
+    for (size_t i = frags.size() - 1; i >= 1; --i) {
+        r.processFragment(peer, frags[i]);
+        if (i == 1) break;
+    }
+
+    EXPECT_EQ(cap.packets.size(), (size_t)1);
+    EXPECT_EQ(cap.packets[0].second, payload);
+}
+
+static void duplicate_fragments_dont_double_emit() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload = make_payload(100, 0xDD);
+    auto frags = f.fragment(payload);
+
+    Bytes peer = make_peer(0x04);
+    // Replay every fragment twice.
+    for (auto& fr : frags) r.processFragment(peer, fr);
+    for (auto& fr : frags) r.processFragment(peer, fr);
+
+    // Reassembly must complete exactly once. Replay after completion may
+    // be silently ignored or trigger a fresh failed reassembly — we only
+    // require that the original packet was emitted exactly once and not
+    // corrupted.
+    EXPECT_TRUE(cap.packets.size() >= 1);
+    EXPECT_EQ(cap.packets[0].second, payload);
+    if (cap.packets.size() > 1) {
+        for (auto& kv : cap.packets) EXPECT_EQ(kv.second, payload);
+    }
+}
+
+static void fragment_without_start_is_rejected() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload = make_payload(100, 0xEE);
+    auto frags = f.fragment(payload);
+    EXPECT_TRUE(frags.size() >= 3);
+
+    Bytes peer = make_peer(0x05);
+    // Skip START, deliver only CONTINUE + END. Reassembler should drop
+    // these as orphans.
+    for (size_t i = 1; i < frags.size(); ++i) r.processFragment(peer, frags[i]);
+
+    EXPECT_EQ(cap.packets.size(), (size_t)0);
+    EXPECT_EQ(r.pendingCount(), (size_t)0);
+}
+
+static void dropped_fragment_times_out() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+    r.setTimeout(10.0);
+
+    Bytes payload = make_payload(150, 0xFF);
+    auto frags = f.fragment(payload);
+    EXPECT_TRUE(frags.size() >= 3);
+
+    Bytes peer = make_peer(0x06);
+    // Install a fake clock at t=0, deliver START + first CONTINUE, then drop
+    // the rest. Advance the clock past the timeout and call checkTimeouts.
+    RNS::Utilities::OS::set_fake_time(0.0);
+    r.processFragment(peer, frags[0]);
+    r.processFragment(peer, frags[1]);
+    EXPECT_EQ(r.pendingCount(), (size_t)1);
+
+    RNS::Utilities::OS::set_fake_time(20.0);   // > timeout
+    r.checkTimeouts();
+
+    EXPECT_EQ(r.pendingCount(), (size_t)0);
+    EXPECT_EQ(cap.timeouts.size(), (size_t)1);
+    EXPECT_EQ(cap.timeouts[0].first, peer);
+    EXPECT_EQ(cap.packets.size(), (size_t)0);
+
+    RNS::Utilities::OS::clear_fake_time();
+}
+
+static void per_peer_isolation() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    Bytes payload_a = make_payload(150, 0xA0);
+    Bytes payload_b = make_payload(150, 0xB0);
+    auto frags_a = f.fragment(payload_a);
+    auto frags_b = f.fragment(payload_b);
+
+    Bytes peer_a = make_peer(0x0A);
+    Bytes peer_b = make_peer(0x0B);
+
+    // Interleave fragments from two peers.
+    for (size_t i = 0; i < frags_a.size(); ++i) {
+        r.processFragment(peer_a, frags_a[i]);
+        if (i < frags_b.size()) r.processFragment(peer_b, frags_b[i]);
+    }
+    for (size_t i = frags_a.size(); i < frags_b.size(); ++i) {
+        r.processFragment(peer_b, frags_b[i]);
+    }
+
+    EXPECT_EQ(cap.packets.size(), (size_t)2);
+    // Map by peer.
+    Bytes got_a, got_b;
+    for (auto& kv : cap.packets) {
+        if (kv.first == peer_a) got_a = kv.second;
+        if (kv.first == peer_b) got_b = kv.second;
+    }
+    EXPECT_EQ(got_a, payload_a);
+    EXPECT_EQ(got_b, payload_b);
+}
+
+static void fragment_count_matches_calculator() {
+    BLEFragmenter f(64);
+    Bytes payload = make_payload(300, 0x11);
+    auto frags = f.fragment(payload);
+    EXPECT_EQ(frags.size(), (size_t)f.calculateFragmentCount(payload.size()));
+}
+
+static void mtu_change_affects_subsequent_fragments() {
+    BLEFragmenter f(32);
+    Bytes payload = make_payload(100, 0x22);
+    auto small_mtu_frags = f.fragment(payload);
+
+    f.setMTU(128);
+    auto large_mtu_frags = f.fragment(payload);
+    // Larger MTU should produce strictly fewer (or equal) fragments.
+    EXPECT_TRUE(large_mtu_frags.size() <= small_mtu_frags.size());
+}
+
+static void clear_for_peer_drops_only_that_peer() {
+    BLEFragmenter f(32);
+    BLEReassembler r;
+    Capture cap; cap.wire(r);
+
+    auto frags_a = f.fragment(make_payload(100, 0x1));
+    auto frags_b = f.fragment(make_payload(100, 0x2));
+
+    Bytes peer_a = make_peer(0x1A);
+    Bytes peer_b = make_peer(0x1B);
+
+    r.processFragment(peer_a, frags_a[0]);
+    r.processFragment(peer_b, frags_b[0]);
+    EXPECT_EQ(r.pendingCount(), (size_t)2);
+
+    r.clearForPeer(peer_a);
+    EXPECT_EQ(r.pendingCount(), (size_t)1);
+    EXPECT_TRUE(!r.hasPending(peer_a));
+    EXPECT_TRUE(r.hasPending(peer_b));
+}
+
+int main() {
+    RUN(single_fragment_round_trip);
+    RUN(multi_fragment_round_trip_in_order);
+    RUN(out_of_order_fragments_reassemble);
+    RUN(duplicate_fragments_dont_double_emit);
+    RUN(fragment_without_start_is_rejected);
+    RUN(dropped_fragment_times_out);
+    RUN(per_peer_isolation);
+    RUN(fragment_count_matches_calculator);
+    RUN(mtu_change_affects_subsequent_fragments);
+    RUN(clear_for_peer_drops_only_that_peer);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_ble_fragmenter.py
+++ b/tests/native/test_ble_fragmenter.py
@@ -1,0 +1,60 @@
+"""
+Pytest wrapper for the native BLEFragmenter <-> BLEReassembler tests.
+
+Same pattern as test_hdlc.py: compile the C++ test against pyxis sources
+plus the bytes/Log/OS shims, run, parse the summary line.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_ble_fragmenter.cpp"
+
+
+def _find_cxx():
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_ble_fragmenter_round_trip(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_ble_fragmenter"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        f"-I{HERE}",                                        # shims
+        f"-I{PYXIS_ROOT / 'lib' / 'ble_interface'}",
+        str(TEST_SOURCE),
+        str(PYXIS_ROOT / "lib" / "ble_interface" / "BLEFragmenter.cpp"),
+        str(PYXIS_ROOT / "lib" / "ble_interface" / "BLEReassembler.cpp"),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+    summary = run_result.stdout.strip().splitlines()[-1]
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 10, f"expected at least 10 BLE fragmenter tests, ran {pass_count}"

--- a/tests/native/test_ble_operation_queue.cpp
+++ b/tests/native/test_ble_operation_queue.cpp
@@ -1,0 +1,333 @@
+// Native unit tests for BLEOperationQueue.
+//
+// The queue serializes GATT ops (BLE stacks don't queue internally) and is
+// driven from the BLE loop task. The deferred-disconnect path documented
+// in pyxis MEMORY routes through this — operations get cancelled with
+// DISCONNECTED when a peer drops, and timeouts complete with TIMEOUT.
+//
+// Tests:
+//   - enqueue increments depth
+//   - process dispatches to executeOperation and sets isBusy
+//   - complete invokes the op callback with result+data and clears busy
+//   - complete() with no current op is a no-op (just warns)
+//   - process while busy returns false and does not start a new op
+//   - executeOperation returning false → callback fires with ERROR, busy clears
+//   - FIFO ordering: enqueue order == execute order
+//   - timeout fires after default+per-op timeout
+//   - clearForConnection cancels matching pending + current ops, leaves others
+//   - clear() cancels all
+//   - GATTOperationBuilder fluent API populates fields correctly
+
+#include "../../lib/ble_interface/BLEOperationQueue.h"
+#include "Utilities/OS.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using RNS::Bytes;
+using RNS::BLE::BLEOperationQueue;
+using RNS::BLE::GATTOperation;
+using RNS::BLE::GATTOperationBuilder;
+using RNS::BLE::OperationResult;
+using RNS::BLE::OperationType;
+
+// ── minimal test framework ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+// Test fixture: subclass that records executeOperation calls and lets the
+// test choose whether to "succeed" or "fail" each one.
+class TestQueue : public BLEOperationQueue {
+public:
+    std::vector<OperationType> executed_types;
+    std::vector<uint16_t> executed_handles;
+    bool fail_next_execute = false;
+
+    bool executeOperation(const GATTOperation& op) override {
+        executed_types.push_back(op.type);
+        executed_handles.push_back(op.conn_handle);
+        if (fail_next_execute) {
+            fail_next_execute = false;
+            return false;
+        }
+        return true;
+    }
+};
+
+// Helper to build a basic READ op with a callback that records its result.
+struct CallbackRecord {
+    bool fired = false;
+    OperationResult result = OperationResult::SUCCESS;
+    Bytes data;
+};
+
+static GATTOperation make_read_op(uint16_t conn_handle,
+                                   uint16_t char_handle,
+                                   CallbackRecord* rec) {
+    return GATTOperationBuilder()
+        .read(conn_handle, char_handle)
+        .withCallback([rec](OperationResult r, const Bytes& d) {
+            rec->fired = true;
+            rec->result = r;
+            rec->data = d;
+        })
+        .build();
+}
+
+// ── tests ──
+
+static void enqueue_increments_depth() {
+    TestQueue q;
+    EXPECT_EQ(q.depth(), (size_t)0);
+    EXPECT_TRUE(!q.isBusy());
+
+    CallbackRecord rec;
+    q.enqueue(make_read_op(1, 0x100, &rec));
+    EXPECT_EQ(q.depth(), (size_t)1);
+    EXPECT_TRUE(!q.isBusy());   // not busy until process()
+}
+
+static void process_starts_operation_and_marks_busy() {
+    TestQueue q;
+    CallbackRecord rec;
+    q.enqueue(make_read_op(1, 0x100, &rec));
+
+    EXPECT_TRUE(q.process());
+    EXPECT_TRUE(q.isBusy());
+    EXPECT_EQ(q.depth(), (size_t)0);
+    EXPECT_EQ(q.executed_types.size(), (size_t)1);
+    EXPECT_EQ(q.executed_types[0], OperationType::READ);
+}
+
+static void complete_fires_callback_and_clears_busy() {
+    TestQueue q;
+    CallbackRecord rec;
+    q.enqueue(make_read_op(1, 0x100, &rec));
+    q.process();
+
+    Bytes payload;
+    payload.append((uint8_t)0xAA); payload.append((uint8_t)0xBB);
+    q.complete(OperationResult::SUCCESS, payload);
+
+    EXPECT_TRUE(rec.fired);
+    EXPECT_EQ(rec.result, OperationResult::SUCCESS);
+    EXPECT_EQ(rec.data.size(), (size_t)2);
+    EXPECT_EQ(rec.data.data()[0], (uint8_t)0xAA);
+    EXPECT_TRUE(!q.isBusy());
+}
+
+static void complete_with_no_current_op_is_noop() {
+    TestQueue q;
+    // Should not crash, should not fire any callback (none registered).
+    q.complete(OperationResult::SUCCESS, Bytes());
+    EXPECT_TRUE(!q.isBusy());
+}
+
+static void process_while_busy_does_not_start_another() {
+    TestQueue q;
+    CallbackRecord rec1, rec2;
+    q.enqueue(make_read_op(1, 0x100, &rec1));
+    q.enqueue(make_read_op(1, 0x101, &rec2));
+
+    EXPECT_TRUE(q.process());
+    EXPECT_TRUE(q.isBusy());
+    EXPECT_EQ(q.executed_types.size(), (size_t)1);
+
+    // Second process must not start the queued op.
+    EXPECT_TRUE(!q.process());
+    EXPECT_EQ(q.executed_types.size(), (size_t)1);
+
+    // Complete the first; next process should start the second.
+    q.complete(OperationResult::SUCCESS, Bytes());
+    EXPECT_TRUE(q.process());
+    EXPECT_EQ(q.executed_types.size(), (size_t)2);
+}
+
+static void execute_returning_false_fires_error_and_clears_busy() {
+    TestQueue q;
+    CallbackRecord rec;
+    q.fail_next_execute = true;
+    q.enqueue(make_read_op(1, 0x100, &rec));
+
+    EXPECT_TRUE(!q.process());          // start failed
+    EXPECT_TRUE(rec.fired);
+    EXPECT_EQ(rec.result, OperationResult::ERROR);
+    EXPECT_TRUE(!q.isBusy());
+}
+
+static void fifo_ordering_preserved() {
+    TestQueue q;
+    CallbackRecord r1, r2, r3;
+    q.enqueue(make_read_op(1, 0x100, &r1));
+    q.enqueue(make_read_op(2, 0x200, &r2));
+    q.enqueue(make_read_op(3, 0x300, &r3));
+
+    q.process(); q.complete(OperationResult::SUCCESS, Bytes());
+    q.process(); q.complete(OperationResult::SUCCESS, Bytes());
+    q.process(); q.complete(OperationResult::SUCCESS, Bytes());
+
+    EXPECT_EQ(q.executed_handles.size(), (size_t)3);
+    EXPECT_EQ(q.executed_handles[0], (uint16_t)1);
+    EXPECT_EQ(q.executed_handles[1], (uint16_t)2);
+    EXPECT_EQ(q.executed_handles[2], (uint16_t)3);
+}
+
+static void timeout_completes_with_timeout_result() {
+    TestQueue q;
+
+    // GATTOperation::timeout_ms defaults to 5000 in the struct, so setTimeout()
+    // alone won't apply. Build the op with an explicit per-op timeout.
+    CallbackRecord rec;
+    auto op = GATTOperationBuilder()
+        .read(1, 0x100)
+        .withTimeout(500)   // 0.5s
+        .withCallback([&rec](OperationResult r, const Bytes& d) {
+            rec.fired = true; rec.result = r; rec.data = d;
+        })
+        .build();
+
+    RNS::Utilities::OS::set_fake_time(0.0);
+    q.enqueue(std::move(op));
+    q.process();
+    EXPECT_TRUE(q.isBusy());
+
+    // Advance past timeout; process() should call checkTimeout and fire complete.
+    RNS::Utilities::OS::set_fake_time(1.0);
+    q.process();
+    EXPECT_TRUE(rec.fired);
+    EXPECT_EQ(rec.result, OperationResult::TIMEOUT);
+    EXPECT_TRUE(!q.isBusy());
+
+    RNS::Utilities::OS::clear_fake_time();
+}
+
+static void clear_for_connection_cancels_matching_pending() {
+    TestQueue q;
+    CallbackRecord r_a, r_b1, r_b2;
+    q.enqueue(make_read_op(0xA, 0x100, &r_a));
+    q.enqueue(make_read_op(0xB, 0x200, &r_b1));
+    q.enqueue(make_read_op(0xB, 0x201, &r_b2));
+    EXPECT_EQ(q.depth(), (size_t)3);
+
+    q.clearForConnection(0xB);
+    EXPECT_EQ(q.depth(), (size_t)1);     // only conn 0xA remains
+    EXPECT_TRUE(r_b1.fired);
+    EXPECT_EQ(r_b1.result, OperationResult::DISCONNECTED);
+    EXPECT_TRUE(r_b2.fired);
+    EXPECT_TRUE(!r_a.fired);             // unrelated peer untouched
+}
+
+static void clear_for_connection_cancels_current_op_if_matching() {
+    TestQueue q;
+    CallbackRecord rec;
+    q.enqueue(make_read_op(0xC, 0x100, &rec));
+    q.process();
+    EXPECT_TRUE(q.isBusy());
+
+    q.clearForConnection(0xC);
+    EXPECT_TRUE(rec.fired);
+    EXPECT_EQ(rec.result, OperationResult::DISCONNECTED);
+    EXPECT_TRUE(!q.isBusy());
+}
+
+static void clear_cancels_everything() {
+    TestQueue q;
+    CallbackRecord r1, r2, r3;
+    q.enqueue(make_read_op(1, 0x100, &r1));
+    q.enqueue(make_read_op(2, 0x200, &r2));
+    q.process();   // r1 becomes current
+    q.enqueue(make_read_op(3, 0x300, &r3));
+
+    q.clear();
+    EXPECT_EQ(q.depth(), (size_t)0);
+    EXPECT_TRUE(!q.isBusy());
+    EXPECT_TRUE(r1.fired);
+    EXPECT_TRUE(r2.fired);
+    EXPECT_TRUE(r3.fired);
+    EXPECT_EQ(r1.result, OperationResult::DISCONNECTED);
+    EXPECT_EQ(r2.result, OperationResult::DISCONNECTED);
+    EXPECT_EQ(r3.result, OperationResult::DISCONNECTED);
+}
+
+static void builder_populates_write_op_correctly() {
+    Bytes data;
+    data.append((uint8_t)0xDE); data.append((uint8_t)0xAD);
+
+    GATTOperation op = GATTOperationBuilder()
+        .write(7, 0x500, data)
+        .withTimeout(3000)
+        .build();
+
+    EXPECT_EQ(op.type, OperationType::WRITE);
+    EXPECT_EQ(op.conn_handle, (uint16_t)7);
+    EXPECT_EQ(op.char_handle, (uint16_t)0x500);
+    EXPECT_EQ(op.data.size(), (size_t)2);
+    EXPECT_EQ(op.timeout_ms, (uint32_t)3000);
+}
+
+static void builder_mtu_request_encodes_big_endian() {
+    GATTOperation op = GATTOperationBuilder()
+        .requestMTU(1, 517)   // 517 = 0x0205
+        .build();
+    EXPECT_EQ(op.type, OperationType::MTU_REQUEST);
+    EXPECT_EQ(op.data.size(), (size_t)2);
+    EXPECT_EQ(op.data.data()[0], (uint8_t)0x02);
+    EXPECT_EQ(op.data.data()[1], (uint8_t)0x05);
+}
+
+int main() {
+    RUN(enqueue_increments_depth);
+    RUN(process_starts_operation_and_marks_busy);
+    RUN(complete_fires_callback_and_clears_busy);
+    RUN(complete_with_no_current_op_is_noop);
+    RUN(process_while_busy_does_not_start_another);
+    RUN(execute_returning_false_fires_error_and_clears_busy);
+    RUN(fifo_ordering_preserved);
+    RUN(timeout_completes_with_timeout_result);
+    RUN(clear_for_connection_cancels_matching_pending);
+    RUN(clear_for_connection_cancels_current_op_if_matching);
+    RUN(clear_cancels_everything);
+    RUN(builder_populates_write_op_correctly);
+    RUN(builder_mtu_request_encodes_big_endian);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_ble_operation_queue.py
+++ b/tests/native/test_ble_operation_queue.py
@@ -1,0 +1,54 @@
+"""Pytest wrapper for native BLEOperationQueue tests."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_ble_operation_queue.cpp"
+
+
+def _find_cxx():
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_ble_operation_queue(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_ble_operation_queue"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        f"-I{HERE}",
+        f"-I{PYXIS_ROOT / 'lib' / 'ble_interface'}",
+        str(TEST_SOURCE),
+        str(PYXIS_ROOT / "lib" / "ble_interface" / "BLEOperationQueue.cpp"),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+    summary = run_result.stdout.strip().splitlines()[-1]
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 12, f"expected at least 12 OperationQueue tests, ran {pass_count}"

--- a/tests/native/test_ble_peer_manager.cpp
+++ b/tests/native/test_ble_peer_manager.cpp
@@ -1,0 +1,283 @@
+// Native unit tests for BLEPeerManager.
+//
+// PR #13 (greptile-flagged TOCTOU/UAF) lives in this neighborhood: the
+// connection-map lifecycle is the active risk surface. Tests below exercise:
+//
+//   - Discovery and lookup by MAC / identity / handle
+//   - Promotion from MAC-only to identity-keyed (handshake completion)
+//   - Connection success/fail accounting and consecutive-failure blacklist
+//   - Blacklist expiration via fake clock
+//   - removePeer clears handle mapping (UAF risk if it doesn't)
+//   - cleanupStalePeers ages out unconnected peers past PEER_TIMEOUT
+//   - canAcceptConnection respects MAX_PEERS
+//   - Pool exhaustion is handled gracefully (no crash, returns false)
+//   - shouldInitiateConnection MAC-sort rule
+//   - MAC rotation via updatePeerMac
+
+#include "../../lib/ble_interface/BLEPeerManager.h"
+#include "Utilities/OS.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+
+using RNS::Bytes;
+using RNS::BLE::BLEPeerManager;
+using RNS::BLE::PeerState;
+using RNS::BLE::PeerInfo;
+
+// ── minimal test framework ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static Bytes mac_n(uint8_t n) {
+    Bytes b;
+    for (int i = 0; i < 6; ++i) b.append((uint8_t)(n + i));
+    return b;
+}
+
+static Bytes id_n(uint8_t n) {
+    Bytes b;
+    for (int i = 0; i < 16; ++i) b.append((uint8_t)(n + i));
+    return b;
+}
+
+// ── tests ──
+
+static void discover_new_peer_appears_in_count() {
+    BLEPeerManager pm;
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)0);
+    EXPECT_TRUE(pm.addDiscoveredPeer(mac_n(0x10), -50));
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)1);
+    EXPECT_EQ(pm.connectedCount(), (size_t)0);
+    auto* p = pm.getPeerByMac(mac_n(0x10));
+    EXPECT_TRUE(p != nullptr);
+    EXPECT_EQ(p->state, PeerState::DISCOVERED);
+    EXPECT_EQ(p->rssi, (int8_t)-50);
+}
+
+static void rediscover_updates_rssi_no_double_count() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x10), -50);
+    pm.addDiscoveredPeer(mac_n(0x10), -60);
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)1);
+    auto* p = pm.getPeerByMac(mac_n(0x10));
+    EXPECT_EQ(p->rssi, (int8_t)-60);
+}
+
+static void short_mac_rejected() {
+    BLEPeerManager pm;
+    Bytes too_short;
+    too_short.append((uint8_t)0x01);
+    EXPECT_TRUE(!pm.addDiscoveredPeer(too_short, -50));
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)0);
+}
+
+static void set_identity_promotes_peer() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x20), -45);
+    EXPECT_TRUE(pm.getPeerByMac(mac_n(0x20)) != nullptr);
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xA0)) == nullptr);
+
+    EXPECT_TRUE(pm.setPeerIdentity(mac_n(0x20), id_n(0xA0)));
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xA0)) != nullptr);
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)1);   // Should still be 1, not 2.
+}
+
+static void set_identity_unknown_mac_returns_false() {
+    BLEPeerManager pm;
+    EXPECT_TRUE(!pm.setPeerIdentity(mac_n(0x99), id_n(0x99)));
+}
+
+static void set_handle_then_lookup_by_handle() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x30), -55);
+    pm.setPeerIdentity(mac_n(0x30), id_n(0xB0));
+    pm.setPeerHandle(id_n(0xB0), 3);
+
+    auto* p = pm.getPeerByHandle(3);
+    EXPECT_TRUE(p != nullptr);
+    EXPECT_EQ(p->mac_address, mac_n(0x30));
+}
+
+static void out_of_range_handle_is_rejected_silently() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x30), -55);
+    pm.setPeerIdentity(mac_n(0x30), id_n(0xB0));
+    // MAX_CONN_HANDLES = 8 — handle 99 must not crash.
+    pm.setPeerHandle(id_n(0xB0), 99);
+    EXPECT_TRUE(pm.getPeerByHandle(99) == nullptr);
+}
+
+static void connection_failures_blacklist_after_threshold() {
+    BLEPeerManager pm;
+    RNS::Utilities::OS::set_fake_time(0.0);
+    pm.addDiscoveredPeer(mac_n(0x40), -50);
+    pm.setPeerIdentity(mac_n(0x40), id_n(0xC0));
+
+    pm.connectionFailed(id_n(0xC0));
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xC0))->state != PeerState::BLACKLISTED);
+    pm.connectionFailed(id_n(0xC0));
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xC0))->state != PeerState::BLACKLISTED);
+    pm.connectionFailed(id_n(0xC0));
+    // Threshold = 3 → now blacklisted.
+    EXPECT_EQ(pm.getPeerByIdentity(id_n(0xC0))->state, PeerState::BLACKLISTED);
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xC0))->blacklisted_until > 0.0);
+
+    RNS::Utilities::OS::clear_fake_time();
+}
+
+static void connection_success_clears_consecutive_failures() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x40), -50);
+    pm.setPeerIdentity(mac_n(0x40), id_n(0xC0));
+
+    pm.connectionFailed(id_n(0xC0));
+    pm.connectionFailed(id_n(0xC0));
+    EXPECT_EQ(pm.getPeerByIdentity(id_n(0xC0))->consecutive_failures, (uint8_t)2);
+
+    pm.connectionSucceeded(id_n(0xC0));
+    EXPECT_EQ(pm.getPeerByIdentity(id_n(0xC0))->consecutive_failures, (uint8_t)0);
+    EXPECT_EQ(pm.getPeerByIdentity(id_n(0xC0))->state, PeerState::CONNECTED);
+}
+
+static void blacklist_blocks_rediscovery_until_expiration() {
+    BLEPeerManager pm;
+    RNS::Utilities::OS::set_fake_time(100.0);
+    pm.addDiscoveredPeer(mac_n(0x50), -50);
+    pm.setPeerIdentity(mac_n(0x50), id_n(0xD0));
+    pm.connectionFailed(id_n(0xD0));
+    pm.connectionFailed(id_n(0xD0));
+    pm.connectionFailed(id_n(0xD0));
+    EXPECT_EQ(pm.getPeerByIdentity(id_n(0xD0))->state, PeerState::BLACKLISTED);
+    double until = pm.getPeerByIdentity(id_n(0xD0))->blacklisted_until;
+    EXPECT_TRUE(until > 100.0);
+
+    // While blacklisted, addDiscoveredPeer for that MAC must return false.
+    EXPECT_TRUE(!pm.addDiscoveredPeer(mac_n(0x50), -40));
+
+    // Advance past expiration; expiration sweep clears blacklist.
+    RNS::Utilities::OS::set_fake_time(until + 1.0);
+    pm.checkBlacklistExpirations();
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xD0))->state != PeerState::BLACKLISTED);
+
+    RNS::Utilities::OS::clear_fake_time();
+}
+
+// Removing a peer must drop its conn_handle entry. If the handle map kept a
+// dangling pointer to the freed slot, getPeerByHandle would return a UAF.
+static void remove_peer_clears_handle_map() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x60), -50);
+    pm.setPeerIdentity(mac_n(0x60), id_n(0xE0));
+    pm.setPeerHandle(id_n(0xE0), 4);
+    EXPECT_TRUE(pm.getPeerByHandle(4) != nullptr);
+
+    pm.removePeer(id_n(0xE0));
+    EXPECT_TRUE(pm.getPeerByIdentity(id_n(0xE0)) == nullptr);
+    EXPECT_TRUE(pm.getPeerByHandle(4) == nullptr);
+}
+
+static void cleanup_ages_out_unconnected_peers() {
+    BLEPeerManager pm;
+    RNS::Utilities::OS::set_fake_time(0.0);
+    pm.addDiscoveredPeer(mac_n(0x70), -50);
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)1);
+
+    RNS::Utilities::OS::set_fake_time(1000.0);   // way past PEER_TIMEOUT (30s)
+    pm.cleanupStalePeers(30.0);
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)0);
+
+    RNS::Utilities::OS::clear_fake_time();
+}
+
+static void mac_pool_full_returns_false_no_crash() {
+    BLEPeerManager pm;
+    // PEERS_POOL_SIZE = 8 (MAC-only). Fill it.
+    for (uint8_t i = 0; i < 8; ++i) {
+        EXPECT_TRUE(pm.addDiscoveredPeer(mac_n(0xA0 + i), -50));
+    }
+    // 9th MAC-only peer must fail without exception.
+    EXPECT_TRUE(!pm.addDiscoveredPeer(mac_n(0xA8), -50));
+    EXPECT_EQ(pm.totalPeerCount(), (size_t)8);
+}
+
+static void should_initiate_lower_mac_wins() {
+    Bytes our_mac;  for (uint8_t b : {0x01,0x02,0x03,0x04,0x05,0x06}) our_mac.append(b);
+    Bytes other;    for (uint8_t b : {0x01,0x02,0x03,0x04,0x05,0x07}) other.append(b);
+    EXPECT_TRUE(BLEPeerManager::shouldInitiateConnection(our_mac, other));
+    EXPECT_TRUE(!BLEPeerManager::shouldInitiateConnection(other, our_mac));
+}
+
+static void update_peer_mac_handles_rotation() {
+    BLEPeerManager pm;
+    pm.addDiscoveredPeer(mac_n(0x80), -50);
+    pm.setPeerIdentity(mac_n(0x80), id_n(0xF0));
+
+    EXPECT_TRUE(pm.updatePeerMac(id_n(0xF0), mac_n(0x90)));
+    auto* p = pm.getPeerByIdentity(id_n(0xF0));
+    EXPECT_TRUE(p != nullptr);
+    EXPECT_EQ(p->mac_address, mac_n(0x90));
+    // Old MAC lookup should not return this peer (it's now identity-keyed and
+    // by_mac lookup goes through the rotated MAC).
+    auto* p_by_new = pm.getPeerByMac(mac_n(0x90));
+    EXPECT_TRUE(p_by_new != nullptr);
+    EXPECT_EQ(p_by_new->mac_address, mac_n(0x90));
+}
+
+int main() {
+    RUN(discover_new_peer_appears_in_count);
+    RUN(rediscover_updates_rssi_no_double_count);
+    RUN(short_mac_rejected);
+    RUN(set_identity_promotes_peer);
+    RUN(set_identity_unknown_mac_returns_false);
+    RUN(set_handle_then_lookup_by_handle);
+    RUN(out_of_range_handle_is_rejected_silently);
+    RUN(connection_failures_blacklist_after_threshold);
+    RUN(connection_success_clears_consecutive_failures);
+    RUN(blacklist_blocks_rediscovery_until_expiration);
+    RUN(remove_peer_clears_handle_map);
+    RUN(cleanup_ages_out_unconnected_peers);
+    RUN(mac_pool_full_returns_false_no_crash);
+    RUN(should_initiate_lower_mac_wins);
+    RUN(update_peer_mac_handles_rotation);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_ble_peer_manager.py
+++ b/tests/native/test_ble_peer_manager.py
@@ -1,0 +1,54 @@
+"""Pytest wrapper for the native BLEPeerManager tests."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_ble_peer_manager.cpp"
+
+
+def _find_cxx():
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_ble_peer_manager(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_ble_peer_manager"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        f"-I{HERE}",
+        f"-I{PYXIS_ROOT / 'lib' / 'ble_interface'}",
+        str(TEST_SOURCE),
+        str(PYXIS_ROOT / "lib" / "ble_interface" / "BLEPeerManager.cpp"),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+    summary = run_result.stdout.strip().splitlines()[-1]
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 12, f"expected at least 12 PeerManager tests, ran {pass_count}"

--- a/tests/native/test_hdlc.cpp
+++ b/tests/native/test_hdlc.cpp
@@ -1,0 +1,201 @@
+// Native HDLC unit tests.
+//
+// Verifies pyxis's HDLC framing matches the Python RNS TCPInterface spec:
+//   FLAG     = 0x7E
+//   ESC      = 0x7D
+//   ESC_MASK = 0x20
+//   In payload: 0x7E -> 0x7D 0x5E   (ESC + (FLAG ^ ESC_MASK))
+//               0x7D -> 0x7D 0x5D   (ESC + (ESC  ^ ESC_MASK))
+//
+// Build: see test_hdlc.py for the g++ invocation.
+
+#include "../../src/HDLC.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using RNS::HDLC;
+using RNS::Bytes;
+
+// ── minimal test framework ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static Bytes make_bytes(std::initializer_list<uint8_t> bs) {
+    Bytes b;
+    for (uint8_t x : bs) b.append(x);
+    return b;
+}
+
+static std::string hex(const Bytes& b) {
+    static const char* digits = "0123456789abcdef";
+    std::string s;
+    s.reserve(b.size() * 2);
+    for (size_t i = 0; i < b.size(); ++i) {
+        s.push_back(digits[b.data()[i] >> 4]);
+        s.push_back(digits[b.data()[i] & 0xF]);
+    }
+    return s;
+}
+
+// ── tests ──
+
+static void empty_payload_escape() {
+    Bytes empty;
+    EXPECT_EQ(HDLC::escape(empty).size(), (size_t)0);
+    EXPECT_EQ(HDLC::unescape(empty).size(), (size_t)0);
+    Bytes framed = HDLC::frame(empty);
+    EXPECT_EQ(framed.size(), (size_t)2);
+    EXPECT_EQ(framed.data()[0], HDLC::FLAG);
+    EXPECT_EQ(framed.data()[1], HDLC::FLAG);
+}
+
+static void plain_payload_passes_through() {
+    Bytes data = make_bytes({0x01, 0x02, 0x03, 0x04});
+    Bytes esc = HDLC::escape(data);
+    EXPECT_EQ(esc, data);
+    Bytes round = HDLC::unescape(esc);
+    EXPECT_EQ(round, data);
+}
+
+static void escape_single_flag() {
+    Bytes data = make_bytes({0x7E});
+    Bytes esc = HDLC::escape(data);
+    EXPECT_EQ(esc.size(), (size_t)2);
+    EXPECT_EQ(esc.data()[0], HDLC::ESC);
+    EXPECT_EQ(esc.data()[1], (uint8_t)(HDLC::FLAG ^ HDLC::ESC_MASK));
+    EXPECT_EQ(hex(esc), std::string("7d5e"));
+}
+
+static void escape_single_esc() {
+    Bytes data = make_bytes({0x7D});
+    Bytes esc = HDLC::escape(data);
+    EXPECT_EQ(esc.size(), (size_t)2);
+    EXPECT_EQ(esc.data()[0], HDLC::ESC);
+    EXPECT_EQ(esc.data()[1], (uint8_t)(HDLC::ESC ^ HDLC::ESC_MASK));
+    EXPECT_EQ(hex(esc), std::string("7d5d"));
+}
+
+static void round_trip_all_byte_values() {
+    Bytes data;
+    for (int i = 0; i < 256; ++i) data.append((uint8_t)i);
+    Bytes esc = HDLC::escape(data);
+    Bytes round = HDLC::unescape(esc);
+    EXPECT_EQ(round, data);
+
+    // Escaped output should contain no bare FLAG byte. (Receiver relies on
+    // this — FLAG only appears at frame boundaries, never inside the payload.)
+    for (size_t i = 0; i < esc.size(); ++i) {
+        EXPECT_TRUE(esc.data()[i] != HDLC::FLAG);
+    }
+}
+
+static void frame_round_trip_simple() {
+    Bytes payload = make_bytes({0x01, 0x7E, 0x02, 0x7D, 0x03});
+    Bytes framed = HDLC::frame(payload);
+    EXPECT_EQ(framed.data()[0], HDLC::FLAG);
+    EXPECT_EQ(framed.data()[framed.size() - 1], HDLC::FLAG);
+
+    Bytes inner;
+    for (size_t i = 1; i < framed.size() - 1; ++i) inner.append(framed.data()[i]);
+    Bytes recovered = HDLC::unescape(inner);
+    EXPECT_EQ(recovered, payload);
+}
+
+static void unescape_truncated_returns_empty() {
+    // ESC at end with no follow byte is an error per HDLC.h; returns empty.
+    Bytes broken = make_bytes({0x01, 0x02, HDLC::ESC});
+    Bytes result = HDLC::unescape(broken);
+    EXPECT_EQ(result.size(), (size_t)0);
+}
+
+static void unescape_non_canonical_escape_byte() {
+    // HDLC.h XORs anything-after-ESC with ESC_MASK regardless of canonical
+    // value. Document the behavior — Python RNS does the same.
+    Bytes broken = make_bytes({HDLC::ESC, 0x00});
+    Bytes result = HDLC::unescape(broken);
+    EXPECT_EQ(result.size(), (size_t)1);
+    EXPECT_EQ(result.data()[0], (uint8_t)0x20);
+}
+
+static void round_trip_long_payload_with_many_escapes() {
+    Bytes data;
+    for (int i = 0; i < 1024; ++i) data.append((uint8_t)((i * 31) ^ 0x55));
+    Bytes esc = HDLC::escape(data);
+    Bytes round = HDLC::unescape(esc);
+    EXPECT_EQ(round, data);
+}
+
+static void escape_worst_case_doubles_size() {
+    Bytes data;
+    for (int i = 0; i < 100; ++i) data.append(HDLC::FLAG);
+    Bytes esc = HDLC::escape(data);
+    EXPECT_EQ(esc.size(), data.size() * 2);
+}
+
+static void golden_vector_matches_python_rns() {
+    // Computed against the spec: payload {0x01, 0x7E, 0x7D, 0x02} →
+    //   0x01, 0x7D, 0x5E, 0x7D, 0x5D, 0x02
+    // Framed: 0x7E ... 0x7E
+    Bytes payload = make_bytes({0x01, 0x7E, 0x7D, 0x02});
+    Bytes esc = HDLC::escape(payload);
+    EXPECT_EQ(hex(esc), std::string("017d5e7d5d02"));
+    Bytes framed = HDLC::frame(payload);
+    EXPECT_EQ(hex(framed), std::string("7e017d5e7d5d027e"));
+}
+
+int main() {
+    RUN(empty_payload_escape);
+    RUN(plain_payload_passes_through);
+    RUN(escape_single_flag);
+    RUN(escape_single_esc);
+    RUN(round_trip_all_byte_values);
+    RUN(frame_round_trip_simple);
+    RUN(unescape_truncated_returns_empty);
+    RUN(unescape_non_canonical_escape_byte);
+    RUN(round_trip_long_payload_with_many_escapes);
+    RUN(escape_worst_case_doubles_size);
+    RUN(golden_vector_matches_python_rns);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_hdlc.py
+++ b/tests/native/test_hdlc.py
@@ -1,0 +1,66 @@
+"""
+Pytest wrapper that compiles + runs the native HDLC C++ tests.
+
+This sidesteps PlatformIO entirely — we compile the C++ test directly with
+the system g++/clang++, using a minimal Bytes shim so HDLC.h works without
+its full microReticulum dependency tree.
+
+The pattern is intentionally generic: any pyxis-unique C++ unit can get a
+sibling test_<thing>.cpp + test_<thing>.py wrapper using the same shim.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+TEST_SOURCE = HERE / "test_hdlc.cpp"
+
+
+def _find_cxx():
+    """Pick a C++ compiler. Prefer clang++ (Mac default), fall back to g++."""
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_hdlc_compiles_and_passes(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_hdlc"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        f"-I{HERE}",          # bytes_shim.h + Bytes.h compatibility header
+        str(TEST_SOURCE),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n"
+        f"--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=10)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+
+    # Sanity: parse the "N passed, M failed" tail line to confirm tests ran.
+    # Catches a regression where main() forgets to RUN() any tests.
+    summary = run_result.stdout.strip().splitlines()[-1]  # "N passed, M failed"
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 10, f"expected at least 10 HDLC tests, ran {pass_count}"

--- a/tests/native/test_ring_buffers.cpp
+++ b/tests/native/test_ring_buffers.cpp
@@ -1,0 +1,302 @@
+// Native unit tests for PCM and encoded SPSC ring buffers.
+//
+// LXST tuning numbers (PCM_RING_FRAMES=50, PREBUFFER_FRAMES=15,
+// ENCODED_RING_SLOTS=128) live in code that consumes these buffers, but
+// correctness of overflow/underrun/wraparound behavior is what makes those
+// numbers meaningful. Tests:
+//
+//   PacketRingBuffer (fixed frame size):
+//     - empty read returns false
+//     - write+read preserves samples bit-exact
+//     - wrong-size write/read rejected
+//     - capacity is maxFrames - 1 (one slot reserved as the empty/full flag)
+//     - full ring rejects writes; partial drain frees a slot
+//     - wraparound across the buffer end preserves data
+//     - availableFrames consistent across operations
+//     - reset clears producer + consumer
+//     - SPSC stress: producer thread + consumer thread, no loss/reorder
+//
+//   EncodedRingBuffer (variable-length slots):
+//     - length=0 rejected
+//     - length > maxBytesPerSlot rejected
+//     - round-trip preserves payload + length
+//     - read with too-small dest advances read cursor and returns false
+//     - wraparound
+
+#include "../../lib/lxst_audio/packet_ring_buffer.h"
+#include "../../lib/lxst_audio/encoded_ring_buffer.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+// ── minimal test framework ──
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+// ── PacketRingBuffer tests ──
+
+static std::vector<int16_t> make_frame(int n, int seed) {
+    std::vector<int16_t> f(n);
+    for (int i = 0; i < n; ++i) f[i] = (int16_t)((i * 31) ^ seed);
+    return f;
+}
+
+static void prb_empty_read_returns_false() {
+    PacketRingBuffer rb(4, 8);
+    int16_t out[8];
+    EXPECT_TRUE(!rb.read(out, 8));
+    EXPECT_EQ(rb.availableFrames(), 0);
+}
+
+static void prb_write_read_round_trip() {
+    PacketRingBuffer rb(4, 8);
+    auto f = make_frame(8, 0xAA);
+    EXPECT_TRUE(rb.write(f.data(), 8));
+    EXPECT_EQ(rb.availableFrames(), 1);
+
+    int16_t out[8] = {0};
+    EXPECT_TRUE(rb.read(out, 8));
+    for (int i = 0; i < 8; ++i) EXPECT_EQ(out[i], f[i]);
+    EXPECT_EQ(rb.availableFrames(), 0);
+}
+
+static void prb_wrong_size_rejected() {
+    PacketRingBuffer rb(4, 8);
+    auto f = make_frame(8, 0x55);
+    int16_t out[8];
+    EXPECT_TRUE(!rb.write(f.data(), 7));   // wrong count
+    EXPECT_TRUE(!rb.write(f.data(), 9));
+    rb.write(f.data(), 8);
+    EXPECT_TRUE(!rb.read(out, 7));
+    EXPECT_TRUE(!rb.read(out, 9));
+}
+
+static void prb_capacity_is_max_minus_one() {
+    // SPSC with one-slot-reserved-for-empty: capacity is maxFrames - 1.
+    const int N = 4;
+    PacketRingBuffer rb(N, 4);
+    auto f = make_frame(4, 0x11);
+    int wrote = 0;
+    while (rb.write(f.data(), 4)) ++wrote;
+    EXPECT_EQ(wrote, N - 1);              // 3 writes succeed before full
+    EXPECT_EQ(rb.availableFrames(), N - 1);
+}
+
+static void prb_partial_drain_frees_slots() {
+    PacketRingBuffer rb(4, 4);
+    auto f = make_frame(4, 0x22);
+    while (rb.write(f.data(), 4)) {}
+    EXPECT_EQ(rb.availableFrames(), 3);
+
+    int16_t out[4];
+    EXPECT_TRUE(rb.read(out, 4));
+    EXPECT_EQ(rb.availableFrames(), 2);
+    EXPECT_TRUE(rb.write(f.data(), 4));   // slot freed up
+    EXPECT_EQ(rb.availableFrames(), 3);
+}
+
+static void prb_wraparound_preserves_data() {
+    PacketRingBuffer rb(4, 4);
+    int16_t out[4];
+    // Cycle 10 distinct frames through; if wraparound is broken, data
+    // corrupts at the buffer-end boundary.
+    for (int i = 0; i < 10; ++i) {
+        auto f = make_frame(4, 0x40 + i);
+        EXPECT_TRUE(rb.write(f.data(), 4));
+        EXPECT_TRUE(rb.read(out, 4));
+        for (int j = 0; j < 4; ++j) EXPECT_EQ(out[j], f[j]);
+    }
+}
+
+static void prb_reset_clears_state() {
+    PacketRingBuffer rb(4, 4);
+    auto f = make_frame(4, 0x33);
+    rb.write(f.data(), 4);
+    rb.write(f.data(), 4);
+    EXPECT_EQ(rb.availableFrames(), 2);
+    rb.reset();
+    EXPECT_EQ(rb.availableFrames(), 0);
+}
+
+// SPSC stress: separate producer and consumer threads exchange a million
+// frames. Verifies acquire/release ordering on writeIndex_/readIndex_ keeps
+// data intact (no torn frame, no reordering, no loss when sized big enough).
+static void prb_spsc_threaded_stress() {
+    const int FRAMES = 8;
+    PacketRingBuffer rb(64, FRAMES);
+    const int TOTAL = 100000;
+    std::atomic<bool> producer_done{false};
+
+    std::thread producer([&]{
+        for (int i = 0; i < TOTAL; ++i) {
+            std::vector<int16_t> f(FRAMES, (int16_t)(i & 0x7FFF));
+            while (!rb.write(f.data(), FRAMES)) {
+                std::this_thread::yield();
+            }
+        }
+        producer_done.store(true, std::memory_order_release);
+    });
+
+    int received = 0;
+    int failures = 0;
+    while (received < TOTAL) {
+        int16_t out[FRAMES];
+        if (rb.read(out, FRAMES)) {
+            int16_t expected = (int16_t)(received & 0x7FFF);
+            for (int j = 0; j < FRAMES; ++j) {
+                if (out[j] != expected) ++failures;
+            }
+            ++received;
+        } else {
+            std::this_thread::yield();
+            if (producer_done.load(std::memory_order_acquire) &&
+                rb.availableFrames() == 0) break;
+        }
+    }
+    producer.join();
+
+    EXPECT_EQ(received, TOTAL);
+    EXPECT_EQ(failures, 0);
+}
+
+// ── EncodedRingBuffer tests ──
+
+static void erb_zero_length_rejected() {
+    EncodedRingBuffer eb(4, 64);
+    uint8_t data[1] = {0xAA};
+    EXPECT_TRUE(!eb.write(data, 0));
+    EXPECT_TRUE(!eb.write(data, -1));
+}
+
+static void erb_oversize_rejected() {
+    EncodedRingBuffer eb(4, 16);
+    uint8_t big[32]; std::memset(big, 0xCC, sizeof(big));
+    EXPECT_TRUE(!eb.write(big, 17));
+    EXPECT_TRUE(eb.write(big, 16));
+}
+
+static void erb_round_trip_variable_lengths() {
+    EncodedRingBuffer eb(8, 64);
+    std::vector<std::vector<uint8_t>> sent;
+
+    for (int i = 0; i < 5; ++i) {
+        std::vector<uint8_t> v;
+        int len = 1 + i * 7;
+        for (int j = 0; j < len; ++j) v.push_back((uint8_t)((j ^ i) * 31));
+        sent.push_back(v);
+        EXPECT_TRUE(eb.write(v.data(), len));
+    }
+    EXPECT_EQ(eb.availableSlots(), 5);
+
+    for (size_t i = 0; i < sent.size(); ++i) {
+        uint8_t out[128] = {0};
+        int actual = -1;
+        EXPECT_TRUE(eb.read(out, 128, &actual));
+        EXPECT_EQ(actual, (int)sent[i].size());
+        for (int j = 0; j < actual; ++j) EXPECT_EQ(out[j], sent[i][j]);
+    }
+    EXPECT_EQ(eb.availableSlots(), 0);
+}
+
+static void erb_too_small_dest_advances_cursor() {
+    // Per impl: if maxLength < stored length, read advances readIndex and
+    // returns false with actualLength=0. This is intentional drop-on-truncation.
+    EncodedRingBuffer eb(4, 64);
+    uint8_t big[40]; std::memset(big, 0x88, sizeof(big));
+    eb.write(big, 40);
+    EXPECT_EQ(eb.availableSlots(), 1);
+
+    uint8_t small[10];
+    int actual = -1;
+    EXPECT_TRUE(!eb.read(small, 10, &actual));
+    EXPECT_EQ(actual, 0);
+    EXPECT_EQ(eb.availableSlots(), 0);   // cursor advanced, slot consumed
+}
+
+static void erb_wraparound() {
+    EncodedRingBuffer eb(4, 8);
+    uint8_t buf[8];
+    for (int i = 0; i < 12; ++i) {
+        for (int j = 0; j < 8; ++j) buf[j] = (uint8_t)((i + j) * 13);
+        EXPECT_TRUE(eb.write(buf, 8));
+        uint8_t out[8] = {0};
+        int actual = -1;
+        EXPECT_TRUE(eb.read(out, 8, &actual));
+        EXPECT_EQ(actual, 8);
+        for (int j = 0; j < 8; ++j) EXPECT_EQ(out[j], buf[j]);
+    }
+}
+
+static void erb_full_then_drain() {
+    EncodedRingBuffer eb(4, 8);
+    uint8_t data[4] = {1,2,3,4};
+    int wrote = 0;
+    while (eb.write(data, 4)) ++wrote;
+    EXPECT_EQ(wrote, 3);                  // capacity = N - 1
+
+    int actual;
+    uint8_t out[8];
+    while (eb.read(out, 8, &actual)) {}
+    EXPECT_EQ(eb.availableSlots(), 0);
+}
+
+int main() {
+    RUN(prb_empty_read_returns_false);
+    RUN(prb_write_read_round_trip);
+    RUN(prb_wrong_size_rejected);
+    RUN(prb_capacity_is_max_minus_one);
+    RUN(prb_partial_drain_frees_slots);
+    RUN(prb_wraparound_preserves_data);
+    RUN(prb_reset_clears_state);
+    RUN(prb_spsc_threaded_stress);
+
+    RUN(erb_zero_length_rejected);
+    RUN(erb_oversize_rejected);
+    RUN(erb_round_trip_variable_lengths);
+    RUN(erb_too_small_dest_advances_cursor);
+    RUN(erb_wraparound);
+    RUN(erb_full_then_drain);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_ring_buffers.cpp
+++ b/tests/native/test_ring_buffers.cpp
@@ -204,6 +204,9 @@ static void prb_spsc_threaded_stress() {
 static void erb_zero_length_rejected() {
     EncodedRingBuffer eb(4, 64);
     uint8_t data[1] = {0xAA};
+    // EncodedRingBuffer::write() takes `int length` (signed) and rejects
+    // `length <= 0`. Both 0 and -1 hit the same branch — we exercise both
+    // to lock that contract in case the param ever migrates to size_t.
     EXPECT_TRUE(!eb.write(data, 0));
     EXPECT_TRUE(!eb.write(data, -1));
 }

--- a/tests/native/test_ring_buffers.py
+++ b/tests/native/test_ring_buffers.py
@@ -1,0 +1,56 @@
+"""Pytest wrapper for native ring buffer tests (PCM + encoded SPSC)."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_ring_buffers.cpp"
+
+
+def _find_cxx():
+    for cmd in ("clang++", "g++"):
+        if shutil.which(cmd):
+            return cmd
+    pytest.skip("no C++ compiler found")
+
+
+def test_ring_buffers(tmp_path):
+    cxx = _find_cxx()
+    binary = tmp_path / "test_ring_buffers"
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Wno-unused-parameter",
+        "-pthread",
+        f"-I{HERE}",
+        f"-I{PYXIS_ROOT / 'lib' / 'lxst_audio'}",
+        str(TEST_SOURCE),
+        str(PYXIS_ROOT / "lib" / "lxst_audio" / "packet_ring_buffer.cpp"),
+        str(PYXIS_ROOT / "lib" / "lxst_audio" / "encoded_ring_buffer.cpp"),
+        "-o", str(binary),
+    ]
+    compile_result = subprocess.run(cmd, capture_output=True, text=True)
+    assert compile_result.returncode == 0, (
+        f"compilation failed:\n--- cmd ---\n{' '.join(cmd)}\n"
+        f"--- stderr ---\n{compile_result.stderr}"
+    )
+
+    run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60)
+    assert run_result.returncode == 0, (
+        f"tests failed:\n--- stdout ---\n{run_result.stdout}\n"
+        f"--- stderr ---\n{run_result.stderr}"
+    )
+    summary = run_result.stdout.strip().splitlines()[-1]
+    parts = summary.split()
+    pass_count = int(parts[0])
+    fail_count = int(parts[2])
+    assert fail_count == 0, run_result.stdout
+    assert pass_count >= 13, f"expected at least 13 ring buffer tests, ran {pass_count}"


### PR DESCRIPTION
## Summary

- **`tests/build_scripts/test_patch_nimble.py`** — 7 tests on `patch_nimble.py` (idempotency, drift detection, missing-file skip, partial-application safety, subprocess-runnability)
- **`tests/native/`** — 6 native C++ test units, each compiled standalone by `clang++`/`g++` against pyxis source + minimal `Bytes`/`Log`/`Utilities/OS` shims:
  - `test_hdlc` (11 cases) — HDLC escape/unescape/frame round-trip + golden vector against Python RNS
  - `test_ble_fragmenter` (10 cases) — BLEFragmenter ↔ BLEReassembler round-trip including out-of-order, duplicate, dropped + fake-clock timeout, per-peer isolation, MTU change
  - `test_ble_peer_manager` (15 cases) — connection-map state machine: discovery, identity promotion, blacklist, handle map cleanup (the area greptile flagged for TOCTOU/UAF in #13), MAC rotation, pool exhaustion
  - `test_ble_operation_queue` (13 cases) — GATT op queue FIFO + busy-state + timeout + clearForConnection + builder
  - `test_ring_buffers` (14 cases) — PCM + encoded SPSC ring buffers, including a 100k-frame multithreaded producer/consumer stress
  - `test_audio_filters` (9 cases) — VoiceFilterChain frequency response, peak limiting, multichannel
- **`tests/README.md`** — pattern + invocation docs.
- **`.github/workflows/test.yml`** — CI runs the pyxis pytest suite + the clean-passing microReticulum `native17` unit suites on push/PR to main.

13 pytest tests, ~72 underlying C++ assertions, 3.4s total. One command: `/usr/bin/python3 -m pytest tests/build_scripts tests/native -v` (system Python 3.9, not Homebrew Python — only the former has pytest preinstalled).

## Bug surfaced

`lib/lxst_audio/audio_filters.cpp::VoiceFilterChain::applyHighPass` algebraically degenerates to `y[n] = α * x[n]` (constant gain, not a high-pass). Identical formula in upstream `LXST-kt/native_audio_filters.cpp`. Filed as [LXST-kt#13](https://github.com/torlando-tech/LXST-kt/issues/13). The new `dc_offset_attenuated_by_hpf` test asserts current (broken) behavior with a comment pointing at the issue — to be tightened to `< 0.01` once the upstream fix lands.

## Test plan

- [x] `pytest tests/build_scripts tests/native -v` → 13 passed in 3.4s locally
- [x] All 6 C++ binaries compile clean under `clang++ -std=c++17 -Wall -Wextra`
- [x] `tests/native/Bytes.h` shim has only the surface area pyxis sources actually use; pattern is reusable for future units
- [ ] Verify CI workflow runs cleanly on first push (will check after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)