### PR TITLE
fix(store): raise microStore value cap so larger path entries persist

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -189,6 +189,14 @@ build_flags =
     ; caused FileStore::put → flush_buffer() to fail under sustained
     ; announce writes (~3/sec), surfacing as path-table-add error spam.
     -DUSTORE_USE_LITTLEFS
+    ; Raise the microStore value cap from its 1024-byte default. Reticulum path-
+    ; table entries for destinations with larger announce app_data run 1025-1033
+    ; bytes; at 1024 they hit "[ustore] put: failed due to excessive data length"
+    ; and never enter the path table ("Failed to add destination ... to path
+    ; table!"), so those peers are unreachable even though the TCP link is up.
+    ; This sizes both the put limit and TypedStore's read buffer (it reads into a
+    ; vector of USTORE_MAX_VALUE_LEN), so reads won't truncate either.
+    -DUSTORE_MAX_VALUE_LEN=2048
     -DUSE_NIMBLE
     -DCONFIG_BT_NIMBLE_MEM_ALLOC_MODE_EXTERNAL=1
     -Os


### PR DESCRIPTION
## What
The device looked like it was "failing to connect to the TCP server" — but the TCP link was actually up the whole time.

## Root cause
The link works: the device connects and **receives the server's Reticulum announces**. The failure is downstream — path-table entries for destinations with larger announce app_data are 1025–1033 bytes, over microStore's `USTORE_MAX_VALUE_LEN` default of **1024**:

```
[ustore] put: failed due to excessive data length: 1025
[ERR] Failed to add destination ... to path table!
```

So those destinations never enter the path table and are unreachable — which presents to the user as "not connected." The on-device smoke test's destinations were small enough to fit; a real network has larger ones.

## Fix
`-DUSTORE_MAX_VALUE_LEN=2048`. The macro is `#ifndef`-guarded, so the build flag overrides the 1024 default. It bounds **both** the put limit **and** `TypedStore`'s read buffer (it reads into a vector sized to `USTORE_MAX_VALUE_LEN`), so the larger values store and read back without truncation.

## Testing
On-device after the fix: **zero** `excessive data length` / `Failed to add destination` errors (was many), and path-table puts succeed. RAM +~3KB (larger transient read buffer) — acceptable.

Pre-existing limit (from the graft's microStore config), surfaced by a real network with bigger announces than the smoke test exercised.
