### PR TITLE
fix: announce/sync interval units+defaults, live Settings clock, OTA repair

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -876,8 +876,8 @@ void SettingsScreen::load_settings() {
     _settings.brightness = prefs.getUChar(KEY_BRIGHTNESS, 180);
     _settings.keyboard_light = prefs.getBool(KEY_KB_LIGHT, false);
     _settings.screen_timeout = prefs.getUShort(KEY_TIMEOUT, 60);
-    _settings.announce_interval = prefs.getUInt(KEY_ANNOUNCE_INT, 60);
-    _settings.sync_interval = prefs.getUInt(KEY_SYNC_INT, 3600);  // Default 60 minutes
+    _settings.announce_interval = prefs.getUInt(KEY_ANNOUNCE_INT, 3600);   // Default 3600s = 1 hour
+    _settings.sync_interval = prefs.getUInt(KEY_SYNC_INT, 14400);  // Default 14400s = 4 hours
     _settings.gps_time_sync = prefs.getBool(KEY_GPS_SYNC, true);
 
     // Notification settings
@@ -1018,7 +1018,7 @@ void SettingsScreen::update_ui_from_settings() {
         lv_textarea_set_text(_ta_announce_interval, String(_settings.announce_interval / 60).c_str());  // stored seconds -> shown minutes
     }
     if (_ta_sync_interval) {
-        // Display in minutes (stored in seconds)
+        // Display in hours (stored in seconds)
         lv_textarea_set_text(_ta_sync_interval, String(_settings.sync_interval / 3600).c_str());  // stored seconds -> shown hours
     }
     if (_switch_gps_sync) {
@@ -1157,7 +1157,7 @@ void SettingsScreen::update_settings_from_ui() {
         _settings.announce_interval = String(lv_textarea_get_text(_ta_announce_interval)).toInt() * 60;  // minutes -> seconds
     }
     if (_ta_sync_interval) {
-        // UI shows minutes, store as seconds
+        // UI shows hours, store as seconds
         _settings.sync_interval = String(lv_textarea_get_text(_ta_sync_interval)).toInt() * 3600;  // hours -> seconds
     }
     if (_switch_gps_sync) {

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -771,7 +771,7 @@ void SettingsScreen::create_advanced_section(lv_obj_t* parent) {
     lv_obj_clear_flag(announce_row, LV_OBJ_FLAG_SCROLLABLE);
 
     lv_obj_t* announce_label = lv_label_create(announce_row);
-    lv_label_set_text(announce_label, "Announce Interval:");
+    lv_label_set_text(announce_label, "Announce Interval (min):");
     lv_obj_align(announce_label, LV_ALIGN_LEFT_MID, 0, 0);
     lv_obj_set_style_text_color(announce_label, Theme::textTertiary(), 0);
     lv_obj_set_style_text_font(announce_label, &lv_font_montserrat_14, 0);
@@ -813,7 +813,7 @@ void SettingsScreen::create_advanced_section(lv_obj_t* parent) {
     lv_obj_clear_flag(sync_row, LV_OBJ_FLAG_SCROLLABLE);
 
     lv_obj_t* sync_label = lv_label_create(sync_row);
-    lv_label_set_text(sync_label, "Prop Sync Interval:");
+    lv_label_set_text(sync_label, "Prop Sync Interval (hrs):");
     lv_obj_align(sync_label, LV_ALIGN_LEFT_MID, 0, 0);
     lv_obj_set_style_text_color(sync_label, Theme::textTertiary(), 0);
     lv_obj_set_style_text_font(sync_label, &lv_font_montserrat_14, 0);
@@ -1015,11 +1015,11 @@ void SettingsScreen::update_ui_from_settings() {
         lv_dropdown_set_selected(_dropdown_timeout, idx);
     }
     if (_ta_announce_interval) {
-        lv_textarea_set_text(_ta_announce_interval, String(_settings.announce_interval).c_str());
+        lv_textarea_set_text(_ta_announce_interval, String(_settings.announce_interval / 60).c_str());  // stored seconds -> shown minutes
     }
     if (_ta_sync_interval) {
         // Display in minutes (stored in seconds)
-        lv_textarea_set_text(_ta_sync_interval, String(_settings.sync_interval / 60).c_str());
+        lv_textarea_set_text(_ta_sync_interval, String(_settings.sync_interval / 3600).c_str());  // stored seconds -> shown hours
     }
     if (_switch_gps_sync) {
         if (_settings.gps_time_sync) {
@@ -1154,11 +1154,11 @@ void SettingsScreen::update_settings_from_ui() {
         }
     }
     if (_ta_announce_interval) {
-        _settings.announce_interval = String(lv_textarea_get_text(_ta_announce_interval)).toInt();
+        _settings.announce_interval = String(lv_textarea_get_text(_ta_announce_interval)).toInt() * 60;  // minutes -> seconds
     }
     if (_ta_sync_interval) {
         // UI shows minutes, store as seconds
-        _settings.sync_interval = String(lv_textarea_get_text(_ta_sync_interval)).toInt() * 60;
+        _settings.sync_interval = String(lv_textarea_get_text(_ta_sync_interval)).toInt() * 3600;  // hours -> seconds
     }
     if (_switch_gps_sync) {
         _settings.gps_time_sync = lv_obj_has_state(_switch_gps_sync, LV_STATE_CHECKED);
@@ -1319,6 +1319,16 @@ void SettingsScreen::set_gps(TinyGPSPlus* gps) {
 void SettingsScreen::refresh() {
     update_gps_display();
     update_system_info();
+}
+
+void SettingsScreen::tick() {
+    // Called every main-loop pass while Settings is the active screen. Throttled to
+    // ~1s, it refreshes the live readouts so the clock (and GPS/system info) updates
+    // on screen instead of being a static snapshot from when the screen was opened.
+    uint32_t now = millis();
+    if (now - _last_tick_ms < 1000) return;
+    _last_tick_ms = now;
+    refresh();
 }
 
 void SettingsScreen::set_back_callback(BackCallback callback) {

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
@@ -52,8 +52,8 @@ struct AppSettings {
     bool ble_enabled;         // Enable BLE mesh interface
 
     // Advanced
-    uint32_t announce_interval;  // seconds
-    uint32_t sync_interval;      // seconds (0 = disabled, default 3600 = hourly)
+    uint32_t announce_interval;  // seconds (UI shows minutes; default 3600 = 1h)
+    uint32_t sync_interval;      // seconds (0 = disabled; UI shows hours; default 14400 = 4h)
     bool gps_time_sync;
 
     // Propagation
@@ -80,8 +80,8 @@ struct AppSettings {
         lora_power(17),
         auto_enabled(false),
         ble_enabled(false),
-        announce_interval(60),
-        sync_interval(3600),
+        announce_interval(3600),
+        sync_interval(14400),
         gps_time_sync(true),
         prop_auto_select(true),
         prop_selected_node(""),
@@ -185,6 +185,7 @@ public:
      * Refresh GPS and system info displays
      */
     void refresh();
+    void tick();  // periodic update while the screen is shown (ticks clock/GPS/system readouts)
 
     /**
      * Set callback for back button
@@ -261,6 +262,7 @@ private:
     lv_obj_t* _label_gps_alt;
     lv_obj_t* _label_gps_hdop;
     lv_obj_t* _label_gps_time;
+    uint32_t _last_tick_ms = 0;  // throttle for tick()
 
     // System info labels (read-only)
     lv_obj_t* _label_identity_hash;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -341,6 +341,9 @@ void UIManager::update() {
     if (_current_screen == SCREEN_ANNOUNCES && _announce_list_screen) {
         _announce_list_screen->tick();
     }
+    if (_current_screen == SCREEN_SETTINGS && _settings_screen) {
+        _settings_screen->tick();  // keep the live clock / GPS / system readouts ticking
+    }
     LVGL_LOCK();
     // Process outbound LXMF messages
     _router.process_outbound();

--- a/patch_nimble.py
+++ b/patch_nimble.py
@@ -23,7 +23,11 @@ import os
 
 NIMBLE_BASE = os.path.join(
     env.get("PROJECT_DIR", "."),
-    ".pio", "libdeps", "tdeck", "NimBLE-Arduino", "src"
+    # Per-environment libdeps tree (each env gets its own). Was hardcoded to
+    # "tdeck", so building any OTHER env (e.g. tdeck-ota) patched the wrong tree
+    # and left nimble_host_reset_reason undefined -> link error. Match the sibling
+    # pre-scripts (patch_msgpack/filestore/littlefs, sync_file_libdeps).
+    ".pio", "libdeps", env.get("PIOENV", "tdeck"), "NimBLE-Arduino", "src"
 )
 
 def apply_patch(filepath, old, new, label):

--- a/platformio.ini
+++ b/platformio.ini
@@ -226,7 +226,14 @@ build_flags =
 
 ; OTA flashing environment (wireless upload via ArduinoOTA)
 ; Usage: pio run -e tdeck-ota -t upload
+;   The old upload_command pointed at tools/espota.py (which does not exist in the
+;   repo); use PlatformIO's built-in espota uploader instead.
+;   NOTE: espota resolves the host via gethostbyname, which on macOS does NOT do
+;   mDNS, so the .local default may fail to resolve -- if upload can't find the
+;   host, pass the device's LAN IP explicitly:
+;     pio run -e tdeck-ota -t upload --upload-port <device-ip>
 [env:tdeck-ota]
 extends = env:tdeck
-upload_protocol = custom
-upload_command = "$PYTHONEXE" tools/espota.py -i pyxis-tdeck.local -p 3232 -f $SOURCE
+upload_protocol = espota
+upload_port = pyxis-tdeck.local
+upload_flags = --port=3232

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -539,7 +539,7 @@ void load_app_settings() {
 
     // Advanced
     app_settings.announce_interval = prefs.getULong("announce", 3600);
-    app_settings.sync_interval = prefs.getULong("sync_int", 3600);  // Default 60 minutes
+    app_settings.sync_interval = prefs.getULong("sync_int", 14400);  // Default 14400s = 4 hours
     app_settings.gps_time_sync = prefs.getBool("gps_sync", true);
 
     // Propagation
@@ -647,20 +647,26 @@ void on_wifi_connected() {
     }
 
     {
+        // NOTE: do NOT call WiFi.setSleep(false) here. The ESP32 REQUIRES WiFi
+        // modem-sleep ENABLED whenever WiFi + Bluetooth coexist (shared 2.4GHz
+        // radio); disabling it aborts at runtime ("Should enable WiFi modem sleep
+        // when both WiFi and Bluetooth are enabled"). For OTA RF headroom, stop BLE
+        // asynchronously from loop() after Update begins instead.
+
         // Initialize ArduinoOTA for wireless flashing
         ArduinoOTA.setHostname("pyxis-tdeck");
         ArduinoOTA.onStart([]() {
-            INFO("OTA: Update starting — suspending BLE for clean WiFi");
-            // Pause BLE to free the shared 2.4GHz radio for WiFi transfer
-            if (ble_interface_impl) {
-                ble_interface_impl->stop();
-                INFO("OTA: BLE stopped");
-            }
-            // Disconnect TCP to reduce WiFi contention
-            if (tcp_interface_impl) {
-                tcp_interface_impl->stop();
-                INFO("OTA: TCP stopped");
-            }
+            // MUST be non-blocking. ArduinoOTA calls onStart BEFORE it connects back
+            // to the host, so anything slow here delays the connect-back past espota's
+            // ~10s accept window and the transfer never starts ("No response from
+            // device"). The old code called TCPClientInterface::stop() here, which
+            // blocks up to 30s draining an in-flight connect -- that was the bug (and
+            // its un-fed WDT also tripped reboots). Just log + feed the WDT; BLE/TCP
+            // stay up during the transfer (some RF contention, but it completes). If
+            // the transfer proves flaky, tear them down asynchronously from loop()
+            // after Update has begun, never synchronously in this callback.
+            INFO("OTA: Update starting");
+            esp_task_wdt_reset();
         });
         ArduinoOTA.onEnd([]() { INFO("OTA: Update complete, rebooting"); });
         ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
@@ -2435,7 +2441,7 @@ void loop() {
             if (tcp_online) {
                 router->request_messages_from_propagation_node();
                 last_sync = now;
-                INFO("Periodic propagation sync (interval: " + std::to_string(app_settings.sync_interval / 60) + " min)");
+                INFO("Periodic propagation sync (interval: " + std::to_string(app_settings.sync_interval / 3600) + " hours)");
             }
         }
     }


### PR DESCRIPTION
## Settings / clock (user-reported)
- **Announce interval** — default raised to **1 h** (was 60 s); the field is now in **minutes** (`Announce Interval (min):`, populate `/60`, read `*60`).
- **Prop sync interval** — default raised to **4 h** (was 1 h); the field is now in **hours** (`Prop Sync Interval (hrs):`, populate `/3600`, read `*3600`).
- **Live Settings clock** — `SettingsScreen::tick()` (throttled ~1 s) is hooked into `UIManager::update()` exactly like the announce-list tick, so the Time line (and GPS/system readouts) refresh while the screen is open instead of being a static snapshot from when it was opened.

## OTA repair — was broken two independent ways (diagnosed via a parallel workflow)
- **Build:** `patch_nimble.py` hardcoded the `tdeck` libdeps path, so any *other* env (each gets its own `.pio/libdeps/<env>` tree) never received the NimBLE patch that **defines** `nimble_host_reset_reason` → `undefined reference` link error for `tdeck-ota`. Made it env-aware (`env.get("PIOENV", …)`, matching the four sibling pre-scripts). Bonus: also restores 3 NimBLE *stability* patches that were silently missing from OTA builds.
- **Runtime:** `ArduinoOTA` `onStart` synchronously called `TCPClientInterface::stop()` (blocks up to **30 s**), overrunning espota's ~10 s connect-back window → `No response from device` (phase 2), and the un-fed watchdog during that block tripped reboots. Made `onStart` non-blocking.
- **Config:** `[env:tdeck-ota]` `upload_command` invoked a `tools/espota.py` that doesn't exist → switched to `upload_protocol = espota`.
- Documented inline that `WiFi.setSleep(false)` must **not** be used here — the ESP32 requires WiFi modem-sleep whenever WiFi + BT coexist, and disabling it aborts at boot.

## Verification (on device)
- `pio run -e tdeck-ota` links clean (previously `undefined reference to nimble_host_reset_reason`).
- **OTA over WiFi completes 100 % (`Result: OK`) and the device reboots clean** — wireless flashing works again.
- The whole batch was USB-deployed; boots clean (0 aborts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWZuYkHBRqNb6BZHV8sTG5
