### PR TITLE
chore(build): unify pre-script libdeps paths on a shared helper + OTA log accuracy

### DIFF
--- a/_build_helpers.py
+++ b/_build_helpers.py
@@ -1,0 +1,19 @@
+"""Shared helpers for the PlatformIO pre-build scripts (patch_*, sync_file_libdeps).
+
+Centralizes the per-environment libdeps path so it is computed exactly ONE way.
+Each PlatformIO environment gets its OWN .pio/libdeps/<PIOENV> tree, so this path
+MUST be resolved per-environment. Hardcoding the env component (e.g. "tdeck")
+silently misdirects a patch when building any OTHER env -- that is exactly how the
+`nimble_host_reset_reason` undefined-reference link error appeared in tdeck-ota.
+Always go through env_libdeps_dir(); never re-hand-roll the path with a literal env.
+"""
+import os
+
+
+def env_libdeps_dir(env, *parts):
+    """Path inside THIS environment's libdeps tree: .pio/libdeps/<PIOENV>/<parts...>."""
+    return os.path.join(
+        env.get("PROJECT_DIR", "."),
+        ".pio", "libdeps", env.get("PIOENV", "tdeck"),
+        *parts,
+    )

--- a/_build_helpers.py
+++ b/_build_helpers.py
@@ -5,7 +5,7 @@ Each PlatformIO environment gets its OWN .pio/libdeps/<PIOENV> tree, so this pat
 MUST be resolved per-environment. Hardcoding the env component (e.g. "tdeck")
 silently misdirects a patch when building any OTHER env -- that is exactly how the
 `nimble_host_reset_reason` undefined-reference link error appeared in tdeck-ota.
-Always go through env_libdeps_dir(); never re-hand-roll the path with a literal env.
+Always go through env_libdeps_dir() instead of re-deriving this path in each script.
 """
 import os
 
@@ -14,6 +14,8 @@ def env_libdeps_dir(env, *parts):
     """Path inside THIS environment's libdeps tree: .pio/libdeps/<PIOENV>/<parts...>."""
     return os.path.join(
         env.get("PROJECT_DIR", "."),
+        # "tdeck" is only a never-hit fallback (PlatformIO always injects PIOENV);
+        # it is NOT the per-script hardcoding the module docstring warns against.
         ".pio", "libdeps", env.get("PIOENV", "tdeck"),
         *parts,
     )

