### PR TITLE
fix: correct conversation timestamps (clock race) + ~2x faster message load

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -72,10 +72,17 @@ lib_deps =
     ; and the bz2 layer + decompress-on-receive in Resource::assemble(). The
     ; far-diverged 0.3.0 fork's Resource/Transport/Identity work is subsumed by
     ; upstream's reimplementation. Bump in lockstep with microLXMF below.
-    https://github.com/torlando-tech/microReticulum.git#2f21feef9ff30ebde86370b56335813232a0d3e1
+    ; cb71ace: OS::ltime() now uses the monotonic 64-bit esp_timer instead of a
+    ; racy 32-bit millis() rollover counter (static low32/high32 raced across
+    ; FreeRTOS tasks, inflating OS::time() by N*49.7 days — garbage convo
+    ; timestamps, e.g. "Future"/"49w ago"/year-2046 now).
+    https://github.com/torlando-tech/microReticulum.git#cb71aceb8a9c58444521d5ce24ea2db10191d92d
     ; microLXMF: chore/microreticulum-0.4.1-layout — includes namespaced to
     ; <microReticulum/...> for the 0.4.x src/microReticulum/ layout.
-    https://github.com/torlando-tech/microLXMF.git#33760d0d38d81a9fc3bc07693ffeb7dd678a414c
+    ; 3cdde79: faster load_message_metadata — single LittleFS open (read_file
+    ; returns 0 on miss, no separate file_exists probe) + JSON field filter that
+    ; skips the large "packed" blob. ~2x quicker conversation load.
+    https://github.com/torlando-tech/microLXMF.git#3cdde79172af915c4e330be36ff9775550e57fa5
     lvgl/lvgl@^8.3.11
     bblanchon/ArduinoJson@^7.4.2
     hideakitai/MsgPack@^0.4.2


### PR DESCRIPTION
## What
Fixes two issues reported on the T-Deck:
1. **Conversation timestamps were wrong** — showed "Future", "49w ago", a year-2046 clock.
2. **Slow conversation load** — entering a chat took ~1.3s for 10 messages.

## Root causes + fixes

### Timestamp (microReticulum `cb71ace`)
`OS::ltime()` tracked 32-bit `millis()` rollover with a `static low32/high32` pair. That read-modify-write is **not thread-safe**: concurrent `ltime()` calls from the transport/UI/BLE FreeRTOS tasks (dual-core) raced on `if (new_low32 < low32) high32++`, spuriously incrementing `high32`. Each spurious increment adds 49.7 days to `OS::time()`. On-device, `high32` reached ~145 within minutes → `OS::time()` inflated by ~19.7 years (year 2046), so the relative-time formatter produced garbage.

Fix: use the monotonic 64-bit `esp_timer_get_time()` on ESP32 (race-free, no 49-day rollover). Non-ESP32 Arduino keeps the `millis()` fallback.

**Verified on device:** clock holds at the correct epoch (2026); message diffs are sane (≈28h / ≈4.7h ago) instead of climbing to 2046.

### Load speed (microLXMF `3cdde79`)
`load_message_metadata()` did a `file_exists()` probe **and** a `read_file()` — a redundant LittleFS open per message (on top of `read_file()`'s own `size()` + `readFile()`), then parsed the whole JSON including the large `"packed"` hex blob. Fix: read the hot file directly (`read_file` returns 0 on a miss) and parse with a field filter that skips `"packed"`. **~2x faster** (~1330ms → ~670ms for 10 messages, measured on device).

## Testing
- On-device: timestamps verified correct + stable across runtime; load time halved.
- Clean re-fetch of both pinned deps builds green; fetched sources contain both fixes.

## Notes
- Both fixes live in the pinned forks (microReticulum `pyxis-fixes-on-0.4.1`, microLXMF `chore/microreticulum-0.4.1-layout`); this PR bumps the pins.
- A separately-reported **screen-wake latency** is a distinct display/loop concern (not the millis-based path this change touches) and is being investigated separately.