--- a/patch_filestore.py
+++ b/patch_filestore.py
@@ -23,12 +23,11 @@ Three purposes:
    patch pending the upstream fix landing.
 """
 Import("env")
-import os
+import os, sys
+sys.path.insert(0, env.get("PROJECT_DIR", "."))
+from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
-FILESTORE_H = os.path.join(
-    env.get("PROJECT_DIR", "."),
-    ".pio", "libdeps", env.get("PIOENV", "tdeck"), "microStore", "include", "microStore", "FileStore.h",
-)
+FILESTORE_H = env_libdeps_dir(env, "microStore", "include", "microStore", "FileStore.h")
 
 OLD = """\tbool exists(const uint8_t* key, uint8_t key_len)
 \t{

--- a/patch_littlefs_paths.py
+++ b/patch_littlefs_paths.py
@@ -24,12 +24,10 @@ normalize paths to a leading "/" itself (file an issue / PR on the fork).
 Import("env")  # noqa: F821
 import os
 import sys
+sys.path.insert(0, env.get("PROJECT_DIR", "."))  # noqa: F821
+from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
-ADAPTER_H = os.path.join(
-    env.get("PROJECT_DIR", "."),  # noqa: F821
-    ".pio", "libdeps", env.get("PIOENV", "tdeck"),  # noqa: F821
-    "microStore", "include", "microStore", "Adapters", "LittleFSFileSystem.h",
-)
+ADAPTER_H = env_libdeps_dir(env, "microStore", "include", "microStore", "Adapters", "LittleFSFileSystem.h")
 
 MARKER = "_pyxis_norm_path"
 

--- a/patch_msgpack.py
+++ b/patch_msgpack.py
@@ -15,12 +15,11 @@ Mirrors the patch the microLXMF conformance-bridge applies via its
 CMakeLists (microLXMF/conformance-bridge/CMakeLists.txt:106-125).
 """
 Import("env")
-import os
+import os, sys
+sys.path.insert(0, env.get("PROJECT_DIR", "."))
+from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
-MSGPACK_BASE = os.path.join(
-    env.get("PROJECT_DIR", "."),
-    ".pio", "libdeps", env.get("PIOENV", "tdeck"), "MsgPack", "MsgPack"
-)
+MSGPACK_BASE = env_libdeps_dir(env, "MsgPack", "MsgPack")
 
 def apply_patch(filepath, old, new, label):
     if not os.path.exists(filepath):

--- a/patch_nimble.py
+++ b/patch_nimble.py
@@ -19,16 +19,11 @@ Patch 4 — NimBLEDevice.cpp: Expose host reset reason via global volatile varia
   global volatile int that application code can poll to capture the reason in UDP logs.
 """
 Import("env")
-import os
+import os, sys
+sys.path.insert(0, env.get("PROJECT_DIR", "."))
+from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
-NIMBLE_BASE = os.path.join(
-    env.get("PROJECT_DIR", "."),
-    # Per-environment libdeps tree (each env gets its own). Was hardcoded to
-    # "tdeck", so building any OTHER env (e.g. tdeck-ota) patched the wrong tree
-    # and left nimble_host_reset_reason undefined -> link error. Match the sibling
-    # pre-scripts (patch_msgpack/filestore/littlefs, sync_file_libdeps).
-    ".pio", "libdeps", env.get("PIOENV", "tdeck"), "NimBLE-Arduino", "src"
-)
+NIMBLE_BASE = env_libdeps_dir(env, "NimBLE-Arduino", "src")
 
 def apply_patch(filepath, old, new, label):
     if not os.path.exists(filepath):

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -682,7 +682,9 @@ void on_wifi_connected() {
         });
         ArduinoOTA.onError([](ota_error_t error) { ERROR("OTA: Error"); });
         ArduinoOTA.begin();
-        INFO("OTA: Ready");
+        // ArduinoOTA.begin() returns void, so this is "started", not a verified-ready
+        // state -- log the target instead of claiming readiness we can't confirm.
+        INFO("OTA: wireless flash service started (pyxis-tdeck:3232)");
 
         // Initialize UDP log broadcasting (multicast group 239.0.99.99:9999)
         udp_log_init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -654,7 +654,8 @@ void on_wifi_connected() {
         // asynchronously from loop() after Update begins instead.
 
         // Initialize ArduinoOTA for wireless flashing
-        ArduinoOTA.setHostname("pyxis-tdeck");
+        static const char* OTA_HOSTNAME = "pyxis-tdeck";
+        ArduinoOTA.setHostname(OTA_HOSTNAME);
         ArduinoOTA.onStart([]() {
             // MUST be non-blocking. ArduinoOTA calls onStart BEFORE it connects back
             // to the host, so anything slow here delays the connect-back past espota's
@@ -684,7 +685,7 @@ void on_wifi_connected() {
         ArduinoOTA.begin();
         // ArduinoOTA.begin() returns void, so this is "started", not a verified-ready
         // state -- log the target instead of claiming readiness we can't confirm.
-        INFO("OTA: wireless flash service started (pyxis-tdeck:3232)");
+        INFO((String("OTA: wireless flash service started (") + OTA_HOSTNAME + ":3232)").c_str());
 
         // Initialize UDP log broadcasting (multicast group 239.0.99.99:9999)
         udp_log_init();

--- a/sync_file_libdeps.py
+++ b/sync_file_libdeps.py
@@ -15,8 +15,11 @@ fresh source on every build.
 """
 Import("env")
 import os
+import sys
 import shutil
 from pathlib import Path
+sys.path.insert(0, env.get("PROJECT_DIR", "."))
+from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
 # (source_dir, libdep_subdir_name) — populated from env vars so the
 # script doesn't bake any contributor's local checkout path into the
@@ -32,7 +35,7 @@ if _micro_reticulum_dir:
 
 PROJECT_DIR = Path(env.get("PROJECT_DIR", "."))
 ENV_NAME = env.get("PIOENV", "tdeck")
-LIBDEPS_BASE = PROJECT_DIR / ".pio" / "libdeps" / ENV_NAME
+LIBDEPS_BASE = Path(env_libdeps_dir(env))
 
 
 def mirror(src: Path, dst: Path):

--- a/sync_file_libdeps.py
+++ b/sync_file_libdeps.py
@@ -34,7 +34,6 @@ if _micro_reticulum_dir:
     FILE_DEPS.append((_micro_reticulum_dir, "microReticulum"))
 
 PROJECT_DIR = Path(env.get("PROJECT_DIR", "."))
-ENV_NAME = env.get("PIOENV", "tdeck")
 LIBDEPS_BASE = Path(env_libdeps_dir(env))
 
 

--- a/tests/build_scripts/conftest.py
+++ b/tests/build_scripts/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# The pre-build scripts (patch_*, sync_file_libdeps) import their sibling
+# `_build_helpers` from the repo root. Put the repo root on sys.path so the tests
+# can load those scripts regardless of how pytest was invoked -- CI runs bare
+# `pytest ...`, which (unlike `python -m pytest`) does NOT add the cwd to sys.path.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/tests/build_scripts/test_patch_nimble.py
+++ b/tests/build_scripts/test_patch_nimble.py
@@ -243,6 +243,11 @@ def test_script_is_executable_via_python(tmp_path):
         f"        return {str(tmp_path)!r} if key == 'PROJECT_DIR' else default\n"
         f"import builtins\n"
         f"builtins.env = _Env()\n"
+        # The script imports its sibling _build_helpers; in a real build PROJECT_DIR
+        # is the repo root (where both live), but here PROJECT_DIR is a temp dir, so
+        # put the script's actual directory on sys.path for the import to resolve.
+        f"import sys, os\n"
+        f"sys.path.insert(0, os.path.dirname({str(PATCH_SCRIPT)!r}))\n"
         f"exec(open({str(PATCH_SCRIPT)!r}).read())\n"
     )
     # Use the same interpreter that runs the test suite (sys.executable),


### PR DESCRIPTION
OTA hardening follow-up to the `patch_nimble.py` hardcoded-`tdeck` bug that broke `tdeck-ota` linking.

## Unify pre-script libdeps paths
All five PlatformIO pre-scripts independently constructed the per-env libdeps path as `os.path.join(PROJECT_DIR, ".pio", "libdeps", PIOENV, …)`. `patch_nimble.py` had hardcoded `"tdeck"` in that slot, so building any *other* env (each gets its own `.pio/libdeps/<env>` tree) patched the wrong tree → `undefined reference to nimble_host_reset_reason`.

- New **`_build_helpers.env_libdeps_dir(env, *parts)`** — the single, per-environment libdeps path resolver.
- Converted all five (`patch_nimble` / `patch_msgpack` / `patch_filestore` / `patch_littlefs_paths`, `sync_file_libdeps`) to use it, so the env component can no longer be hand-rolled or hardcoded wrong per script.

## OTA log accuracy
`ArduinoOTA.begin()` returns void, so the old `"OTA: Ready"` asserted a state it couldn't verify. Changed to `"OTA: wireless flash service started (pyxis-tdeck:3232)"` — logs the espota target instead of claiming readiness.

## Verification
Both `tdeck` and `tdeck-ota` build, and the NimBLE patch lands in **each env's own** libdeps tree (`nimble_host_reset_reason` count = 2 in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWZuYkHBRqNb6BZHV8sTG5
