### PR TITLE
fix: stabilize LXST voice calls and Reticulum path storage

### DIFF
--- a/lib/ble_interface/BLEInterface.cpp
+++ b/lib/ble_interface/BLEInterface.cpp
@@ -1177,7 +1177,15 @@ bool BLEInterface::start_task(int priority, int core) {
     BaseType_t result = xTaskCreatePinnedToCore(
         ble_task,
         "ble",
-        12288,          // 12KB stack (string ops in debug logs need headroom)
+        24576,          // 24KB — this task's loop() processes deferred BLE-received RNS
+                        // packets inline: Transport inbound -> destination/path resolution
+                        // -> microStore `get` (a ~1KB value buffer) -> filestore read, and
+                        // can reach Resource::assemble()'s bz2 decompress. That is the SAME
+                        // deep chain loopTask and the capture task run, both sized at 24576.
+                        // At the old 12288 a path lookup during an active call (BLE-routed,
+                        // ~50 pkt/s) overflowed the stack ("stack overflow in task ble" ->
+                        // PANIC ~seconds into a call); idle it survived because path lookups
+                        // are rare. Size for the workload, matching the other RNS tasks.
         this,
         priority,
         &_task_handle,

--- a/lib/lv_mem_hybrid.h
+++ b/lib/lv_mem_hybrid.h
@@ -21,10 +21,6 @@ extern "C" {
  * during a call. UI alloc latency on PSRAM is imperceptible. */
 #define LV_MEM_HYBRID_PSRAM_THRESHOLD 256
 
-/* Track which allocations went to PSRAM vs internal RAM */
-/* We use a simple heuristic: PSRAM addresses are above 0x3C000000 on ESP32-S3 */
-#define IS_PSRAM_ADDR(ptr) ((uintptr_t)(ptr) >= 0x3C000000)
-
 static inline void* lv_mem_hybrid_alloc(size_t size) {
     void* ptr;
 
@@ -61,15 +57,16 @@ static inline void* lv_mem_hybrid_realloc(void* ptr, size_t size) {
 
     /* heap_caps_realloc has libc realloc semantics and can move an allocation
      * between capability sets while preserving min(old_size, size) bytes. */
-    uint32_t preferred_caps;
-    uint32_t fallback_caps;
-    if (IS_PSRAM_ADDR(ptr) || size >= LV_MEM_HYBRID_PSRAM_THRESHOLD) {
-        preferred_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
-        fallback_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-    } else {
-        preferred_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-        fallback_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
-    }
+    const uint32_t preferred_caps =
+        (size >= LV_MEM_HYBRID_PSRAM_THRESHOLD
+             ? MALLOC_CAP_SPIRAM
+             : MALLOC_CAP_INTERNAL) |
+        MALLOC_CAP_8BIT;
+    const uint32_t fallback_caps =
+        (size >= LV_MEM_HYBRID_PSRAM_THRESHOLD
+             ? MALLOC_CAP_INTERNAL
+             : MALLOC_CAP_SPIRAM) |
+        MALLOC_CAP_8BIT;
 
     void* new_ptr = heap_caps_realloc(ptr, size, preferred_caps);
     if (new_ptr) return new_ptr;

--- a/lib/lv_mem_hybrid.h
+++ b/lib/lv_mem_hybrid.h
@@ -59,37 +59,23 @@ static inline void* lv_mem_hybrid_realloc(void* ptr, size_t size) {
         return NULL;
     }
 
-    /* Determine where the original allocation was */
-    if (IS_PSRAM_ADDR(ptr)) {
-        /* Was in PSRAM, keep it there */
-        void* new_ptr = heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-        if (new_ptr) return new_ptr;
-        /* Fall back to internal if PSRAM realloc fails */
-        new_ptr = heap_caps_malloc(size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-        if (new_ptr) {
-            /* Copy and free old - can't use realloc across memory types */
-            /* We don't know old size, so this is a best-effort fallback */
-            heap_caps_free(ptr);
-            return new_ptr;
-        }
-        return NULL;
+    /* heap_caps_realloc has libc realloc semantics and can move an allocation
+     * between capability sets while preserving min(old_size, size) bytes. */
+    uint32_t preferred_caps;
+    uint32_t fallback_caps;
+    if (IS_PSRAM_ADDR(ptr) || size >= LV_MEM_HYBRID_PSRAM_THRESHOLD) {
+        preferred_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
+        fallback_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
     } else {
-        /* Was in internal RAM */
-        if (size >= LV_MEM_HYBRID_PSRAM_THRESHOLD) {
-            /* Growing to large size - move to PSRAM */
-            void* new_ptr = heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-            if (new_ptr) {
-                heap_caps_free(ptr);
-                return new_ptr;
-            }
-            /* Fall back to internal realloc */
-        }
-        /* Keep in internal RAM */
-        void* new_ptr = heap_caps_realloc(ptr, size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-        if (new_ptr) return new_ptr;
-        /* Fall back to PSRAM */
-        return heap_caps_realloc(ptr, size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+        preferred_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+        fallback_caps = MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT;
     }
+
+    void* new_ptr = heap_caps_realloc(ptr, size, preferred_caps);
+    if (new_ptr) return new_ptr;
+
+    /* realloc failure leaves ptr valid, so trying the alternate heap is safe. */
+    return heap_caps_realloc(ptr, size, fallback_caps);
 }
 
 #ifdef __cplusplus

--- a/lib/lv_mem_hybrid.h
+++ b/lib/lv_mem_hybrid.h
@@ -14,8 +14,12 @@
 extern "C" {
 #endif
 
-/* Threshold: allocations larger than this go to PSRAM */
-#define LV_MEM_HYBRID_PSRAM_THRESHOLD 1024
+/* Threshold: allocations larger than this go to PSRAM.
+ * Lowered 1024->256 (2026-06-24): pushes most small LVGL objects (styles, obj
+ * metadata, labels, anim descriptors) into PSRAM, de-fragmenting the scarce
+ * ~57-66KB internal block so the LXST audio pipeline can allocate reliably
+ * during a call. UI alloc latency on PSRAM is imperceptible. */
+#define LV_MEM_HYBRID_PSRAM_THRESHOLD 256
 
 /* Track which allocations went to PSRAM vs internal RAM */
 /* We use a simple heuristic: PSRAM addresses are above 0x3C000000 on ESP32-S3 */

--- a/lib/lxst_audio/es7210.cpp
+++ b/lib/lxst_audio/es7210.cpp
@@ -10,17 +10,12 @@
 #include "es7210.h"
 
 #define I2S_DSP_MODE_A 0
-#define MCLK_DIV_FRE   256  // MCLK = sample_rate * 256 (2.048MHz at 8kHz = 256Fs, the ES7210's standard clock)
-// ATTEMPTED FIX (2026-06-23, from the Linux es7210 driver, rockchip-linux/kernel) -- STILL WARPS;
-// kept as the reference-CORRECT baseline. The ES7210 internal modem needs 512Fs and is designed to
-// take a 256Fs MCLK + internal doubler (REG02=RATIO_256=0xC1: doubler ON, dll bypassed). pyxis was on
-// a non-standard 512Fs-direct path (4.096MHz, REG02=0x81). Switching to the standard 256Fs+doubler
-// here (via the {2048000,8000} coeff row, doubler=1) STILL warps the ADC: 800Hz captured as ~1000Hz
-// (+25%). EVERY clock config warps differently and NONE zero it: 512Fs +17%, 256Fs+dbl +25%, 2048Fs
-// +22%, 16kHz -86%. So the fault is BELOW the register config -- the actual MCLK signal reaching the
-// ES7210 (pin 5), or a board/chip anomaly. Resolve with a scope on MCLK(5)/LRCK/SDOUT, or test
-// whether a known-good firmware (LilyGO mic example / Sideband) captures clean on THIS board (board
-// defect vs software). Harness: tools/voice_test/inject_sweep.py (warp ratio must -> 1.0).
+#define MCLK_DIV_FRE   768  // MCLK = sample_rate * 768 (12.288MHz at 16kHz). 12.288MHz is a standard
+// audio rate the ESP32-S3 APLL locks CLEANLY (use_apll=true + fixed_mclk in i2s_capture.cpp). The
+// {12288000,16000} coeff row divides it (adc_div=3) down to the 8.192MHz sigma-delta modulator clock
+// with far lower relative jitter than the 256Fs/4.096MHz row. The raw ES7210 capture was garbled
+// ("oscillating static that builds") because a jittery MCLK feeds the modulator directly -- its DLL is
+// bypassed (no on-chip cleanup) -- so the source MCLK must be a clean, exact, high-rate clock.
 
 #define ES7210_MCLK_SOURCE            FROM_CLOCK_DOUBLE_PIN
 #define FROM_PAD_PIN                  0

--- a/lib/lxst_audio/es7210.cpp
+++ b/lib/lxst_audio/es7210.cpp
@@ -10,7 +10,17 @@
 #include "es7210.h"
 
 #define I2S_DSP_MODE_A 0
-#define MCLK_DIV_FRE   512  // MCLK = sample_rate * 512 (4.096MHz at 8kHz)
+#define MCLK_DIV_FRE   256  // MCLK = sample_rate * 256 (2.048MHz at 8kHz = 256Fs, the ES7210's standard clock)
+// ATTEMPTED FIX (2026-06-23, from the Linux es7210 driver, rockchip-linux/kernel) -- STILL WARPS;
+// kept as the reference-CORRECT baseline. The ES7210 internal modem needs 512Fs and is designed to
+// take a 256Fs MCLK + internal doubler (REG02=RATIO_256=0xC1: doubler ON, dll bypassed). pyxis was on
+// a non-standard 512Fs-direct path (4.096MHz, REG02=0x81). Switching to the standard 256Fs+doubler
+// here (via the {2048000,8000} coeff row, doubler=1) STILL warps the ADC: 800Hz captured as ~1000Hz
+// (+25%). EVERY clock config warps differently and NONE zero it: 512Fs +17%, 256Fs+dbl +25%, 2048Fs
+// +22%, 16kHz -86%. So the fault is BELOW the register config -- the actual MCLK signal reaching the
+// ES7210 (pin 5), or a board/chip anomaly. Resolve with a scope on MCLK(5)/LRCK/SDOUT, or test
+// whether a known-good firmware (LilyGO mic example / Sideband) captures clean on THIS board (board
+// defect vs software). Harness: tools/voice_test/inject_sweep.py (warp ratio must -> 1.0).
 
 #define ES7210_MCLK_SOURCE            FROM_CLOCK_DOUBLE_PIN
 #define FROM_PAD_PIN                  0
@@ -42,6 +52,7 @@ static const struct _coeff_div_es7210 coeff_div[] = {
     {16384000,  8000 ,  0x00,  0x04,  0x01,  0x00,  0x20,  0x00,    0x08,  0x00},
     {19200000,  8000 ,  0x00,  0x1e,  0x00,  0x01,  0x28,  0x00,    0x09,  0x60},
     {4096000,   8000 ,  0x00,  0x01,  0x01,  0x00,  0x20,  0x00,    0x02,  0x00},
+    {2048000,   8000 ,  0x00,  0x01,  0x01,  0x01,  0x20,  0x00,    0x01,  0x00},  // 256Fs: doubler ON -> REG02=0xC1, lrck_div=256 (ES7210 standard 8kHz clock)
     {11289600,  11025,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x01,  0x00},
     {12288000,  12000,  0x00,  0x02,  0x01,  0x00,  0x20,  0x00,    0x04,  0x00},
     {19200000,  12000,  0x00,  0x14,  0x00,  0x01,  0x28,  0x00,    0x06,  0x40},
@@ -231,8 +242,29 @@ esp_err_t es7210_adc_init(TwoWire *tw, audio_hal_codec_config_t *codec_cfg)
     ret |= es7210_config_sample(i2s_cfg->samples);
     ret |= es7210_mic_select(mic_select);
     ret |= es7210_adc_set_gain_all(GAIN_0DB);
+    // DIAGNOSTIC (2026-06-24): the LilyGO/ESP-ADF-derived init above leaves several ADC +
+    // mic-power analog registers at reset defaults that the Linux es7210 driver
+    // (rockchip-linux/kernel) writes explicitly. The raw capture has ~7.6% ASYMMETRIC analog
+    // THD (a clean sine's positive half collapses) that intermodulates speech into "chiptune".
+    // Apply the Linux analog config: ADC dynamics/HPF (REG20-23) + mic ALC/power (REG47-4C).
+    ret |= es7210_write_reg(0x20, 0x0a);
+    ret |= es7210_write_reg(0x21, 0x2a);
+    ret |= es7210_write_reg(0x22, 0x0a);
+    ret |= es7210_write_reg(0x23, 0x2a);
+    ret |= es7210_write_reg(0x47, 0x08);
+    ret |= es7210_write_reg(0x48, 0x08);
+    ret |= es7210_write_reg(0x49, 0x08);
+    ret |= es7210_write_reg(0x4A, 0x08);
+    ret |= es7210_write_reg(0x4B, 0x0F);
+    ret |= es7210_write_reg(0x4C, 0x0F);
     return ESP_OK;
 }
+
+// Runtime register poke for the T:REG diagnostic harness — write/read any ES7210 register
+// over I2C while capturing, to probe the mic analog config (MICBIAS REG41/42, VMID REG40,
+// ADC DC-block HPF REG22/23, etc.) without reflashing for every guess.
+extern "C" void pyxis_es7210_write_reg(int addr, int val) { es7210_write_reg((uint8_t)addr, (uint8_t)val); }
+extern "C" int  pyxis_es7210_read_reg(int addr) { return es7210_read_reg((uint8_t)addr); }
 
 esp_err_t es7210_adc_deinit()
 {

--- a/lib/lxst_audio/i2s_capture.cpp
+++ b/lib/lxst_audio/i2s_capture.cpp
@@ -59,9 +59,9 @@ bool I2SCapture::init() {
     // takes ~20ms; 16 × 64 = 1024 samples = 64ms headroom prevents DMA overflow.
     i2s_config.dma_buf_count = 16;
     i2s_config.dma_buf_len = 64;
-    i2s_config.use_apll = false;  // Match the working LilyGO T-Deck mic example. APLL + fixed_mclk (the old config) warped the ES7210 capture; the reference uses the main PLL with mclk_multiple.
+    i2s_config.use_apll = true;   // EXACT low-jitter MCLK via the APLL. CRITICAL: at our 256Fs config the ES7210 DLL is BYPASSED (REG02=0xC1) -- zero on-chip clock cleanup -- so source MCLK jitter feeds the sigma-delta modulator directly. use_apll=false makes 4.096MHz by a fractional-N divide (39.0625, dithered) whose jitter destabilizes the modulator on broadband speech (silence/tones stay clean) -> "oscillating static". (The LilyGO example uses main-PLL but is VAD-only, which tolerates it.)
     i2s_config.tx_desc_auto_clear = true;
-    i2s_config.fixed_mclk = 0;                          // Let the driver derive MCLK from mclk_multiple (256 * 8kHz = 2.048MHz = 256Fs), exactly like the LilyGO mic example. Forcing fixed_mclk + use_apll warped the ES7210 capture. See es7210.cpp MCLK_DIV_FRE.
+    i2s_config.fixed_mclk = 12288000;                   // Force the APLL to an EXACT 12.288MHz (768Fs at 16kHz). A standard audio rate the APLL locks cleanly; 3x higher than 4.096MHz so MCLK jitter into the ES7210's (DLL-bypassed) sigma-delta modulator is far lower. Pairs with es7210.cpp MCLK_DIV_FRE=768 + the {12288000,16000} coeff (REG02=0xC3).
     i2s_config.mclk_multiple = I2S_MCLK_MULTIPLE_256;   // Ignored when fixed_mclk is set
     i2s_config.bits_per_chan = I2S_BITS_PER_CHAN_16BIT;
     // TDM channel mask — required for ES7210 on T-Deck Plus

--- a/lib/lxst_audio/i2s_capture.cpp
+++ b/lib/lxst_audio/i2s_capture.cpp
@@ -21,6 +21,11 @@ static const char* TAG = "LXST:Capture";
 
 // Defined in main.cpp — sends to both Serial and UDP
 extern "C" void pyxis_log(const char* msg);
+extern "C" void pyxis_audio_dump(const void* pcm, size_t bytes);
+extern "C" bool pyxis_rawmic_mode();
+extern "C" int pyxis_rawmic_stage();
+extern "C" bool pyxis_record_active();
+extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead);
 
 I2SCapture::I2SCapture() = default;
 
@@ -54,9 +59,9 @@ bool I2SCapture::init() {
     // takes ~20ms; 16 × 64 = 1024 samples = 64ms headroom prevents DMA overflow.
     i2s_config.dma_buf_count = 16;
     i2s_config.dma_buf_len = 64;
-    i2s_config.use_apll = true;   // APLL gives accurate audio clocks (vs main PLL integer dividers)
+    i2s_config.use_apll = false;  // Match the working LilyGO T-Deck mic example. APLL + fixed_mclk (the old config) warped the ES7210 capture; the reference uses the main PLL with mclk_multiple.
     i2s_config.tx_desc_auto_clear = true;
-    i2s_config.fixed_mclk = 4096000;                    // Force 4.096MHz MCLK (matches ES7210 coeff table for 8kHz)
+    i2s_config.fixed_mclk = 0;                          // Let the driver derive MCLK from mclk_multiple (256 * 8kHz = 2.048MHz = 256Fs), exactly like the LilyGO mic example. Forcing fixed_mclk + use_apll warped the ES7210 capture. See es7210.cpp MCLK_DIV_FRE.
     i2s_config.mclk_multiple = I2S_MCLK_MULTIPLE_256;   // Ignored when fixed_mclk is set
     i2s_config.bits_per_chan = I2S_BITS_PER_CHAN_16BIT;
     // TDM channel mask — required for ES7210 on T-Deck Plus
@@ -219,6 +224,12 @@ void I2SCapture::captureLoop() {
 
         int samplesRead = bytesRead / sizeof(int16_t);
 
+        // Raw-mic recorder: capture CH0 to a frame-aligned PSRAM buffer for a reliable,
+        // checksummed serial transfer (bypasses the lossy/offset-fragile UDP dump path).
+        if (pyxis_record_active()) {
+            pyxis_record_write_ch0(readBuf, samplesRead);
+        }
+
         // Dump first raw I2S samples on each capture start
         if (framesEncoded == 0 && samplesRead >= 16 && totalSamples == 0) {
             char rawdump[192];
@@ -229,12 +240,21 @@ void I2SCapture::captureLoop() {
             pyxis_log(rawdump);
         }
 
-        // TDM deinterleave — extract CH0 (mic) at 8kHz.
-        // readBuf is [CH0,CH1,CH0,CH1,...], CH0 at even indices.
-        int ch0Count = samplesRead / 2;
+        // RAW-MIC DIAGNOSTIC stage 0: the FULL interleaved I2S read (both TDM channels,
+        // 16kHz int16) — for de-interleave/channel + noise-floor analysis. Stages 1/2
+        // (post-decimate pre-filter, and post-filter pre-codec) are tapped below to
+        // localize where speech is lost in the DSP.
+        if (pyxis_rawmic_mode() && pyxis_rawmic_stage() == 0) {
+            pyxis_audio_dump(readBuf, bytesRead);
+        }
+
+        // TDM deinterleave CH0 (mic) at 16kHz, then 2:1 decimate to Codec2's 8kHz (2-tap avg
+        // of adjacent 16kHz CH0 samples = readBuf[4i] and readBuf[4i+2]).
+        int ch0Count = samplesRead / 4;
         for (int i = 0; i < ch0Count; i++) {
-            ch0Buf[i] = readBuf[i * 2];
-            int16_t v = ch0Buf[i] < 0 ? -ch0Buf[i] : ch0Buf[i];
+            int32_t s = ((int32_t)readBuf[4 * i] + (int32_t)readBuf[4 * i + 2]) / 2;
+            ch0Buf[i] = (int16_t)s;
+            int16_t v = (int16_t)(s < 0 ? -s : s);
             if (v > runningPeak) runningPeak = v;
         }
 
@@ -275,6 +295,10 @@ void I2SCapture::captureLoop() {
 
             if (accumCount_ == frameSamples_) {
                 // Full frame ready — process it
+                // RAWMIC stage 1: decimated mic PCM (8kHz) BEFORE filters + inject.
+                if (pyxis_rawmic_mode() && pyxis_rawmic_stage() == 1) {
+                    pyxis_audio_dump(accumBuffer_, (size_t)frameSamples_ * sizeof(int16_t));
+                }
                 int16_t* frameData = muted_.load(std::memory_order_relaxed)
                     ? silenceBuf_ : accumBuffer_;
 
@@ -330,6 +354,10 @@ void I2SCapture::captureLoop() {
                 if (filtersEnabled_ && filterChain_ && !muted_.load(std::memory_order_relaxed)
                         && !injectSine_.load(std::memory_order_relaxed)) {
                     filterChain_->process(frameData, frameSamples_, CODEC_SAMPLE_RATE);
+                }
+                // RAWMIC stage 2: mic PCM (8kHz) AFTER filters, just before Codec2 encode.
+                if (pyxis_rawmic_mode() && pyxis_rawmic_stage() == 2) {
+                    pyxis_audio_dump(frameData, (size_t)frameSamples_ * sizeof(int16_t));
                 }
 
                 // Log PCM levels for first few frames and periodically

--- a/lib/lxst_audio/i2s_capture.cpp
+++ b/lib/lxst_audio/i2s_capture.cpp
@@ -27,6 +27,7 @@ extern "C" bool pyxis_rawmic_mode();
 extern "C" int pyxis_rawmic_stage();
 extern "C" bool pyxis_record_active();
 extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead);
+extern "C" void pyxis_audio_phase(uint32_t phase);
 
 I2SCapture::I2SCapture() = default;
 
@@ -112,8 +113,12 @@ bool I2SCapture::configureEncoder(Codec2Wrapper* codec, bool enableFilters) {
     frameSamples_ = codec_->samplesPerFrame() * FRAMES_PER_BATCH;
     filtersEnabled_ = enableFilters;
 
-    // Allocate ring buffer in PSRAM
-    encodedRing_ = new EncodedRingBuffer(ENCODED_RING_SLOTS, ENCODED_RING_MAX_BYTES);
+    // Queue filtered PCM in PSRAM. Encoding is deferred to loopTask; Codec2's
+    // DSP stack overflowed the memory-constrained capture task at phase 110.
+    encodedRing_ = new EncodedRingBuffer(
+        PCM_RING_SLOTS, frameSamples_ * static_cast<int>(sizeof(int16_t)));
+    encodePcmBuffer_ = static_cast<int16_t*>(
+        heap_caps_malloc(sizeof(int16_t) * frameSamples_, MALLOC_CAP_SPIRAM));
 
     // Allocate accumulation buffer in PSRAM
     accumBuffer_ = static_cast<int16_t*>(
@@ -129,6 +134,13 @@ bool I2SCapture::configureEncoder(Codec2Wrapper* codec, bool enableFilters) {
     // AGC boosts quiet sections; 12dB max prevents noise pumping during silence.
     if (enableFilters) {
         filterChain_ = new VoiceFilterChain(1, 300.0f, 3400.0f, -12.0f, 12.0f);
+    }
+
+    if (!encodedRing_ || !encodePcmBuffer_ || !accumBuffer_ || !silenceBuf_ ||
+            (enableFilters && !filterChain_)) {
+        ESP_LOGE(TAG, "Capture buffer allocation failed");
+        releaseBuffers();
+        return false;
     }
 
     ESP_LOGI(TAG, "Encoder configured: Codec2 mode %d, %d samples/batch (%d x %d), %d bytes/frame, filters=%d",
@@ -207,6 +219,8 @@ void I2SCapture::releaseBuffers() {
     filterChain_ = nullptr;
     delete encodedRing_;
     encodedRing_ = nullptr;
+    free(encodePcmBuffer_);
+    encodePcmBuffer_ = nullptr;
     free(accumBuffer_);
     accumBuffer_ = nullptr;
     free(silenceBuf_);
@@ -378,6 +392,7 @@ void I2SCapture::captureLoop() {
                     frameData = accumBuffer_;
                 }
 
+                pyxis_audio_phase(100);  // entering filter/encode batch
                 // Apply voice filters (skip if injecting test sine)
                 if (filtersEnabled_ && filterChain_ && !muted_.load(std::memory_order_relaxed)
                         && !injectSine_.load(std::memory_order_relaxed)) {
@@ -402,26 +417,20 @@ void I2SCapture::captureLoop() {
                     pyxis_log(logbuf);
                 }
 
-                // Encode
-                int encodedLen = codec_->encode(frameData, frameSamples_,
-                                                encodeBuf_, sizeof(encodeBuf_));
-                if (encodedLen > 0) {
+                const int pcmBytes = frameSamples_ * static_cast<int>(sizeof(int16_t));
+                if (encodedRing_ && encodedRing_->write(
+                        reinterpret_cast<const uint8_t*>(frameData), pcmBytes)) {
                     framesEncoded++;
                     if (framesEncoded <= 3 || (framesEncoded % 500 == 0)) {
-                        char logbuf[128];
-                        char hex[64];
-                        int hpos = 0;
-                        for (int h = 0; h < encodedLen && h < 20 && hpos < 60; h++)
-                            hpos += snprintf(hex + hpos, 64 - hpos, "%02X ", encodeBuf_[h]);
-                        snprintf(logbuf, sizeof(logbuf), "[CAP] Encoded #%lu: %d bytes: %s",
-                                 (unsigned long)framesEncoded, encodedLen, hex);
+                        char logbuf[112];
+                        snprintf(logbuf, sizeof(logbuf),
+                                 "[CAP] Queued PCM #%lu: %d bytes stack_free=%u",
+                                 (unsigned long)framesEncoded, pcmBytes,
+                                 (unsigned)uxTaskGetStackHighWaterMark(nullptr) * sizeof(StackType_t));
                         pyxis_log(logbuf);
                     }
-                }
-                if (encodedLen > 0 && encodedRing_) {
-                    if (!encodedRing_->write(encodeBuf_, encodedLen)) {
-                        ringDrops++;
-                    }
+                } else {
+                    ringDrops++;
                 }
 
                 accumCount_ = 0;
@@ -433,8 +442,22 @@ void I2SCapture::captureLoop() {
 }
 
 bool I2SCapture::readEncodedPacket(uint8_t* dest, int maxLength, int* actualLength) {
-    if (!encodedRing_) return false;
-    return encodedRing_->read(dest, maxLength, actualLength);
+    if (!encodedRing_ || !encodePcmBuffer_ || !codec_ || !actualLength) return false;
+    int pcmBytes = 0;
+    const int expectedBytes = frameSamples_ * static_cast<int>(sizeof(int16_t));
+    if (!encodedRing_->read(reinterpret_cast<uint8_t*>(encodePcmBuffer_),
+                            expectedBytes, &pcmBytes) || pcmBytes != expectedBytes) {
+        *actualLength = 0;
+        return false;
+    }
+
+    // Codec2 now runs on loopTask, which already has a large stack. Encode and
+    // decode are also naturally serialized when LXSTAudio shares one codec.
+    pyxis_audio_phase(110);
+    int encodedLen = codec_->encode(encodePcmBuffer_, frameSamples_, dest, maxLength);
+    pyxis_audio_phase(111);
+    *actualLength = encodedLen > 0 ? encodedLen : 0;
+    return encodedLen > 0;
 }
 
 int I2SCapture::availablePackets() const {

--- a/lib/lxst_audio/i2s_capture.cpp
+++ b/lib/lxst_audio/i2s_capture.cpp
@@ -14,6 +14,7 @@
 #include "audio_filters.h"
 #include "encoded_ring_buffer.h"
 #include <Arduino.h>
+#include <freertos/semphr.h>
 
 using namespace Hardware::TDeck;
 
@@ -139,6 +140,16 @@ bool I2SCapture::configureEncoder(Codec2Wrapper* codec, bool enableFilters) {
 bool I2SCapture::start() {
     if (!i2sInitialized_ || !codec_ || capturing_.load()) return false;
 
+    if (taskExited_) {
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
+    }
+    taskExited_ = static_cast<void*>(xSemaphoreCreateBinary());
+    if (!taskExited_) {
+        ESP_LOGE(TAG, "Failed to create capture-exit semaphore");
+        return false;
+    }
+
     // Set capturing BEFORE starting task to avoid race (same pattern as LXST-kt)
     capturing_.store(true, std::memory_order_relaxed);
 
@@ -150,6 +161,8 @@ bool I2SCapture::start() {
     if (ret != pdPASS) {
         ESP_LOGE(TAG, "Failed to create capture task");
         capturing_.store(false, std::memory_order_relaxed);
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
         return false;
     }
 
@@ -158,14 +171,25 @@ bool I2SCapture::start() {
 }
 
 void I2SCapture::stop() {
-    if (!capturing_.load()) return;
-
     capturing_.store(false, std::memory_order_relaxed);
 
-    // Wait for task to exit
-    if (taskHandle_) {
-        vTaskDelay(pdMS_TO_TICKS(50));
+    // Stop I2S first so a task blocked in i2s_read() wakes immediately, then
+    // wait for explicit task-exit acknowledgement before releasing its driver,
+    // codec, ring, or owning object.
+    TaskHandle_t task = static_cast<TaskHandle_t>(taskHandle_);
+    if (task && i2sInitialized_) i2s_stop(I2S_NUM_1);
+    if (task && taskExited_) {
+        if (xSemaphoreTake(static_cast<SemaphoreHandle_t>(taskExited_),
+                           pdMS_TO_TICKS(500)) != pdTRUE) {
+            ESP_LOGE(TAG, "Capture task exit timed out; force deleting task");
+            vTaskDelete(task);
+        }
         taskHandle_ = nullptr;
+    }
+
+    if (taskExited_) {
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
     }
 
     if (i2sInitialized_) {
@@ -193,6 +217,10 @@ void I2SCapture::releaseBuffers() {
 void I2SCapture::captureTask(void* param) {
     auto* self = static_cast<I2SCapture*>(param);
     self->captureLoop();
+    self->capturing_.store(false, std::memory_order_relaxed);
+    self->taskHandle_ = nullptr;
+    auto done = static_cast<SemaphoreHandle_t>(self->taskExited_);
+    if (done) xSemaphoreGive(done);
     vTaskDelete(NULL);
 }
 

--- a/lib/lxst_audio/i2s_capture.h
+++ b/lib/lxst_audio/i2s_capture.h
@@ -102,6 +102,7 @@ private:
     std::atomic<bool> capturing_{false};
     std::atomic<bool> muted_{false};
     void* taskHandle_ = nullptr;
+    void* taskExited_ = nullptr;  // FreeRTOS binary semaphore; task signals before delete
 
     // Test injection (see setInjectSine). When injectSine_ is true,
     // the capture path replaces accumulated mic samples with a

--- a/lib/lxst_audio/i2s_capture.h
+++ b/lib/lxst_audio/i2s_capture.h
@@ -123,6 +123,8 @@ private:
     // Audio pipeline components
     Codec2Wrapper* codec_ = nullptr;  // Shared, not owned
     VoiceFilterChain* filterChain_ = nullptr;
+    // SPSC queue of filtered PCM batches. The capture task only performs I2S
+    // and filtering; loopTask performs Codec2 encoding and transmission.
     EncodedRingBuffer* encodedRing_ = nullptr;
 
     // Accumulation buffer: I2S delivers variable bursts, we need fixed-size frames
@@ -130,8 +132,8 @@ private:
     int accumCount_ = 0;
     int frameSamples_ = 0;  // Codec2 samples per frame (e.g., 320 for 700C, 160 for 1600/3200)
 
-    // Pre-allocated encode output buffer
-    uint8_t encodeBuf_[256];
+    // PSRAM staging buffer used by loopTask while encoding queued PCM.
+    int16_t* encodePcmBuffer_ = nullptr;
 
     // Silence buffer for mute
     int16_t* silenceBuf_ = nullptr;
@@ -144,9 +146,10 @@ private:
     // Matches Columba's 200ms batch (1600 samples for Codec2 3200).
     // The AGC needs large blocks for stable gain tracking.
     static constexpr int FRAMES_PER_BATCH = 10;
-    static constexpr int ENCODED_RING_SLOTS = 128;
-    static constexpr int ENCODED_RING_MAX_BYTES = 256;
-    static constexpr int CAPTURE_TASK_STACK = 24576;  // 24KB — pyxis_log→sendto uses ~4KB lwIP stack
+    static constexpr int PCM_RING_SLOTS = 8;
+    // Codec2 no longer runs on this task. 8 KiB covers local I2S buffers,
+    // filters and bounded diagnostic sendto without starving playback.
+    static constexpr int CAPTURE_TASK_STACK = 8192;
     static constexpr int CAPTURE_TASK_PRIORITY = 5;
     static constexpr int CAPTURE_TASK_CORE = 0;
 };

--- a/lib/lxst_audio/i2s_capture.h
+++ b/lib/lxst_audio/i2s_capture.h
@@ -137,7 +137,7 @@ private:
 
     bool filtersEnabled_ = true;
 
-    static constexpr int I2S_SAMPLE_RATE = 8000;   // I2S runs at 8kHz — matches Codec2 directly, no resampling needed
+    static constexpr int I2S_SAMPLE_RATE = 16000;  // EXACT-LilyGO test: 16kHz capture, decimated 2:1 to 8kHz. (ES7210 ADC warp unresolved -- see es7210.cpp.)
     static constexpr int CODEC_SAMPLE_RATE = 8000; // Codec2 expects 8kHz
     // Accumulate this many codec frames before filter+encode.
     // Matches Columba's 200ms batch (1600 samples for Codec2 3200).

--- a/lib/lxst_audio/i2s_playback.cpp
+++ b/lib/lxst_audio/i2s_playback.cpp
@@ -23,6 +23,7 @@ extern "C" void pyxis_audio_dump(const void* pcm, size_t bytes);
 // When raw-mic diagnostic mode is on, the capture task owns the UDP dump stream
 // (raw mic PCM); suppress the decoded-PCM dump here so they don't interleave.
 extern "C" bool pyxis_rawmic_mode();
+extern "C" bool pyxis_record_active();
 
 I2SPlayback::I2SPlayback() = default;
 
@@ -184,6 +185,11 @@ bool I2SPlayback::writeEncodedPacket(const uint8_t* data, int length) {
     }
     pcmSampleCount_.fetch_add((uint32_t)decodedSamples, std::memory_order_relaxed);
     pcmSumSquares_.fetch_add(sumsq, std::memory_order_relaxed);
+
+    // MUTE the speaker during raw-mic recording: do NOT feed decoded PCM to the playback
+    // ring, so the T-Deck speaker can't play the loopback round-trip back into the adjacent
+    // mic (acoustic feedback -> "oscillating static that builds"). Decode+metrics still run.
+    if (pyxis_record_active()) return true;
 
     // Audio-loopback test tap: dump the freshly decoded PCM (int16 LE mono,
     // 8 kHz). No-op unless the loopback harness armed it via T:LOOPBACK on.

--- a/lib/lxst_audio/i2s_playback.cpp
+++ b/lib/lxst_audio/i2s_playback.cpp
@@ -11,6 +11,7 @@
 #include "codec_wrapper.h"
 #include "packet_ring_buffer.h"
 #include <Arduino.h>
+#include <freertos/semphr.h>
 
 using namespace Hardware::TDeck;
 
@@ -62,6 +63,16 @@ bool I2SPlayback::configureDecoder(Codec2Wrapper* codec) {
 
 bool I2SPlayback::start() {
     if (!codec_ || playing_.load()) return false;
+
+    if (taskExited_) {
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
+    }
+    taskExited_ = static_cast<void*>(xSemaphoreCreateBinary());
+    if (!taskExited_) {
+        ESP_LOGE(TAG, "Failed to create playback-exit semaphore");
+        return false;
+    }
 
     // Caller (LXSTAudio) is responsible for calling tone_deinit() first.
     // Defensively uninstall in case it wasn't done.
@@ -118,6 +129,8 @@ bool I2SPlayback::start() {
         playing_.store(false, std::memory_order_relaxed);
         i2s_driver_uninstall(I2S_NUM_0);
         i2sInitialized_ = false;
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
         return false;
     }
 
@@ -126,13 +139,24 @@ bool I2SPlayback::start() {
 }
 
 void I2SPlayback::stop() {
-    if (!playing_.load()) return;
-
     playing_.store(false, std::memory_order_relaxed);
 
-    if (taskHandle_) {
-        vTaskDelay(pdMS_TO_TICKS(50));
+    // Stop I2S to unblock a pending i2s_write(), then join the playback task
+    // before uninstalling the driver or releasing task-owned buffers.
+    TaskHandle_t task = static_cast<TaskHandle_t>(taskHandle_);
+    if (task && i2sInitialized_) i2s_stop(I2S_NUM_0);
+    if (task && taskExited_) {
+        if (xSemaphoreTake(static_cast<SemaphoreHandle_t>(taskExited_),
+                           pdMS_TO_TICKS(500)) != pdTRUE) {
+            ESP_LOGE(TAG, "Playback task exit timed out; force deleting task");
+            vTaskDelete(task);
+        }
         taskHandle_ = nullptr;
+    }
+
+    if (taskExited_) {
+        vSemaphoreDelete(static_cast<SemaphoreHandle_t>(taskExited_));
+        taskExited_ = nullptr;
     }
 
     if (i2sInitialized_) {
@@ -222,6 +246,10 @@ int I2SPlayback::bufferedFrames() const {
 void I2SPlayback::playbackTask(void* param) {
     auto* self = static_cast<I2SPlayback*>(param);
     self->playbackLoop();
+    self->playing_.store(false, std::memory_order_relaxed);
+    self->taskHandle_ = nullptr;
+    auto done = static_cast<SemaphoreHandle_t>(self->taskExited_);
+    if (done) xSemaphoreGive(done);
     vTaskDelete(NULL);
 }
 

--- a/lib/lxst_audio/i2s_playback.cpp
+++ b/lib/lxst_audio/i2s_playback.cpp
@@ -16,6 +16,14 @@ using namespace Hardware::TDeck;
 
 static const char* TAG = "LXST:Playback";
 
+// Decoded-PCM tap for the firmware audio-loopback test harness (defined in
+// src/main.cpp). Self-gates on an arm flag, so it is a cheap no-op in normal
+// operation. Declared extern "C" to avoid pulling main.cpp headers in here.
+extern "C" void pyxis_audio_dump(const void* pcm, size_t bytes);
+// When raw-mic diagnostic mode is on, the capture task owns the UDP dump stream
+// (raw mic PCM); suppress the decoded-PCM dump here so they don't interleave.
+extern "C" bool pyxis_rawmic_mode();
+
 I2SPlayback::I2SPlayback() = default;
 
 I2SPlayback::~I2SPlayback() {
@@ -176,6 +184,13 @@ bool I2SPlayback::writeEncodedPacket(const uint8_t* data, int length) {
     }
     pcmSampleCount_.fetch_add((uint32_t)decodedSamples, std::memory_order_relaxed);
     pcmSumSquares_.fetch_add(sumsq, std::memory_order_relaxed);
+
+    // Audio-loopback test tap: dump the freshly decoded PCM (int16 LE mono,
+    // 8 kHz). No-op unless the loopback harness armed it via T:LOOPBACK on.
+    // Suppressed in raw-mic mode (the capture task owns the dump stream then).
+    if (!pyxis_rawmic_mode()) {
+        pyxis_audio_dump(decodeBuf_, (size_t)decodedSamples * sizeof(int16_t));
+    }
 
     // Write decoded PCM to ring buffer one frame at a time
     // (ring buffer only accepts exactly frameSamples_ per write)

--- a/lib/lxst_audio/i2s_playback.cpp
+++ b/lib/lxst_audio/i2s_playback.cpp
@@ -56,6 +56,12 @@ bool I2SPlayback::configureDecoder(Codec2Wrapper* codec) {
     dropBuf_ = static_cast<int16_t*>(
         heap_caps_malloc(sizeof(int16_t) * frameSamples_, MALLOC_CAP_SPIRAM));
 
+    if (!pcmRing_ || !decodeBuf_ || !dropBuf_) {
+        ESP_LOGE(TAG, "Playback buffer allocation failed");
+        releaseBuffers();
+        return false;
+    }
+
     ESP_LOGI(TAG, "Decoder configured: Codec2 mode %d, %d samples/frame",
              codec_->libraryMode(), frameSamples_);
     return true;
@@ -270,6 +276,11 @@ void I2SPlayback::playbackLoop() {
     // Silence frame for underruns
     int16_t* silenceFrame = static_cast<int16_t*>(
         heap_caps_calloc(frameSamples_, sizeof(int16_t), MALLOC_CAP_SPIRAM));
+    if (!silenceFrame) {
+        ESP_LOGE(TAG, "Failed to allocate silence frame");
+        free(frameBuf);
+        return;
+    }
 
     uint32_t framesPlayed = 0;
 

--- a/lib/lxst_audio/i2s_playback.h
+++ b/lib/lxst_audio/i2s_playback.h
@@ -129,7 +129,7 @@ private:
     static constexpr int SAMPLE_RATE = 8000;
     static constexpr int PCM_RING_FRAMES = 50;
     static constexpr int PREBUFFER_FRAMES = 15;
-    static constexpr int PLAYBACK_TASK_STACK = 8192;
+    static constexpr int PLAYBACK_TASK_STACK = 4096;
     static constexpr int PLAYBACK_TASK_PRIORITY = 5;
     static constexpr int PLAYBACK_TASK_CORE = 0;
 };

--- a/lib/lxst_audio/i2s_playback.h
+++ b/lib/lxst_audio/i2s_playback.h
@@ -105,6 +105,7 @@ private:
     std::atomic<bool> playing_{false};
     std::atomic<bool> muted_{false};
     void* taskHandle_ = nullptr;
+    void* taskExited_ = nullptr;  // FreeRTOS binary semaphore; task signals before delete
 
     Codec2Wrapper* codec_ = nullptr;  // Shared, not owned
     PacketRingBuffer* pcmRing_ = nullptr;

--- a/lib/lxst_audio/lxst_audio.cpp
+++ b/lib/lxst_audio/lxst_audio.cpp
@@ -9,6 +9,8 @@
 #include <Hardware/TDeck/Config.h>
 #include <Arduino.h>
 #include <driver/i2s.h>
+#include <esp_heap_caps.h>
+
 #include "es7210.h"
 #include "i2s_capture.h"
 #include "i2s_playback.h"
@@ -18,6 +20,17 @@
 using namespace Hardware::TDeck;
 
 static const char* TAG = "LXST:Audio";
+extern "C" void pyxis_log(const char* msg);
+
+static void log_audio_heap(const char* stage) {
+    char buf[112];
+    snprintf(buf, sizeof(buf), "[AUDIO] %s internal=%u largest=%u",
+             stage,
+             (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+             (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
+    pyxis_log(buf);
+}
+
 
 LXSTAudio::LXSTAudio() = default;
 
@@ -32,6 +45,7 @@ bool LXSTAudio::init(int codec2Mode, uint8_t micGain) {
     }
 
     codec2Mode_ = codec2Mode;
+
 
     Serial.printf("[AUDIO] Init starting (heap=%lu)...\n", (unsigned long)esp_get_free_heap_size());
 
@@ -109,34 +123,22 @@ bool LXSTAudio::init(int codec2Mode, uint8_t micGain) {
         Serial.println("[AUDIO] ES7210 re-started with I2S clocks active");
     }
 
-    // Create separate Codec2 instances for encode and decode to avoid mutex
-    // contention during full-duplex calls (capture task + main thread decode)
+    // Keep Codec2 in internal RAM: its tight DSP loops become watchdog-prone
+    // when the state is placed in PSRAM. One shared state is sufficient for
+    // full duplex because Codec2Wrapper serializes encode/decode with a mutex,
+    // and LXST negotiates one profile for both directions.
     encodeCodec_ = new Codec2Wrapper();
-    if (!encodeCodec_->create(codec2Mode)) {
-        Serial.println("[AUDIO] Codec2 encoder create FAILED");
+    if (!encodeCodec_ || !encodeCodec_->create(codec2Mode)) {
+        Serial.println("[AUDIO] Codec2 create FAILED");
         delete capture_;
         capture_ = nullptr;
         delete encodeCodec_;
         encodeCodec_ = nullptr;
         return false;
     }
-    Serial.printf("[AUDIO] Codec2 encoder created (heap=%lu)\n", (unsigned long)esp_get_free_heap_size());
+    decodeCodec_ = encodeCodec_;
+    Serial.printf("[AUDIO] Shared Codec2 created (heap=%lu)\n", (unsigned long)esp_get_free_heap_size());
 
-    decodeCodec_ = new Codec2Wrapper();
-    if (!decodeCodec_->create(codec2Mode)) {
-        Serial.println("[AUDIO] Codec2 decoder create FAILED");
-        delete capture_;
-        capture_ = nullptr;
-        encodeCodec_->destroy();
-        delete encodeCodec_;
-        encodeCodec_ = nullptr;
-        delete decodeCodec_;
-        decodeCodec_ = nullptr;
-        return false;
-    }
-    Serial.printf("[AUDIO] Codec2 decoder created (heap=%lu)\n", (unsigned long)esp_get_free_heap_size());
-
-    // Configure encoder on capture side (owns its codec instance)
     if (!capture_->configureEncoder(encodeCodec_, true)) {
         Serial.println("[AUDIO] Capture encoder config FAILED");
         delete capture_;
@@ -144,15 +146,12 @@ bool LXSTAudio::init(int codec2Mode, uint8_t micGain) {
         encodeCodec_->destroy();
         delete encodeCodec_;
         encodeCodec_ = nullptr;
-        decodeCodec_->destroy();
-        delete decodeCodec_;
         decodeCodec_ = nullptr;
         return false;
     }
 
-    // Create playback engine with its own codec instance
     playback_ = new I2SPlayback();
-    if (!playback_->configureDecoder(decodeCodec_)) {
+    if (!playback_ || !playback_->configureDecoder(decodeCodec_)) {
         ESP_LOGE(TAG, "Playback decoder config failed");
         delete capture_;
         capture_ = nullptr;
@@ -161,8 +160,6 @@ bool LXSTAudio::init(int codec2Mode, uint8_t micGain) {
         encodeCodec_->destroy();
         delete encodeCodec_;
         encodeCodec_ = nullptr;
-        decodeCodec_->destroy();
-        delete decodeCodec_;
         decodeCodec_ = nullptr;
         return false;
     }
@@ -191,16 +188,13 @@ void LXSTAudio::deinit() {
         playback_ = nullptr;
     }
 
+    // encodeCodec_ and decodeCodec_ intentionally alias one mutex-protected
+    // Codec2 state; destroy it exactly once.
+    decodeCodec_ = nullptr;
     if (encodeCodec_) {
         encodeCodec_->destroy();
         delete encodeCodec_;
         encodeCodec_ = nullptr;
-    }
-
-    if (decodeCodec_) {
-        decodeCodec_->destroy();
-        delete decodeCodec_;
-        decodeCodec_ = nullptr;
     }
 
     initialized_ = false;
@@ -301,27 +295,35 @@ bool LXSTAudio::startFullDuplex() {
 
     // Release I2S_NUM_0 from tone generator
     Notification::tone_deinit();
+    log_audio_heap("after tone release");
 
-    // Start playback (speaker) first — I2S_NUM_0
-    if (!playback_->isPlaying()) {
-        ESP_LOGI(TAG, "Starting playback (heap=%lu)...", (unsigned long)esp_get_free_heap_size());
-        if (!playback_->start()) {
-            ESP_LOGE(TAG, "Failed to start playback for full-duplex");
-            return false;
-        }
-        ESP_LOGI(TAG, "Playback started (heap=%lu)", (unsigned long)esp_get_free_heap_size());
-    }
-
-    // Start capture (mic) — I2S_NUM_1
+    // Start capture first. Its larger contiguous stack must be allocated before
+    // playback fragments the remaining internal heap. Codec2 encoding itself is
+    // deferred to loopTask, so the capture task only needs 8 KiB.
     if (!capture_->isCapturing()) {
         ESP_LOGI(TAG, "Starting capture (heap=%lu)...", (unsigned long)esp_get_free_heap_size());
         if (!capture_->start()) {
             ESP_LOGE(TAG, "Failed to start capture for full-duplex");
-            playback_->stop();
-            playback_->configureDecoder(decodeCodec_);
+            log_audio_heap("capture start FAILED");
             return false;
         }
+        log_audio_heap("capture started");
         ESP_LOGI(TAG, "Capture started (heap=%lu)", (unsigned long)esp_get_free_heap_size());
+    }
+
+    // Start playback (speaker) second — I2S_NUM_0.
+    if (!playback_->isPlaying()) {
+        ESP_LOGI(TAG, "Starting playback (heap=%lu)...", (unsigned long)esp_get_free_heap_size());
+        if (!playback_->start()) {
+            ESP_LOGE(TAG, "Failed to start playback for full-duplex");
+            log_audio_heap("playback start FAILED");
+            capture_->stop();
+            capture_->init();
+            capture_->configureEncoder(encodeCodec_, true);
+            return false;
+        }
+        log_audio_heap("playback started");
+        ESP_LOGI(TAG, "Playback started (heap=%lu)", (unsigned long)esp_get_free_heap_size());
     }
 
     state_ = State::FULL_DUPLEX;

--- a/lib/lxst_audio/lxst_audio.cpp
+++ b/lib/lxst_audio/lxst_audio.cpp
@@ -44,16 +44,21 @@ bool LXSTAudio::init(int codec2Mode, uint8_t micGain) {
         cfg.codec_mode = AUDIO_HAL_CODEC_MODE_ENCODE;
         cfg.i2s_iface.mode = AUDIO_HAL_MODE_SLAVE;
         cfg.i2s_iface.fmt = AUDIO_HAL_I2S_NORMAL;
-        cfg.i2s_iface.samples = AUDIO_HAL_08K_SAMPLES;
+        cfg.i2s_iface.samples = AUDIO_HAL_16K_SAMPLES;  // EXACT-LilyGO test: 16kHz (es7210 256Fs); i2s_capture decimates 2:1 to Codec2's 8kHz
         cfg.i2s_iface.bits = AUDIO_HAL_BIT_LENGTH_16BITS;
 
         uint32_t ret_val = ESP_OK;
         ret_val |= es7210_adc_init(&Wire, &cfg);
         ret_val |= es7210_adc_config_i2s(cfg.codec_mode, &cfg.i2s_iface);
+        // ROOT-CAUSE FIX: was (es7210_gain_value_t)micGain (default 7 = 21dB), which
+        // SATURATED the ES7210 ADC to the negative rail (0x8000 spikes) + a huge noise
+        // floor (rms 7003 in silence) + spectral-peak shift that LOOKED like a +17-25%
+        // pitch warp. At 0dB the capture is pristine (tones land at ratio 1.000, conc 0.90)
+        // but too quiet. 12dB = a clean middle: real signal level, well below saturation.
         ret_val |= es7210_adc_set_gain(
             (es7210_input_mics_t)(ES7210_INPUT_MIC1 | ES7210_INPUT_MIC2 |
                                   ES7210_INPUT_MIC3 | ES7210_INPUT_MIC4),
-            (es7210_gain_value_t)micGain);
+            GAIN_12DB);
         ret_val |= es7210_adc_ctrl_state(cfg.codec_mode, AUDIO_HAL_CTRL_START);
 
         if (ret_val != ESP_OK) {

--- a/lib/tdeck_ui/Hardware/TDeck/ButtonDebouncer.h
+++ b/lib/tdeck_ui/Hardware/TDeck/ButtonDebouncer.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 microReticulum contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef HARDWARE_TDECK_BUTTON_DEBOUNCER_H
+#define HARDWARE_TDECK_BUTTON_DEBOUNCER_H
+
+#include <cstdint>
+
+namespace Hardware {
+namespace TDeck {
+
+// Portable, symmetric debounce state machine. `raw_pressed` is the logical
+// active state (true means pressed), independent of GPIO polarity.
+class ButtonDebouncer {
+public:
+    explicit ButtonDebouncer(uint32_t interval_ms)
+        : interval_ms_(interval_ms) {}
+
+    bool update(bool raw_pressed, uint32_t now_ms) {
+        changed_ = false;
+        if (!initialized_) {
+            initialized_ = true;
+            raw_pressed_ = raw_pressed;
+            stable_pressed_ = raw_pressed;
+            raw_changed_at_ms_ = now_ms;
+            return stable_pressed_;
+        }
+
+        if (raw_pressed != raw_pressed_) {
+            raw_pressed_ = raw_pressed;
+            raw_changed_at_ms_ = now_ms;
+        }
+
+        if (stable_pressed_ != raw_pressed_ &&
+            static_cast<uint32_t>(now_ms - raw_changed_at_ms_) >= interval_ms_) {
+            stable_pressed_ = raw_pressed_;
+            changed_ = true;
+        }
+        return stable_pressed_;
+    }
+
+    bool stable() const { return stable_pressed_; }
+    bool changed() const { return changed_; }
+
+private:
+    uint32_t interval_ms_;
+    uint32_t raw_changed_at_ms_ = 0;
+    bool initialized_ = false;
+    bool raw_pressed_ = false;
+    bool stable_pressed_ = false;
+    bool changed_ = false;
+};
+
+}  // namespace TDeck
+}  // namespace Hardware
+
+#endif  // HARDWARE_TDECK_BUTTON_DEBOUNCER_H

--- a/lib/tdeck_ui/Hardware/TDeck/Config.h
+++ b/lib/tdeck_ui/Hardware/TDeck/Config.h
@@ -119,8 +119,9 @@ namespace Tch {
 }
 
 namespace Trk {
-    // Debounce timing
-    constexpr uint32_t DEBOUNCE_MS = 10;
+    // GPIO 0 is susceptible to short transients. Require a stable level on
+    // both edges before turning the trackball button into LV_KEY_ENTER.
+    constexpr uint32_t DEBOUNCE_MS = 50;
 
     // Pulse counting for movement speed
     constexpr uint32_t PULSE_RESET_MS = 50;  // Reset pulse count after 50ms idle

--- a/lib/tdeck_ui/Hardware/TDeck/Keyboard.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/Keyboard.cpp
@@ -7,6 +7,9 @@
 
 #include <microReticulum/Log.h>
 
+// Defined in main.cpp; mirrors input diagnostics to Serial and UDP logging.
+extern "C" void pyxis_log(const char* msg);
+
 using namespace RNS;
 
 namespace Hardware {
@@ -110,6 +113,12 @@ uint8_t Keyboard::poll() {
     if (key == KEY_NONE || key == 0xFF) {
         return 0;
     }
+
+    // Source-tag every accepted hardware key so phantom Enter/newline reports
+    // can be distinguished from the trackball's synthetic LV_KEY_ENTER.
+    char diag[64];
+    snprintf(diag, sizeof(diag), "[INPUT] keyboard key=0x%02X", key);
+    pyxis_log(diag);
 
     // Add key to buffer
     buffer_push((char)key);

--- a/lib/tdeck_ui/Hardware/TDeck/Trackball.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/Trackball.cpp
@@ -8,6 +8,9 @@
 #include <microReticulum/Log.h>
 #include <driver/gpio.h>
 
+// Defined in main.cpp; mirrors input diagnostics to Serial and UDP logging.
+extern "C" void pyxis_log(const char* msg);
+
 using namespace RNS;
 
 namespace Hardware {
@@ -21,8 +24,7 @@ volatile int16_t Trackball::_pulse_left = 0;
 volatile int16_t Trackball::_pulse_right = 0;
 volatile uint32_t Trackball::_last_pulse_time = 0;
 
-bool Trackball::_button_pressed = false;
-uint32_t Trackball::_last_button_time = 0;
+ButtonDebouncer Trackball::_button_debouncer(Trk::DEBOUNCE_MS);
 Trackball::State Trackball::_state;
 bool Trackball::_initialized = false;
 
@@ -96,7 +98,8 @@ bool Trackball::init_hardware_only() {
     // Initialize state
     _state.delta_x = 0;
     _state.delta_y = 0;
-    _state.button_pressed = false;
+    _state.button_pressed = _button_debouncer.update(
+        digitalRead(Pin::TRACKBALL_BUTTON) == LOW, millis());
     _state.timestamp = millis();
 
     _initialized = true;
@@ -211,6 +214,7 @@ void Trackball::lvgl_read_cb(lv_indev_drv_t* drv, lv_indev_data_t* data) {
         // Button just released - queue ENTER key for press/release cycle
         button_was_pressed = false;
         pending_key = LV_KEY_ENTER;
+        pyxis_log("[INPUT] trackball enter=release");
         // Fall through to let pending_key logic handle it
     }
 
@@ -304,20 +308,14 @@ void Trackball::lvgl_read_cb(lv_indev_drv_t* drv, lv_indev_data_t* data) {
 }
 
 bool Trackball::read_button_debounced() {
-    bool current = (digitalRead(Pin::TRACKBALL_BUTTON) == LOW);  // Active low
-    uint32_t now = millis();
-
-    // Debounce: only accept change if stable for debounce period
-    if (current != _button_pressed) {
-        if (now - _last_button_time > Trk::DEBOUNCE_MS) {
-            _last_button_time = now;
-            return current;
-        }
-    } else {
-        _last_button_time = now;
+    const bool raw_pressed = (digitalRead(Pin::TRACKBALL_BUTTON) == LOW);
+    const bool stable_pressed = _button_debouncer.update(raw_pressed, millis());
+    if (_button_debouncer.changed()) {
+        pyxis_log(stable_pressed
+            ? "[INPUT] trackball button=pressed"
+            : "[INPUT] trackball button=released");
     }
-
-    return _button_pressed;
+    return stable_pressed;
 }
 
 // ISR handlers - MUST be in IRAM for ESP32

--- a/lib/tdeck_ui/Hardware/TDeck/Trackball.h
+++ b/lib/tdeck_ui/Hardware/TDeck/Trackball.h
@@ -5,6 +5,7 @@
 #define HARDWARE_TDECK_TRACKBALL_H
 
 #include "Config.h"
+#include "ButtonDebouncer.h"
 
 #ifdef ARDUINO
 #include <Arduino.h>
@@ -107,9 +108,9 @@ private:
     static volatile int16_t _pulse_right;
     static volatile uint32_t _last_pulse_time;
 
-    // Button state
-    static bool _button_pressed;
-    static uint32_t _last_button_time;
+    // Symmetric button debounce state. GPIO 0 is a strapping/noise-sensitive
+    // input, so both press and release must remain stable before LVGL sees them.
+    static ButtonDebouncer _button_debouncer;
 
     // State tracking
     static State _state;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -20,6 +20,10 @@
 
 using namespace RNS;
 
+// Arm/disarm the decoded-PCM dump used by the audio-loopback test mode.
+// Defined in src/main.cpp (owns the UDP multicast socket).
+extern "C" void pyxis_audio_dump_arm(bool on);
+
 // NVS keys for propagation settings
 static const char* NVS_NAMESPACE = "propagation";
 static const char* KEY_AUTO_SELECT = "auto_select";
@@ -43,10 +47,13 @@ public:
 };
 static std::shared_ptr<LXSTAnnounceHandler> s_lxst_announce_handler;
 
-// Default preferred profile: Codec2-700C (ULBW). Sized to fit a LoRa
-// SF7-9 link with header overhead. T:CALL_PROFILE in the test hooks
-// changes this between calls.
-int UIManager::_preferred_profile = UIManager::LXST_PROFILE_ULBW;
+// Default preferred profile: Codec2-1600 (VLBW). Good quality at low CPU and the
+// right default for WiFi/IP calls (where most calls run with the app). 700C (ULBW)
+// is BOTH the lowest quality AND the heaviest Codec2 mode (newamp1) -- reserve it for
+// marginal LoRa links by selecting ULBW (via the call profile setting / T:CALL_PROFILE
+// hook). TODO: auto-select per active interface (WiFi->LBW/3200, LoRa-only->ULBW/700C).
+// See the LXST voice audit (2026-06-23).
+int UIManager::_preferred_profile = UIManager::LXST_PROFILE_VLBW;
 
 int UIManager::profile_to_codec2_mode(int profile) {
     switch (profile) {
@@ -77,6 +84,7 @@ UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::Me
       _ble_interface(nullptr),
       _initialized(false),
       _call_state(CallState::IDLE),
+      _call_loopback(false),
       _lxst_audio(nullptr),
       _call_start_ms(0),
       _call_timeout_ms(0),
@@ -1137,7 +1145,9 @@ void UIManager::call_send_signal(int signal) {
 
 void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
                                       int batch_count, int total_frames) {
-    if (!_call_link || _call_link.status() != Type::Link::ACTIVE) {
+    // Loopback test mode has no link — skip the link guard and route the
+    // built wire packet back through the RX parser instead of sending it.
+    if (!_call_loopback && (!_call_link || _call_link.status() != Type::Link::ACTIVE)) {
         if (_call_audio_tx_count == 0) {
             char dbg[64];
             snprintf(dbg, sizeof(dbg), "LXST: TX drop: link=%p status=%d",
@@ -1153,8 +1163,11 @@ void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
     // Each batch = [codec_type(0x02)] + [mode_header] + [10 * raw_codec2].
     // Columba's native ring buffer expects exactly frameSamples (1600) decoded
     // samples per writeEncodedPacket call.  For Codec2 3200: 10 * 160 = 1600.
-    // batch_data contains batch_count concatenated batches of 82 bytes each.
-    static constexpr int BATCH_BYTES = 82;  // codec_type(1) + mode(1) + 10*8
+    // batch_len is the EXACT byte length of one batch, computed by the caller from
+    // the real encoded size (codec_type + mode_header + N*raw_codec2). It VARIES by
+    // Codec2 mode: 42 bytes for 700C (4 bytes/frame), 82 for 1600/3200 (8/frame).
+    // (Previously hardcoded to 82, which shipped 40 bytes of uninitialized stack and
+    // a lying bin8 length on every 700C packet -- the voice-quality root cause.)
 
     uint8_t packet_buf[256];
     int pos = 0;
@@ -1165,17 +1178,19 @@ void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
     if (batch_count == 1) {
         // Single batch: bare bin8
         packet_buf[pos++] = 0xC4;               // bin8
-        packet_buf[pos++] = (uint8_t)BATCH_BYTES;
-        memcpy(packet_buf + pos, batch_data, BATCH_BYTES);
-        pos += BATCH_BYTES;
+        packet_buf[pos++] = (uint8_t)batch_len;
+        memcpy(packet_buf + pos, batch_data, batch_len);
+        pos += batch_len;
     } else {
-        // Multiple batches: fixarray(N) of bin8 entries
+        // Multiple batches: fixarray(N) of bin8 entries, each batch_len bytes (all
+        // share one Codec2 mode). NOTE: pyxis only ever sends batch_count==1 today;
+        // true variable-length multi-batch would need per-batch lengths passed in.
         packet_buf[pos++] = 0x90 | (uint8_t)batch_count;  // fixarray(N), N≤15
         for (int b = 0; b < batch_count; b++) {
             packet_buf[pos++] = 0xC4;               // bin8
-            packet_buf[pos++] = (uint8_t)BATCH_BYTES;
-            memcpy(packet_buf + pos, batch_data + b * BATCH_BYTES, BATCH_BYTES);
-            pos += BATCH_BYTES;
+            packet_buf[pos++] = (uint8_t)batch_len;
+            memcpy(packet_buf + pos, batch_data + b * batch_len, batch_len);
+            pos += batch_len;
         }
     }
 
@@ -1192,6 +1207,15 @@ void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
         INFO(dbg);
     }
 
+    if (_call_loopback) {
+        // Loopback: feed the just-built wire packet straight back through the
+        // RX parser so the real framing + parse + decode path runs locally.
+        // call_on_packet() does NOT re-enter pump_call_tx(), so this is a
+        // bounded synchronous chain (no infinite loop, all on core 1).
+        call_on_packet(Bytes(packet_buf, pos));
+        return;
+    }
+
     try {
         Bytes audio_data(packet_buf, pos);
         Packet packet(_call_link, audio_data);
@@ -1204,8 +1228,9 @@ void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
 }
 
 void UIManager::call_rx_audio_frame(const uint8_t* frame, size_t frame_len) {
-    // Guard: packets can arrive after hangup from the network pipeline
-    if (!_lxst_audio || _call_state == CallState::IDLE) return;
+    // Guard: packets can arrive after hangup from the network pipeline.
+    // In loopback mode _call_state stays IDLE, so bypass the IDLE guard.
+    if (!_lxst_audio || (!_call_loopback && _call_state == CallState::IDLE)) return;
 
     // Wire format: [codec_type_byte] + [mode_header + codec2_subframes...]
     // codec_type: 0x00=Raw, 0x01=Opus, 0x02=Codec2 (matches LXST Codecs/__init__.py)
@@ -1324,7 +1349,8 @@ void UIManager::call_on_packet(const Bytes& data) {
         //   - fixarray: batched frames [bin8(...), bin8(...), ...]
         // Audio buffer writes don't touch LVGL — safe to process here
 
-        if ((_call_state != CallState::ACTIVE && _call_state != CallState::CONNECTING)
+        // Loopback test mode routes audio here with _call_state == IDLE.
+        if ((!_call_loopback && _call_state != CallState::ACTIVE && _call_state != CallState::CONNECTING)
             || !_lxst_audio) {
             return;
         }
@@ -1523,9 +1549,12 @@ void UIManager::call_ended() {
 }
 
 void UIManager::pump_call_tx() {
-    if (_call_state == CallState::IDLE) return;
+    // In loopback test mode _call_state is IDLE and there is no link, but mic
+    // capture is running — drain the encoded packets and feed the local
+    // loopback (see call_send_audio_batch). All bypasses gate on _call_loopback.
+    if (!_call_loopback && _call_state == CallState::IDLE) return;
     if (!_lxst_audio || !_lxst_audio->isCapturing()) return;
-    if (!_call_link || _call_link.status() != Type::Link::ACTIVE) return;
+    if (!_call_loopback && (!_call_link || _call_link.status() != Type::Link::ACTIVE)) return;
 
     int available = _lxst_audio->capturePacketsAvailable();
 
@@ -1556,6 +1585,62 @@ void UIManager::pump_call_tx() {
             INFO(dbg);
         }
     }
+}
+
+void UIManager::start_loopback() {
+    // Don't stomp a live real call. (The harness never overlaps the two, but
+    // be defensive: a real call owns _lxst_audio and must not be torn down.)
+    if (_call_state != CallState::IDLE) {
+        WARNING("LXST: Loopback refused — call in progress");
+        return;
+    }
+
+    // Always (re)create the pipeline so it picks up the currently selected
+    // profile/codec mode (driven by T:CALL_PROFILE). Mirrors call_answer().
+    if (_lxst_audio) {
+        _lxst_audio->stopCapture();
+        _lxst_audio->stopPlayback();
+        _lxst_audio->deinit();
+        delete _lxst_audio;
+        _lxst_audio = nullptr;
+    }
+    _call_audio_rx_count = 0;
+    _call_audio_tx_count = 0;
+
+    _lxst_audio = new LXSTAudio();
+    int codec_mode = profile_to_codec2_mode(_preferred_profile);
+    if (codec_mode < 0) codec_mode = CODEC2_MODE_700C;
+    if (!_lxst_audio->init(codec_mode)) {
+        WARNING("LXST: Loopback audio init failed");
+        delete _lxst_audio;
+        _lxst_audio = nullptr;
+        return;
+    }
+    // Same start path a real call uses: mic + speaker simultaneously, so
+    // isCapturing() (pump_call_tx) and isPlaying() (writeEncodedPacket) hold.
+    if (!_lxst_audio->startFullDuplex()) {
+        WARNING("LXST: Loopback full-duplex start failed");
+    }
+
+    _call_loopback = true;       // enable bypass branches BEFORE arming the dump
+    pyxis_audio_dump_arm(true);  // resets the running PCM byte offset to 0
+    INFO("LXST: Loopback started (codec mode set by profile)");
+}
+
+void UIManager::stop_loopback() {
+    // Disarm + clear the flag FIRST so pump_call_tx()/writeEncodedPacket()
+    // stop touching _lxst_audio before we tear it down.
+    _call_loopback = false;
+    pyxis_audio_dump_arm(false);
+
+    if (_lxst_audio) {
+        _lxst_audio->stopCapture();
+        _lxst_audio->stopPlayback();
+        _lxst_audio->deinit();
+        delete _lxst_audio;
+        _lxst_audio = nullptr;
+    }
+    INFO("LXST: Loopback stopped");
 }
 
 void UIManager::call_update() {

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -107,6 +107,10 @@ UIManager::~UIManager() {
     }
     delete _lxst_audio;
 
+    // This pointer owns the long-lived incoming-destination callback, not only
+    // the current call. Clear it only when the manager itself is destroyed.
+    if (s_call_instance == this) s_call_instance = nullptr;
+
     if (_conversation_list_screen) delete _conversation_list_screen;
     if (_chat_screen) delete _chat_screen;
     if (_compose_screen) delete _compose_screen;
@@ -940,7 +944,6 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
 
     _call_peer_hash = peer_hash;
     _call_muted = false;
-    s_call_instance = this;
 
     lxst_breadcrumb(2, ESP.getFreeHeap());
 
@@ -948,7 +951,6 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     Identity peer_identity = Identity::recall(peer_hash);
     if (!peer_identity) {
         WARNING("LXST: Peer identity not known, cannot establish link");
-        s_call_instance = nullptr;
         return;
     }
 
@@ -1061,9 +1063,9 @@ void UIManager::call_hangup() {
     INFO("LXST: Hanging up");
 
     // Set IDLE first — prevents pump_call_tx() (which runs without LVGL lock)
-    // from accessing _lxst_audio after we delete it.
+    // from accessing _lxst_audio after we delete it. s_call_instance remains
+    // installed because it owns the long-lived incoming destination callback.
     _call_state = CallState::IDLE;
-    s_call_instance = nullptr;
 
     // Stop audio
     if (_lxst_audio) {
@@ -1521,9 +1523,9 @@ void UIManager::call_ended() {
     INFO("LXST: Call ended");
 
     // Set IDLE first — prevents pump_call_tx() (which runs without LVGL lock)
-    // from accessing _lxst_audio after we delete it.
+    // from accessing _lxst_audio after we delete it. s_call_instance remains
+    // installed because it owns the long-lived incoming destination callback.
     _call_state = CallState::IDLE;
-    s_call_instance = nullptr;
 
     // Stop audio
     if (_lxst_audio) {

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -1635,6 +1635,10 @@ void UIManager::start_loopback() {
     // isCapturing() (pump_call_tx) and isPlaying() (writeEncodedPacket) hold.
     if (!_lxst_audio->startFullDuplex()) {
         WARNING("LXST: Loopback full-duplex start failed");
+        _lxst_audio->deinit();
+        delete _lxst_audio;
+        _lxst_audio = nullptr;
+        return;
     }
 
     _call_loopback = true;       // enable bypass branches BEFORE arming the dump

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -17,6 +17,7 @@
 #include <microReticulum/Packet.h>
 #include <microReticulum/Transport.h>
 #include <microReticulum/Destination.h>
+#include <esp_heap_caps.h>
 
 using namespace RNS;
 
@@ -933,9 +934,12 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     }
     lxst_breadcrumb(1, ESP.getFreeHeap());
 
-    // Check heap before attempting — Link establishment needs ~10KB for crypto
+    // Link establishment needs roughly 10 KiB for crypto. The former 40 KiB
+    // threshold rejected valid calls on the complete UI build, whose steady
+    // state is about 30 KiB internal free. Audio allocations are now directed
+    // to PSRAM and its task stacks are bounded, so retain a 24 KiB floor.
     size_t free_heap = ESP.getFreeHeap();
-    if (free_heap < 40000) {
+    if (free_heap < 24000) {
         char buf[64];
         snprintf(buf, sizeof(buf), "LXST: Insufficient heap (%u bytes), aborting call", (unsigned)free_heap);
         WARNING(buf);
@@ -1458,10 +1462,15 @@ void UIManager::call_process_signal(uint8_t signal) {
                     call_ended();
                     return;
                 }
+                INFOF("LXST: Audio initialized (internal=%u largest=%u)",
+                      (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+                      (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
                 lxst_breadcrumb(22, ESP.getFreeHeap());
                 // Start full-duplex audio (mic + speaker)
                 if (!_lxst_audio->startFullDuplex()) {
                     WARNING("LXST: Full-duplex start failed");
+                    call_ended();
+                    return;
                 }
                 lxst_breadcrumb(23, ESP.getFreeHeap());
 
@@ -1486,6 +1495,8 @@ void UIManager::call_process_signal(uint8_t signal) {
                 if (!_lxst_audio->isPlaying()) {
                     if (!_lxst_audio->startFullDuplex()) {
                         WARNING("LXST: Full-duplex start failed");
+                        call_ended();
+                        return;
                     }
                 }
                 lxst_breadcrumb(26, ESP.getFreeHeap());
@@ -1508,6 +1519,8 @@ void UIManager::call_process_signal(uint8_t signal) {
                 if (_lxst_audio && !_lxst_audio->isPlaying()) {
                     if (!_lxst_audio->startFullDuplex()) {
                         WARNING("LXST: Full-duplex start failed");
+                        call_ended();
+                        return;
                     }
                 }
                 INFO("LXST: Call active (full-duplex)");
@@ -1908,12 +1921,20 @@ void UIManager::call_answer() {
             return;
         }
     }
+    INFOF("LXST: Audio initialized (internal=%u largest=%u)",
+          (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     lxst_breadcrumb(32, ESP.getFreeHeap());
 
     // Start full-duplex audio (mic + speaker)
     if (!_lxst_audio->startFullDuplex()) {
         WARNING("LXST: Full-duplex start failed");
+        call_ended();
+        return;
     }
+    INFOF("LXST: Full-duplex ready (internal=%u largest=%u)",
+          (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL),
+          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
     lxst_breadcrumb(33, ESP.getFreeHeap());
 
     // Send profile preference (default ULBW = Codec2-700C). Answerer

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -79,6 +79,16 @@ public:
     void pump_call_tx();
 
     /**
+     * Audio loopback test mode (firmware-local). Captures mic -> encode ->
+     * frame -> parse -> decode entirely on-device and dumps the decoded PCM
+     * over UDP for an automated harness to score. Uses the Codec2 mode set by
+     * the preferred profile (T:CALL_PROFILE). No real call/link required.
+     */
+    void start_loopback();
+    void stop_loopback();
+    bool is_loopback() const { return _call_loopback; }
+
+    /**
      * Show conversation list screen
      */
     void show_conversation_list();
@@ -344,14 +354,14 @@ private:
 
     // LXST profile negotiation
     static constexpr int LXST_PREFERRED_PROFILE = 0xFF;
-    static constexpr int LXST_PROFILE_ULBW      = 0x10;  // Codec2 700C  (~700 bps)  — LoRa-friendly default
-    static constexpr int LXST_PROFILE_VLBW      = 0x20;  // Codec2 1600bps
-    static constexpr int LXST_PROFILE_LBW       = 0x30;  // Codec2 3200bps
+    static constexpr int LXST_PROFILE_ULBW      = 0x10;  // Codec2 700C  (~700 bps)  — heaviest CPU; reserve for marginal LoRa
+    static constexpr int LXST_PROFILE_VLBW      = 0x20;  // Codec2 1600bps — DEFAULT (good quality, low CPU)
+    static constexpr int LXST_PROFILE_LBW       = 0x30;  // Codec2 3200bps — best quality + lowest CPU; fast links
 
-    // The profile we ASK the remote for and CONFIGURE locally on every
-    // new call. Defaults to ULBW (Codec2-700C) since pyxis is targeted
-    // at LoRa where 3200 bps would saturate even SF7 BW125. Test
-    // harness can override via T:CALL_PROFILE.
+    // The profile we ASK the remote for and CONFIGURE locally on every new call.
+    // Defaults to VLBW (Codec2-1600): 700C is the heaviest AND lowest-quality mode,
+    // so it is reserved for marginal LoRa links (select ULBW there). Test harness can
+    // override via T:CALL_PROFILE.
     static int _preferred_profile;
 
     // Map profile byte to the Codec2 library mode constant
@@ -371,6 +381,11 @@ private:
     };
 
     CallState _call_state;
+    // Audio loopback test mode active: relaxes call/link state gates in the
+    // TX pump, the wire-packet send site, and the RX parse/decode path so the
+    // pipeline runs locally without a real call. Every loopback bypass is
+    // gated strictly on this flag — real calls are unaffected.
+    bool _call_loopback;
     RNS::Bytes _call_peer_hash;
     RNS::Bytes _call_dest_hash;   // LXST destination hash (for deferred link creation)
     // Vanilla upstream Link's default ctor crashes in load_private_key()

--- a/patch_littlefs_paths.py
+++ b/patch_littlefs_paths.py
@@ -28,6 +28,7 @@ sys.path.insert(0, env.get("PROJECT_DIR", "."))  # noqa: F821
 from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
 
 ADAPTER_H = env_libdeps_dir(env, "microStore", "include", "microStore", "Adapters", "LittleFSFileSystem.h")
+TRANSPORT_CPP = env_libdeps_dir(env, "microReticulum", "src", "microReticulum", "Transport.cpp")
 
 MARKER = "_pyxis_norm_path"
 
@@ -57,7 +58,28 @@ REPLACEMENTS = [
 ]
 
 
+def patch_transport_path_store():
+    """Use an ESP32-valid absolute prefix for microReticulum's path store."""
+    if not os.path.exists(TRANSPORT_CPP):
+        print(f"[patch_littlefs_paths] {TRANSPORT_CPP} not present yet; skipping")
+        return
+    with open(TRANSPORT_CPP) as f:
+        src = f.read()
+    old = 'Utilities::OS::get_filesystem(), "./path_store", false'
+    new = 'Utilities::OS::get_filesystem(), "/path_store", false'
+    if new in src:
+        print("[patch_littlefs_paths] Transport path-store prefix already absolute")
+        return
+    if old not in src:
+        print(f"[patch_littlefs_paths] FATAL: path-store initializer not found in {TRANSPORT_CPP}")
+        sys.exit(1)
+    with open(TRANSPORT_CPP, "w") as f:
+        f.write(src.replace(old, new, 1))
+    print("[patch_littlefs_paths] changed Transport path-store prefix to '/path_store'")
+
+
 def main():
+    patch_transport_path_store()
     if not os.path.exists(ADAPTER_H):
         # libdeps not fetched yet on a clean tree — PIO runs this again post-fetch.
         print(f"[patch_littlefs_paths] {ADAPTER_H} not present yet; skipping")

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -48,6 +48,10 @@ CONFIG_SPIRAM_USE_MALLOC=y
 # This reduces internal heap fragmentation at cost of slightly slower access
 CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=64
 # Reserve this much internal RAM for DMA/ISR (bytes)
+# NOTE: framework=arduino uses PRECOMPILED ESP-IDF libs, so this file is NOT consumed
+# by the tdeck build — internal-RAM placement is controlled via build_flags + custom
+# allocators in platformio.ini (RNS_PSRAM_ALLOCATOR, NIMBLE_MEM_ALLOC_MODE_EXTERNAL)
+# and lib/lv_mem_hybrid.h, not here.
 CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=32768
 
 # ============================================================================

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -257,9 +257,15 @@ static int16_t* g_rec_buf = nullptr;
 static volatile uint32_t g_rec_cap = 0, g_rec_pos = 0;
 static volatile bool g_rec_active = false;
 static SemaphoreHandle_t g_rec_mutex = nullptr;
-extern "C" bool pyxis_record_active() { return g_rec_active; }
+extern "C" bool pyxis_record_active() {
+    if (!g_rec_mutex) return false;
+    if (xSemaphoreTake(g_rec_mutex, portMAX_DELAY) != pdTRUE) return false;
+    bool active = g_rec_active;
+    xSemaphoreGive(g_rec_mutex);
+    return active;
+}
 extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead) {
-    if (!g_rec_active || !g_rec_mutex) return;
+    if (!g_rec_mutex) return;
     if (xSemaphoreTake(g_rec_mutex, portMAX_DELAY) != pdTRUE) return;
     if (!g_rec_active || !g_rec_buf) {
         xSemaphoreGive(g_rec_mutex);
@@ -1550,6 +1556,12 @@ void setup() {
     Serial.begin(115200);
     delay(100);
 
+    // Create diagnostic recorder synchronization before any audio task starts.
+    g_rec_mutex = xSemaphoreCreateMutex();
+    if (!g_rec_mutex) {
+        ERROR("Failed to create recorder mutex; T:RECORD will be unavailable");
+    }
+
     INFO("\n");
     INFO("╔══════════════════════════════════════╗");
     INFO("║   LXMF Messenger for T-Deck Plus    ║");
@@ -2488,8 +2500,7 @@ static void handle_test_hook_command(const String& line) {
         // first with T:RAWMIC on (so any MICBIAS/regs set via T:REG persist), then T:RECORD.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
         int secs = args.toInt(); if (secs < 1) secs = 6; if (secs > 8) secs = 8;
-        if (!g_rec_mutex) g_rec_mutex = xSemaphoreCreateMutex();
-        if (!g_rec_mutex) { Serial.println("T:ERR record mutex alloc failed"); return; }
+        if (!g_rec_mutex) { Serial.println("T:ERR record mutex unavailable"); return; }
 
         uint32_t new_cap = (uint32_t)secs * 32000;  // full interleaved: 16kHz * 2 TDM channels
         int16_t* new_buf = (int16_t*)heap_caps_malloc((size_t)new_cap * sizeof(int16_t), MALLOC_CAP_SPIRAM);
@@ -2516,17 +2527,28 @@ static void handle_test_hook_command(const String& line) {
         Serial.print((unsigned long)g_rec_cap); Serial.println(" samples (16kHz x2ch interleaved)");
     }
     else if (cmd == "T:DUMPREC") {
-        // Transfer the recorded buffer as checksummed hex between REC_BEGIN/REC_END markers.
-        if (g_rec_active) { Serial.println("T:ERR recording active"); return; }
-        if (!g_rec_buf || g_rec_pos == 0) { Serial.println("T:ERR no recording"); return; }
-        uint32_t n = g_rec_pos, sum = 0;
-        for (uint32_t i = 0; i < n; i++) sum += (uint16_t)g_rec_buf[i];
+        // Transfer a completed recording as checksummed hex between REC_BEGIN/REC_END markers.
+        // Snapshot under the recorder mutex; serial commands run on loopTask, so no new
+        // recording can replace this buffer until the dump command returns.
+        if (!g_rec_mutex) { Serial.println("T:ERR no recording"); return; }
+        xSemaphoreTake(g_rec_mutex, portMAX_DELAY);
+        if (g_rec_active) {
+            xSemaphoreGive(g_rec_mutex);
+            Serial.println("T:ERR recording active");
+            return;
+        }
+        int16_t* dump_buf = g_rec_buf;
+        uint32_t n = g_rec_pos;
+        xSemaphoreGive(g_rec_mutex);
+        if (!dump_buf || n == 0) { Serial.println("T:ERR no recording"); return; }
+        uint32_t sum = 0;
+        for (uint32_t i = 0; i < n; i++) sum += (uint16_t)dump_buf[i];
         Serial.print("REC_BEGIN "); Serial.print((unsigned long)n);
         Serial.print(" 16000 "); Serial.println((unsigned long)sum);
         static char line[520];
         for (uint32_t i = 0; i < n; ) {
             int p = 0;
-            for (int k = 0; k < 128 && i < n; k++, i++) p += sprintf(line + p, "%04X", (uint16_t)g_rec_buf[i]);
+            for (int k = 0; k < 128 && i < n; k++, i++) p += sprintf(line + p, "%04X", (uint16_t)dump_buf[i]);
             line[p] = 0; Serial.println(line);
         }
         Serial.println("REC_END");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,6 +157,21 @@ static int udp_log_sock = -1;
 static struct sockaddr_in udp_log_dest;
 static bool udp_log_ready = false;
 
+// Crash-phase evidence that survives panic/watchdog resets without writing
+// flash from the real-time audio task.
+RTC_NOINIT_ATTR static uint32_t g_audio_phase_magic;
+RTC_NOINIT_ATTR static uint32_t g_audio_phase;
+static constexpr uint32_t AUDIO_PHASE_MAGIC = 0x50595841;
+static esp_reset_reason_t g_boot_reset_reason = ESP_RST_UNKNOWN;
+static uint8_t g_boot_lxst_step = 0;
+static uint32_t g_boot_lxst_heap = 0;
+static uint32_t g_boot_lxst_stack = 0;
+
+extern "C" void pyxis_audio_phase(uint32_t phase) {
+    g_audio_phase = phase;
+    g_audio_phase_magic = AUDIO_PHASE_MAGIC;
+}
+
 static void udp_log_init() {
     if (udp_log_sock >= 0) close(udp_log_sock);  // Re-init safe
     udp_log_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -837,6 +852,14 @@ void on_wifi_connected() {
             }
         });
         INFO("UDP log broadcasting on port 9999");
+        if (g_boot_reset_reason != ESP_RST_POWERON || g_boot_lxst_step > 0 ||
+                g_audio_phase_magic == AUDIO_PHASE_MAGIC) {
+            WARNINGF("BOOT CRASH EVIDENCE: reset=%d lxst_step=%u heap=%u stack=%u audio_phase=%u",
+                     (int)g_boot_reset_reason, (unsigned)g_boot_lxst_step,
+                     (unsigned)g_boot_lxst_heap, (unsigned)g_boot_lxst_stack,
+                     g_audio_phase_magic == AUDIO_PHASE_MAGIC ? (unsigned)g_audio_phase : 0U);
+            g_audio_phase_magic = 0;
+        }
     }
 }
 
@@ -1535,16 +1558,19 @@ void setup() {
     Hardware::TDeck::Display::init_hardware_only();
 
     // Capture ESP reset reason early (before WiFi) — logged after WiFi init for UDP visibility
-    esp_reset_reason_t _boot_reset_reason = esp_reset_reason();
+    g_boot_reset_reason = esp_reset_reason();
 
     // Check for LXST crash breadcrumb from previous boot
     {
         Preferences _dbg;
         _dbg.begin("lxst_dbg", true);
         uint8_t step = _dbg.getUChar("step", 0);
+        g_boot_lxst_step = step;
         if (step > 0) {
             uint32_t heap = _dbg.getUInt("heap", 0);
             uint32_t stack = _dbg.getUInt("stack", 0);
+            g_boot_lxst_heap = heap;
+            g_boot_lxst_stack = stack;
             char buf[80];
             snprintf(buf, sizeof(buf), "LXST CRASH: last step=%u heap=%u stack=%u", step, heap, stack);
             WARNING(buf);
@@ -1607,7 +1633,7 @@ void setup() {
     // Log ESP reset reason after WiFi so it reaches UDP logs
     {
         const char* reason_str = "UNKNOWN";
-        switch (_boot_reset_reason) {
+        switch (g_boot_reset_reason) {
             case ESP_RST_POWERON:  reason_str = "POWERON"; break;
             case ESP_RST_SW:       reason_str = "SOFTWARE"; break;
             case ESP_RST_PANIC:    reason_str = "PANIC"; break;
@@ -1619,8 +1645,8 @@ void setup() {
             case ESP_RST_SDIO:     reason_str = "SDIO"; break;
             default: break;
         }
-        if (_boot_reset_reason != ESP_RST_POWERON) {
-            WARNING("Reset reason: " + std::string(reason_str) + " (" + std::to_string((int)_boot_reset_reason) + ")");
+        if (g_boot_reset_reason != ESP_RST_POWERON) {
+            WARNING("Reset reason: " + std::string(reason_str) + " (" + std::to_string((int)g_boot_reset_reason) + ")");
         } else {
             INFO("Reset reason: " + std::string(reason_str));
         }
@@ -2626,6 +2652,28 @@ void loop() {
                                         (lora_interface && lora_interface->online()) ||
                                         (ble_interface && ble_interface->online());
             if (router && has_online_interface) {
+                // Cached paths can retain a usable receiving_interface even if
+                // a dynamically restarted interface is absent from Transport's
+                // broadcast table. Repair only missing active registrations.
+                auto ensure_registered = [](Interface* iface, const char* label) {
+                    if (!iface || !iface->online()) return;
+                    auto& table = Transport::get_interfaces();
+                    if (table.find(iface->get_hash()) == table.end()) {
+                        WARNINGF("Announce egress: restoring missing %s interface registration", label);
+                        Transport::register_interface(*iface);
+                    }
+                };
+                ensure_registered(tcp_interface, "TCP");
+                ensure_registered(lora_interface, "LoRa");
+                ensure_registered(ble_interface, "BLE");
+                const auto& announce_interfaces = Transport::get_interfaces();
+                INFOF("Announce egress: registered_interfaces=%u", (unsigned)announce_interfaces.size());
+                for (const auto& entry : announce_interfaces) {
+                    const Interface& iface = entry.second;
+                    INFOF("Announce egress interface: %s online=%s out=%s mode=%u",
+                          iface.toString().c_str(), iface.online() ? "yes" : "no",
+                          iface.OUT() ? "yes" : "no", (unsigned)iface.mode());
+                }
                 router->announce();
                 if (ui_manager) {
                     ui_manager->announce_lxst();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,7 +179,19 @@ static void udp_log_init() {
     memset(&udp_log_dest, 0, sizeof(udp_log_dest));
     udp_log_dest.sin_family = AF_INET;
     udp_log_dest.sin_port = htons(9999);
+#ifdef PYXIS_TEST_HOOKS
+    // Diagnostic builds send logs directly to the configured harness host.
+    // Multicast delivery can disappear after OTA on dual-interface macOS hosts,
+    // while unicast gives the input-source capture a deterministic destination.
+    const char* diagnostic_host = PYXIS_TEST_TCP_HOST;
+    if (diagnostic_host && diagnostic_host[0] != '\0') {
+        udp_log_dest.sin_addr.s_addr = inet_addr(diagnostic_host);
+    } else {
+        udp_log_dest.sin_addr.s_addr = inet_addr("239.0.99.99");
+    }
+#else
     udp_log_dest.sin_addr.s_addr = inet_addr("239.0.99.99");
+#endif
 }
 
 // UDP send — no locking needed.  sendto() is non-blocking (O_NONBLOCK) and

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -619,6 +619,11 @@ void load_app_settings() {
 
     // Interfaces
     app_settings.tcp_enabled = prefs.getBool("tcp_en", true);
+#ifdef PYXIS_TEST_HOOKS
+    // The test transport must be enabled after reading NVS; setting this beside
+    // the earlier host/port override would be overwritten by tcp_en above.
+    app_settings.tcp_enabled = true;
+#endif
     app_settings.lora_enabled = prefs.getBool("lora_en", false);
     app_settings.lora_frequency = prefs.getFloat("lora_freq", 927.25f);
     app_settings.lora_bandwidth = prefs.getFloat("lora_bw", 50.0f);
@@ -2062,7 +2067,10 @@ static void handle_test_hook_command(const String& line) {
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
         RNS::Bytes dest_hash = parse_hex_arg(args);
         if (dest_hash.size() != 16) { Serial.println("T:ERR bad hex"); return; }
-        ui_manager->test_call_initiate(dest_hash);
+        // Serial hooks run on loopTask, outside the LVGL task. The production
+        // call path mutates screens immediately, so hold the same LVGL lock as
+        // other cross-task UI operations.
+        { LVGL_LOCK(); ui_manager->test_call_initiate(dest_hash); }
         Serial.println(String("T:OK calling=") + args);
     }
     else if (cmd == "T:CALL_STATE") {
@@ -2074,7 +2082,9 @@ static void handle_test_hook_command(const String& line) {
     else if (cmd == "T:CALL_HANGUP") {
         // T:CALL_HANGUP — tear down the active call.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
-        ui_manager->test_call_hangup();
+        // call_hangup() refreshes/deletes LVGL objects; invoking it unlocked
+        // from loopTask corrupts LVGL's event list once playback is active.
+        { LVGL_LOCK(); ui_manager->test_call_hangup(); }
         Serial.println("T:OK hung_up");
     }
     else if (cmd == "T:CALL_ANSWER") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,15 +256,26 @@ extern "C" int  pyxis_es7210_read_reg(int addr);
 static int16_t* g_rec_buf = nullptr;
 static volatile uint32_t g_rec_cap = 0, g_rec_pos = 0;
 static volatile bool g_rec_active = false;
+static SemaphoreHandle_t g_rec_mutex = nullptr;
 extern "C" bool pyxis_record_active() { return g_rec_active; }
 extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead) {
-    if (!g_rec_active || !g_rec_buf) return;
+    if (!g_rec_active || !g_rec_mutex) return;
+    if (xSemaphoreTake(g_rec_mutex, portMAX_DELAY) != pdTRUE) return;
+    if (!g_rec_active || !g_rec_buf) {
+        xSemaphoreGive(g_rec_mutex);
+        return;
+    }
     // Record the FULL interleaved read (both TDM channels) so the harness can de-interleave
     // CH0 (even) AND CH1 (odd) offboard and check which channel actually carries the voice.
-    for (int i = 0; i < samplesRead; i++) {
-        if (g_rec_pos >= g_rec_cap) { g_rec_active = false; return; }
+    for (int i = 0; g_rec_active && i < samplesRead; i++) {
+        if (g_rec_pos >= g_rec_cap) {
+            g_rec_active = false;
+            break;
+        }
         g_rec_buf[g_rec_pos++] = readBuf[i];
     }
+    if (g_rec_pos >= g_rec_cap) g_rec_active = false;
+    xSemaphoreGive(g_rec_mutex);
 }
 
 static void udp_audio_dest_init() {
@@ -2477,18 +2488,36 @@ static void handle_test_hook_command(const String& line) {
         // first with T:RAWMIC on (so any MICBIAS/regs set via T:REG persist), then T:RECORD.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
         int secs = args.toInt(); if (secs < 1) secs = 6; if (secs > 8) secs = 8;
-        if (g_rec_buf) { free(g_rec_buf); g_rec_buf = nullptr; }
-        g_rec_cap = (uint32_t)secs * 32000;  // full interleaved: 16kHz * 2 TDM channels
-        g_rec_buf = (int16_t*)heap_caps_malloc((size_t)g_rec_cap * sizeof(int16_t), MALLOC_CAP_SPIRAM);
-        if (!g_rec_buf) { Serial.println("T:ERR record alloc failed"); g_rec_cap = 0; return; }
-        g_rec_pos = 0;
+        if (!g_rec_mutex) g_rec_mutex = xSemaphoreCreateMutex();
+        if (!g_rec_mutex) { Serial.println("T:ERR record mutex alloc failed"); return; }
+
+        uint32_t new_cap = (uint32_t)secs * 32000;  // full interleaved: 16kHz * 2 TDM channels
+        int16_t* new_buf = (int16_t*)heap_caps_malloc((size_t)new_cap * sizeof(int16_t), MALLOC_CAP_SPIRAM);
+        if (!new_buf) { Serial.println("T:ERR record alloc failed"); return; }
+
         if (!ui_manager->is_loopback()) ui_manager->start_loopback();
+        if (!ui_manager->is_loopback()) {
+            free(new_buf);
+            Serial.println("T:ERR record capture start failed");
+            return;
+        }
+
+        xSemaphoreTake(g_rec_mutex, portMAX_DELAY);
+        int16_t* old_buf = g_rec_buf;
+        g_rec_active = false;
+        g_rec_buf = new_buf;
+        g_rec_cap = new_cap;
+        g_rec_pos = 0;
         g_rec_active = true;
+        xSemaphoreGive(g_rec_mutex);
+        if (old_buf) free(old_buf);
+
         Serial.print("T:OK recording "); Serial.print(secs); Serial.print("s ");
         Serial.print((unsigned long)g_rec_cap); Serial.println(" samples (16kHz x2ch interleaved)");
     }
     else if (cmd == "T:DUMPREC") {
         // Transfer the recorded buffer as checksummed hex between REC_BEGIN/REC_END markers.
+        if (g_rec_active) { Serial.println("T:ERR recording active"); return; }
         if (!g_rec_buf || g_rec_pos == 0) { Serial.println("T:ERR no recording"); return; }
         uint32_t n = g_rec_pos, sum = 0;
         for (uint32_t i = 0; i < n; i++) sum += (uint16_t)g_rec_buf[i];
@@ -2652,28 +2681,6 @@ void loop() {
                                         (lora_interface && lora_interface->online()) ||
                                         (ble_interface && ble_interface->online());
             if (router && has_online_interface) {
-                // Cached paths can retain a usable receiving_interface even if
-                // a dynamically restarted interface is absent from Transport's
-                // broadcast table. Repair only missing active registrations.
-                auto ensure_registered = [](Interface* iface, const char* label) {
-                    if (!iface || !iface->online()) return;
-                    auto& table = Transport::get_interfaces();
-                    if (table.find(iface->get_hash()) == table.end()) {
-                        WARNINGF("Announce egress: restoring missing %s interface registration", label);
-                        Transport::register_interface(*iface);
-                    }
-                };
-                ensure_registered(tcp_interface, "TCP");
-                ensure_registered(lora_interface, "LoRa");
-                ensure_registered(ble_interface, "BLE");
-                const auto& announce_interfaces = Transport::get_interfaces();
-                INFOF("Announce egress: registered_interfaces=%u", (unsigned)announce_interfaces.size());
-                for (const auto& entry : announce_interfaces) {
-                    const Interface& iface = entry.second;
-                    INFOF("Announce egress interface: %s online=%s out=%s mode=%u",
-                          iface.toString().c_str(), iface.online() ? "yes" : "no",
-                          iface.OUT() ? "yes" : "no", (unsigned)iface.mode());
-                }
                 router->announce();
                 if (ui_manager) {
                     ui_manager->announce_lxst();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,10 +232,11 @@ static volatile bool g_rec_active = false;
 extern "C" bool pyxis_record_active() { return g_rec_active; }
 extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead) {
     if (!g_rec_active || !g_rec_buf) return;
-    int n = samplesRead / 2;  // CH0 = even indices of the interleaved I2S read
-    for (int i = 0; i < n; i++) {
+    // Record the FULL interleaved read (both TDM channels) so the harness can de-interleave
+    // CH0 (even) AND CH1 (odd) offboard and check which channel actually carries the voice.
+    for (int i = 0; i < samplesRead; i++) {
         if (g_rec_pos >= g_rec_cap) { g_rec_active = false; return; }
-        g_rec_buf[g_rec_pos++] = readBuf[i * 2];
+        g_rec_buf[g_rec_pos++] = readBuf[i];
     }
 }
 
@@ -2427,16 +2428,16 @@ static void handle_test_hook_command(const String& line) {
         // T:RECORD <secs> — record raw CH0 mic (16kHz) into a PSRAM buffer. Start the capture
         // first with T:RAWMIC on (so any MICBIAS/regs set via T:REG persist), then T:RECORD.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
-        int secs = args.toInt(); if (secs < 1) secs = 6; if (secs > 12) secs = 12;
+        int secs = args.toInt(); if (secs < 1) secs = 6; if (secs > 8) secs = 8;
         if (g_rec_buf) { free(g_rec_buf); g_rec_buf = nullptr; }
-        g_rec_cap = (uint32_t)secs * 16000;
+        g_rec_cap = (uint32_t)secs * 32000;  // full interleaved: 16kHz * 2 TDM channels
         g_rec_buf = (int16_t*)heap_caps_malloc((size_t)g_rec_cap * sizeof(int16_t), MALLOC_CAP_SPIRAM);
         if (!g_rec_buf) { Serial.println("T:ERR record alloc failed"); g_rec_cap = 0; return; }
         g_rec_pos = 0;
         if (!ui_manager->is_loopback()) ui_manager->start_loopback();
         g_rec_active = true;
         Serial.print("T:OK recording "); Serial.print(secs); Serial.print("s ");
-        Serial.print((unsigned long)g_rec_cap); Serial.println(" samples @16kHz raw CH0");
+        Serial.print((unsigned long)g_rec_cap); Serial.println(" samples (16kHz x2ch interleaved)");
     }
     else if (cmd == "T:DUMPREC") {
         // Transfer the recorded buffer as checksummed hex between REC_BEGIN/REC_END markers.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,96 @@ extern "C" void pyxis_log(const char* msg) {
     }
 }
 
+// --- Audio loopback PCM dump (test harness) ---------------------------------
+// In LOOPBACK test mode the decoded PCM is streamed over a SECOND multicast
+// destination (239.0.99.99:9998) so the Mac harness can score voice quality.
+// Reuses udp_log_sock — it's already bound to the WiFi station interface for
+// multicast output (IP_MULTICAST_IF set in udp_log_init), so we only need a
+// second dest sockaddr. The group/port are interface-independent, so this dest
+// survives WiFi reconnects (which only re-bind the socket, not the dest).
+static struct sockaddr_in udp_audio_dest;
+static bool udp_audio_dest_ready = false;
+static volatile bool g_audio_dump_armed = false;
+static uint32_t g_audio_dump_offset = 0;
+// When true, the capture task dumps the RAW de-interleaved mic PCM (pre-filter,
+// pre-codec) over UDP and the playback path SKIPS its decoded-PCM dump, so the
+// harness sees exactly what the ES7210 produces, isolated from the codec.
+static volatile bool g_rawmic_mode = false;
+extern "C" bool pyxis_rawmic_mode() { return g_rawmic_mode; }
+// Which pipeline stage the raw-mic tap dumps: 0=raw I2S (16kHz interleaved),
+// 1=post-decimate pre-filter (8kHz), 2=post-filter pre-codec (8kHz). Lets the
+// harness localize where speech is lost in the DSP without reflashing.
+static volatile int g_rawmic_stage = 0;
+extern "C" int pyxis_rawmic_stage() { return g_rawmic_stage; }
+// Runtime ES7210 register poke (defined in es7210.cpp) for the T:REG diagnostic.
+extern "C" void pyxis_es7210_write_reg(int addr, int val);
+extern "C" int  pyxis_es7210_read_reg(int addr);
+// --- Raw-mic recorder: the capture task fills a frame-aligned PSRAM buffer in order
+// (no UDP loss / offset / de-interleave fragility), then T:DUMPREC transfers it over the
+// reliable USB-serial link as checksummed hex. ---
+static int16_t* g_rec_buf = nullptr;
+static volatile uint32_t g_rec_cap = 0, g_rec_pos = 0;
+static volatile bool g_rec_active = false;
+extern "C" bool pyxis_record_active() { return g_rec_active; }
+extern "C" void pyxis_record_write_ch0(const int16_t* readBuf, int samplesRead) {
+    if (!g_rec_active || !g_rec_buf) return;
+    int n = samplesRead / 2;  // CH0 = even indices of the interleaved I2S read
+    for (int i = 0; i < n; i++) {
+        if (g_rec_pos >= g_rec_cap) { g_rec_active = false; return; }
+        g_rec_buf[g_rec_pos++] = readBuf[i * 2];
+    }
+}
+
+static void udp_audio_dest_init() {
+    memset(&udp_audio_dest, 0, sizeof(udp_audio_dest));
+    udp_audio_dest.sin_family = AF_INET;
+    udp_audio_dest.sin_port = htons(9998);
+    udp_audio_dest.sin_addr.s_addr = inet_addr("239.0.99.99");
+    udp_audio_dest_ready = true;
+}
+
+// Same guards as udp_send(): WiFi connected + socket valid + logging ready
+// (logging-ready implies the socket was bound to a live WiFi iface).
+static void udp_audio_send(const void* data, size_t len) {
+    if (udp_log_sock < 0 || !udp_log_ready || WiFi.status() != WL_CONNECTED) return;
+    if (!udp_audio_dest_ready) udp_audio_dest_init();
+    sendto(udp_log_sock, data, len, 0,
+           (struct sockaddr*)&udp_audio_dest, sizeof(udp_audio_dest));
+}
+
+// Arm/disarm the decoded-PCM dump. Arming resets the running byte offset to 0.
+extern "C" void pyxis_audio_dump_arm(bool on) {
+    if (on) {
+        g_audio_dump_offset = 0;
+        if (!udp_audio_dest_ready) udp_audio_dest_init();
+    }
+    g_audio_dump_armed = on;
+}
+
+// Dump decoded PCM (int16 LE mono @ 8 kHz). Self-gates on the arm flag and is
+// a cheap early-return when disarmed. Chunks into datagrams whose payload is
+// [uint32 LE byte_offset][<=1280 PCM bytes] (<=1284 total), advancing the
+// running offset by the number of PCM bytes emitted.
+extern "C" void pyxis_audio_dump(const void* pcm, size_t bytes) {
+    if (!g_audio_dump_armed || pcm == nullptr || bytes == 0) return;
+    const uint8_t* p = (const uint8_t*)pcm;
+    size_t remaining = bytes;
+    while (remaining > 0) {
+        size_t chunk = remaining > 1280 ? 1280 : remaining;
+        uint8_t dgram[1284];
+        uint32_t off = g_audio_dump_offset;
+        dgram[0] = (uint8_t)(off & 0xFF);
+        dgram[1] = (uint8_t)((off >> 8) & 0xFF);
+        dgram[2] = (uint8_t)((off >> 16) & 0xFF);
+        dgram[3] = (uint8_t)((off >> 24) & 0xFF);
+        memcpy(dgram + 4, p, chunk);
+        udp_audio_send(dgram, chunk + 4);
+        p += chunk;
+        remaining -= chunk;
+        g_audio_dump_offset += (uint32_t)chunk;
+    }
+}
+
 // Forward declarations
 void start_tcp_interface();
 void start_auto_interface();
@@ -2258,6 +2348,110 @@ static void handle_test_hook_command(const String& line) {
         Serial.print(freq);
         Serial.print(" amp=");
         Serial.println(amp, 3);
+    }
+    else if (cmd == "T:LOOPBACK") {
+        // T:LOOPBACK <on|off> — self-contained audio loopback test mode.
+        // "on" resets the PCM byte offset to 0, starts mic capture + speaker
+        // playback, enables the local loopback path (capture -> encode ->
+        // frame -> parse -> decode, all on core 1) and arms the decoded-PCM
+        // dump over UDP multicast 239.0.99.99:9998 for the Mac harness.
+        // "off" stops/disarms. The Codec2 mode is whatever T:CALL_PROFILE
+        // selected. Does NOT require a real call/link.
+        if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
+        String on_off = args;
+        on_off.trim();
+        bool enabled  = (on_off == "on"  || on_off == "1" || on_off == "true");
+        bool disabled = (on_off == "off" || on_off == "0" || on_off == "false");
+        if (!enabled && !disabled) {
+            Serial.println("T:ERR usage: T:LOOPBACK on|off");
+            return;
+        }
+        if (enabled) {
+            ui_manager->start_loopback();
+            Serial.print("T:OK loopback=on active=");
+            Serial.println(ui_manager->is_loopback() ? "1" : "0");
+        } else {
+            ui_manager->stop_loopback();
+            Serial.println("T:OK loopback=off");
+        }
+    }
+    else if (cmd == "T:RAWMIC") {
+        // T:RAWMIC <on|off> — like T:LOOPBACK, but dumps the RAW de-interleaved mic
+        // PCM (pre-filter, pre-codec) over UDP 239.0.99.99:9998 instead of the decoded
+        // round-trip. Isolates the ES7210 capture from the codec so the harness sees
+        // exactly what the mic produces. Reuses the loopback plumbing; the playback
+        // decoded-dump is suppressed while g_rawmic_mode is set.
+        if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
+        String on_off = args;
+        on_off.trim();
+        bool enabled  = on_off.startsWith("on") || on_off == "1" || on_off == "true";
+        bool disabled = (on_off == "off" || on_off == "0" || on_off == "false");
+        if (!enabled && !disabled) {
+            Serial.println("T:ERR usage: T:RAWMIC on[ stage]|off  (stage 0=rawI2S 1=pre-filter 2=post-filter)");
+            return;
+        }
+        if (enabled) {
+            // optional trailing stage: "T:RAWMIC on 2" -> dump the post-filter tap
+            int sp = on_off.indexOf(' ');
+            g_rawmic_stage = (sp >= 0) ? on_off.substring(sp + 1).toInt() : 0;
+            g_rawmic_mode = true;
+            ui_manager->start_loopback();
+            Serial.print("T:OK rawmic=on stage=");
+            Serial.print(g_rawmic_stage);
+            Serial.print(" active=");
+            Serial.println(ui_manager->is_loopback() ? "1" : "0");
+        } else {
+            ui_manager->stop_loopback();
+            g_rawmic_mode = false;
+            Serial.println("T:OK rawmic=off");
+        }
+    }
+    else if (cmd == "T:REG") {
+        // T:REG <hexaddr> [hexval] — read (1 arg) or write (2 args) an ES7210 register over I2C
+        // at runtime. Probes the mic analog config (MICBIAS 0x41/0x42, VMID 0x40, ADC DC-block
+        // HPF 0x22/0x23) live while capturing, without reflashing for each guess.
+        String a = args; a.trim();
+        if (a.length() == 0) { Serial.println("T:ERR usage: T:REG <hexaddr> [hexval]"); return; }
+        int sp = a.indexOf(' ');
+        if (sp < 0) {
+            int addr = (int)strtol(a.c_str(), nullptr, 16);
+            Serial.printf("T:OK reg[0x%02X]=0x%02X\n", addr & 0xff, pyxis_es7210_read_reg(addr) & 0xff);
+        } else {
+            int addr = (int)strtol(a.substring(0, sp).c_str(), nullptr, 16);
+            int val  = (int)strtol(a.substring(sp + 1).c_str(), nullptr, 16);
+            pyxis_es7210_write_reg(addr, val);
+            Serial.printf("T:OK wrote reg[0x%02X]=0x%02X\n", addr & 0xff, val & 0xff);
+        }
+    }
+    else if (cmd == "T:RECORD") {
+        // T:RECORD <secs> — record raw CH0 mic (16kHz) into a PSRAM buffer. Start the capture
+        // first with T:RAWMIC on (so any MICBIAS/regs set via T:REG persist), then T:RECORD.
+        if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
+        int secs = args.toInt(); if (secs < 1) secs = 6; if (secs > 12) secs = 12;
+        if (g_rec_buf) { free(g_rec_buf); g_rec_buf = nullptr; }
+        g_rec_cap = (uint32_t)secs * 16000;
+        g_rec_buf = (int16_t*)heap_caps_malloc((size_t)g_rec_cap * sizeof(int16_t), MALLOC_CAP_SPIRAM);
+        if (!g_rec_buf) { Serial.println("T:ERR record alloc failed"); g_rec_cap = 0; return; }
+        g_rec_pos = 0;
+        if (!ui_manager->is_loopback()) ui_manager->start_loopback();
+        g_rec_active = true;
+        Serial.print("T:OK recording "); Serial.print(secs); Serial.print("s ");
+        Serial.print((unsigned long)g_rec_cap); Serial.println(" samples @16kHz raw CH0");
+    }
+    else if (cmd == "T:DUMPREC") {
+        // Transfer the recorded buffer as checksummed hex between REC_BEGIN/REC_END markers.
+        if (!g_rec_buf || g_rec_pos == 0) { Serial.println("T:ERR no recording"); return; }
+        uint32_t n = g_rec_pos, sum = 0;
+        for (uint32_t i = 0; i < n; i++) sum += (uint16_t)g_rec_buf[i];
+        Serial.print("REC_BEGIN "); Serial.print((unsigned long)n);
+        Serial.print(" 16000 "); Serial.println((unsigned long)sum);
+        static char line[520];
+        for (uint32_t i = 0; i < n; ) {
+            int p = 0;
+            for (int k = 0; k < 128 && i < n; k++, i++) p += sprintf(line + p, "%04X", (uint16_t)g_rec_buf[i]);
+            line[p] = 0; Serial.println(line);
+        }
+        Serial.println("REC_END");
     }
     else {
         Serial.print("T:ERR unknown cmd ");

--- a/tests/native/test_button_debouncer.cpp
+++ b/tests/native/test_button_debouncer.cpp
@@ -1,0 +1,42 @@
+#include <cstdint>
+#include <iostream>
+#include "ButtonDebouncer.h"
+
+using Hardware::TDeck::ButtonDebouncer;
+
+static int passed = 0;
+static int failed = 0;
+#define CHECK(expr) do { if (expr) { ++passed; } else { ++failed; std::cerr << "FAIL line " << __LINE__ << ": " #expr "\n"; } } while (0)
+
+int main() {
+    ButtonDebouncer d(50);
+    CHECK(!d.update(false, 0));
+    CHECK(!d.changed());
+
+    // A 30 ms active-low noise pulse must never become a press or release.
+    CHECK(!d.update(true, 100));
+    CHECK(!d.update(true, 129));
+    CHECK(!d.update(false, 130));
+    CHECK(!d.changed());
+
+    // Both edges must remain stable for the full debounce interval.
+    CHECK(!d.update(true, 200));
+    CHECK(!d.update(true, 249));
+    CHECK(d.update(true, 250));
+    CHECK(d.changed());
+    CHECK(d.update(false, 260));
+    CHECK(d.update(false, 309));
+    CHECK(!d.update(false, 310));
+    CHECK(d.changed());
+
+    // Unsigned subtraction keeps the interval correct across millis() wrap.
+    ButtonDebouncer wrap(50);
+    CHECK(!wrap.update(false, 0xFFFFFFE0u));
+    CHECK(!wrap.update(true, 0xFFFFFFF0u));
+    CHECK(!wrap.update(true, 0x00000020u));
+    CHECK(wrap.update(true, 0x00000022u));
+    CHECK(wrap.changed());
+
+    std::cout << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/native/test_button_debouncer.py
+++ b/tests/native/test_button_debouncer.py
@@ -1,0 +1,33 @@
+"""Compile and execute the portable trackball button debounce regression."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_button_debouncer.cpp"
+
+
+def test_button_debouncer(tmp_path):
+    cxx = shutil.which("clang++") or shutil.which("g++")
+    if not cxx:
+        pytest.skip("no C++ compiler found")
+    binary = tmp_path / "test_button_debouncer"
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        f"-I{PYXIS_ROOT / 'lib' / 'tdeck_ui' / 'Hardware' / 'TDeck'}",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(cmd, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "19 passed, 0 failed" in ran.stdout

--- a/tools/voice_test/.gitignore
+++ b/tools/voice_test/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+out/
+__pycache__/
+*.wav
+*.aiff

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -1,0 +1,39 @@
+# pyxis voice-quality test harness (acoustic loopback)
+
+Automated end-to-end test of the LXST voice pipeline using the **Mac speaker next to
+the T-Deck mic**. The Mac plays a known signal; the T-Deck captures it through the real
+pipeline (ES7210 mic → filters/AGC → Codec2 encode → `call_send_audio_batch` framing →
+`call_on_packet` parse → Codec2 decode) and streams the decoded PCM back over UDP. The
+harness re-aligns and scores the round-trip.
+
+## Physical setup
+- Mac built-in **speaker** within a few cm of the T-Deck **mic**, quiet room.
+- T-Deck on USB (serial control) **and** WiFi (UDP audio) — same LAN as the Mac.
+- Set the Mac output volume to a consistent moderate level.
+
+## Firmware contract (`T:LOOPBACK` test mode)
+- UDP multicast `239.0.99.99:9998`, each datagram = `[uint32 LE byte-offset][int16 LE
+  mono @ 8 kHz PCM]`, ≤1284 B.
+- Serial hooks: `T:CALL_PROFILE 0x10|0x20|0x30` (ULBW/VLBW/LBW), `T:LOOPBACK on|off`.
+
+## Run
+```bash
+cd tools/voice_test
+.venv/bin/python run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW,VLBW,LBW
+# options: --ref my.wav   --text "..."   --output "Mac mini Speakers"   --tail 1.2
+```
+
+Outputs `out/reference.wav` + `out/captured_<profile>.wav` (listen to confirm) and a
+summary table.
+
+## Metrics
+- **STOI** (0–1): objective intelligibility (≥0.55 ≈ intelligible). Primary score.
+- **corr**: time-aligned, gain-matched waveform correlation of the speech region.
+- **segSNR (dB)**: segmental SNR after alignment/gain-match.
+- **band**: speech-band (300–3400 Hz) energy survival vs reference.
+- **hf**: high-band (2–3.4 kHz) survival — Codec2 low profiles roll off the top.
+- **pkts / dropped**: UDP delivery health.
+
+Lower-bitrate profiles (700C) score lower by design; compare profiles and before/after
+firmware changes. The venv was created with `uv venv --python 3.12` +
+`numpy scipy soundfile sounddevice pyserial pystoi`.

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -37,3 +37,34 @@ summary table.
 Lower-bitrate profiles (700C) score lower by design; compare profiles and before/after
 firmware changes. The venv was created with `uv venv --python 3.12` +
 `numpy scipy soundfile sounddevice pyserial pystoi`.
+
+## Sideband/LXST end-to-end regression
+
+`sideband_e2e.py` uses the Mac's real RNS/LXST/Sideband Python stack and the
+T-Deck serial hooks to verify:
+
+- Pyxis calls Sideband and exchanges synthetic Codec2 audio in both directions.
+- Sideband calls Pyxis and exchanges synthetic Codec2 audio in both directions.
+- Pyxis still accepts another incoming call after both calls and hangups.
+- Every Pyxis decode succeeds and produces non-zero PCM.
+
+Build the test firmware with the Mac TCP server baked in, then upload it:
+
+```bash
+export PYXIS_TEST_TCP_HOST=10.0.0.145 PYXIS_TEST_TCP_PORT=4242
+/opt/homebrew/bin/pio run -e tdeck -t upload --upload-port /dev/cu.usbmodem101
+```
+
+Run from the Mac with its Reticulum venv (defaults to the local TCP server on
+`127.0.0.1:4242`):
+
+```bash
+~/.reticulum-host/venv/bin/python tools/voice_test/sideband_e2e.py
+```
+
+Optional overrides: `PYXIS_SERIAL_PORT`, `PYXIS_RNS_HOST`,
+`PYXIS_RNS_PORT`, and `PYXIS_CALL_SECONDS`. Each run uses a fresh Sideband
+identity and isolated RNS storage so stale cached paths cannot false-pass setup.
+On Apple Silicon the harness re-executes itself with `/opt/homebrew/lib` on
+`DYLD_LIBRARY_PATH`, allowing LXST/PyOgg to load Homebrew `libopus` for incoming
+calls.

--- a/tools/voice_test/inject_sweep.py
+++ b/tools/voice_test/inject_sweep.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Inject a sweep of known tones through the loopback and measure the output peak
+frequency for each. If output/input ratio is a constant != 1.0 -> sample-rate
+mismatch. If ~1.0 with high concentration -> codec faithfully preserves frequency
+(mic is the problem). If random/low concentration -> codec garbage."""
+import serial, socket, struct, time, threading, glob
+import numpy as np
+from scipy import signal as sps
+
+SR = 8000
+FREQS = [300, 500, 800, 1200, 1800, 2400]
+
+
+def port():
+    p = glob.glob("/dev/cu.usbmodem*"); return p[0] if p else "/dev/cu.usbmodem101"
+
+
+s0 = serial.Serial(port(), 115200); s0.setDTR(False); s0.setRTS(True); time.sleep(0.2); s0.setRTS(False); s0.close()
+print("reset; waiting for boot..."); time.sleep(18)
+
+s = serial.Serial(port(), 115200, timeout=1); time.sleep(0.3); s.reset_input_buffer()
+def cmd(c, w=0.6):
+    s.write((c + "\n").encode()); s.flush(); time.sleep(w)
+    return s.read(s.in_waiting).decode("utf-8", "replace")
+def lastok(r):
+    h = [l for l in r.splitlines() if "T:OK" in l]; return h[-1] if h else "(none)"
+
+if "T:OK" not in cmd("T:CALL_STATE"):
+    print("device not responding"); raise SystemExit(1)
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); sock.bind(("", 9998))
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                struct.pack("=4sl", socket.inet_aton("239.0.99.99"), socket.INADDR_ANY))
+sock.settimeout(0.5)
+chunks = {}; maxend = [0]; run = [True]; lock = threading.Lock()
+def rx():
+    while run[0]:
+        try:
+            d, _ = sock.recvfrom(2048)
+            if len(d) >= 4:
+                off = struct.unpack("<I", d[:4])[0]
+                with lock:
+                    chunks[off] = d[4:]; maxend[0] = max(maxend[0], off + len(d) - 4)
+        except Exception: pass
+threading.Thread(target=rx, daemon=True).start()
+
+cmd("T:BLE off", 1.8)
+print("profile :", lastok(cmd("T:CALL_PROFILE 0x30")))
+print("loopback:", lastok(cmd("T:LOOPBACK on", 1.0)))
+if "T:OK" not in cmd("T:CALL_STATE"):
+    print("device crashed after loopback on"); raise SystemExit(2)
+
+print(f"\n{'inject':>7} {'outPeak':>8} {'ratio':>6} {'conc':>5}")
+for fq in FREQS:
+    cmd(f"T:CALL_INJECT on {fq} 50", 0.3)
+    time.sleep(1.3)                          # let old audio drain (loopback latency)
+    with lock:
+        chunks.clear(); maxend[0] = 0
+    time.sleep(1.6)                          # capture the new tone
+    with lock:
+        end = maxend[0]; snap = dict(chunks)
+    buf = bytearray(end)
+    for off, p in snap.items():
+        e = min(off + len(p), end); buf[off:e] = p[:e - off]
+    pcm = np.frombuffer(bytes(buf), dtype="<i2").astype(float) / 32768.0
+    if len(pcm) < SR // 2:
+        print(f"{fq:7} {'short':>8}"); continue
+    f, pw = sps.welch(pcm, SR, nperseg=1024); pk = float(f[np.argmax(pw)])
+    conc = float(np.sum(pw[(f >= pk - 100) & (f <= pk + 100)]) / np.sum(pw))
+    print(f"{fq:7} {pk:8.0f} {pk/fq:6.3f} {conc:5.2f}")
+
+cmd("T:CALL_INJECT off"); cmd("T:LOOPBACK off")
+run[0] = False; s.close(); sock.close()
+print("\nIf ratio is a consistent value != 1.0 -> SAMPLE-RATE MISMATCH.")
+print("If ratio ~1.0 + conc high -> codec preserves freq (mic is the problem).")

--- a/tools/voice_test/inject_test.py
+++ b/tools/voice_test/inject_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Codec-isolation diagnostic: inject a known 1 kHz sine BEFORE the encoder
+(T:CALL_INJECT, which replaces the mic in i2s_capture) and loop it back. If the
+captured PCM is a clean ~1 kHz tone, the codec/framing/decode path is fine and the
+mic is the culprit; if it's broadband garbage, the codec path itself is broken.
+
+Resets the device first (the loopback teardown is currently flaky), waits for boot,
+verifies responsiveness, then runs one clean injection.
+
+Run:  .venv/bin/python inject_test.py [freq_hz] [amp_pct] [profile_hex]
+"""
+import sys, serial, socket, struct, time, threading, glob
+import numpy as np
+from scipy import signal as sps
+import soundfile as sf
+
+SR = 8000
+FREQ = int(sys.argv[1]) if len(sys.argv) > 1 else 1000
+AMP = int(sys.argv[2]) if len(sys.argv) > 2 else 50
+PROF = sys.argv[3] if len(sys.argv) > 3 else "0x30"
+
+
+def port():
+    p = glob.glob("/dev/cu.usbmodem*")
+    return p[0] if p else "/dev/cu.usbmodem101"
+
+
+def reset():
+    s = serial.Serial(port(), 115200)
+    s.setDTR(False); s.setRTS(True); time.sleep(0.2); s.setRTS(False); s.close()
+
+
+print(f"resetting device... (inject {FREQ}Hz @ {AMP}% through profile {PROF})")
+try:
+    reset()
+except Exception as e:
+    print("reset note:", e)
+time.sleep(18)
+
+s = serial.Serial(port(), 115200, timeout=1)
+time.sleep(0.3); s.reset_input_buffer()
+
+
+def cmd(c, w=0.6):
+    s.write((c + "\n").encode()); s.flush(); time.sleep(w)
+    return s.read(s.in_waiting).decode("utf-8", "replace")
+
+
+def line(resp, key):
+    hits = [l for l in resp.splitlines() if key in l]
+    return hits[-1] if hits else "(none)"
+
+
+st = cmd("T:CALL_STATE")
+if "T:OK" not in st:
+    print("device NOT responding after reset:", line(st, "T:")); sys.exit(1)
+print("device up:", line(st, "T:OK"))
+
+# UDP receiver
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("", 9998))
+sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
+                struct.pack("=4sl", socket.inet_aton("239.0.99.99"), socket.INADDR_ANY))
+sock.settimeout(0.5)
+chunks = {}; maxend = [0]; run = [True]
+def rx():
+    while run[0]:
+        try:
+            d, _ = sock.recvfrom(2048)
+            if len(d) >= 4:
+                off = struct.unpack("<I", d[:4])[0]; chunks[off] = d[4:]
+                maxend[0] = max(maxend[0], off + len(d) - 4)
+        except Exception:
+            pass
+threading.Thread(target=rx, daemon=True).start()
+
+cmd("T:BLE off", 1.8)
+print("profile :", line(cmd(f"T:CALL_PROFILE {PROF}"), "T:OK"))
+print("loopback:", line(cmd("T:LOOPBACK on", 1.0), "T:OK"))
+if "T:OK" not in cmd("T:CALL_STATE"):
+    print("device crashed after T:LOOPBACK on"); sys.exit(2)
+print("inject  :", line(cmd(f"T:CALL_INJECT on {FREQ} {AMP}", 0.6), "T:"))
+time.sleep(3)
+cmd("T:CALL_INJECT off"); cmd("T:LOOPBACK off")
+run[0] = False; time.sleep(0.3); s.close(); sock.close()
+
+buf = bytearray(maxend[0])
+for off, p in chunks.items():
+    e = min(off + len(p), maxend[0]); buf[off:e] = p[:e - off]
+pcm = np.frombuffer(bytes(buf), dtype="<i2").astype(float) / 32768.0
+print(f"captured {len(pcm)/SR:.2f}s, {len(chunks)} chunks")
+if len(pcm) > SR // 2:
+    f, pw = sps.welch(pcm, SR, nperseg=1024); pk = float(f[np.argmax(pw)])
+    conc = float(np.sum(pw[(f >= pk - 100) & (f <= pk + 100)]) / np.sum(pw))
+    rms = float(np.sqrt(np.mean(pcm ** 2)))
+    print(f"rms={rms:.4f}  peakFreq={pk:.0f}Hz  energy_concentration(+-100Hz)={conc:.2f}")
+    clean = conc > 0.45 and abs(pk - FREQ) < 250
+    print("VERDICT: CLEAN TONE -> codec OK, the MIC capture is the problem"
+          if clean else "VERDICT: GARBAGE/broadband -> the CODEC/encode-decode path is broken")
+    sf.write(f"out/inject_{FREQ}hz.wav", pcm, SR); print(f"saved out/inject_{FREQ}hz.wav")
+else:
+    print("no/short capture - loopback may have failed to stream")

--- a/tools/voice_test/run_voice_test.py
+++ b/tools/voice_test/run_voice_test.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""
+pyxis LXST voice-quality test harness (acoustic loopback).
+
+Physical setup: the Mac's speaker sits right next to the T-Deck's microphone.
+This harness plays a known reference signal out the Mac speaker; the T-Deck mic
+captures it, runs the real pipeline (ES7210 -> filters/AGC -> Codec2 encode ->
+call_send_audio_batch framing -> call_on_packet parse -> Codec2 decode), and dumps
+the decoded PCM back over UDP multicast. We re-align and score the round-trip so we
+can (a) confirm a profile produces intelligible audio and (b) compare profiles and
+before/after a firmware change.
+
+Firmware contract (T:LOOPBACK test mode):
+  - UDP multicast 239.0.99.99:9998, each datagram = [uint32 LE byte_offset][int16 LE
+    mono PCM @ 8 kHz], payload <= 1284 bytes.
+  - Serial T: hooks: `T:CALL_PROFILE 0x10|0x20|0x30` (ULBW/VLBW/LBW),
+    `T:LOOPBACK on`, `T:LOOPBACK off`.
+
+Usage:
+  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW,VLBW,LBW
+  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles LBW --ref my.wav
+
+Deps:  pip install numpy scipy soundfile sounddevice pyserial    (optional: pystoi)
+Make sure the Mac OUTPUT device is the built-in speaker next to the T-Deck, and
+turn the volume to a consistent, moderate level.
+"""
+
+import argparse, socket, struct, sys, time, threading, subprocess, os
+
+SR = 8000                         # Codec2 / pipeline sample rate
+MCAST_GRP, MCAST_PORT = "239.0.99.99", 9998
+PROFILES = {"ULBW": 0x10, "VLBW": 0x20, "LBW": 0x30}   # 700C / 1600 / 3200
+OUTDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+
+
+def _need(mods):
+    miss = []
+    for m in mods:
+        try:
+            __import__(m)
+        except ImportError:
+            miss.append(m)
+    if miss:
+        sys.exit(f"Missing deps: {', '.join(miss)}\n  pip install {' '.join(miss)}")
+
+
+_need(["numpy", "scipy", "soundfile", "sounddevice", "serial"])
+import numpy as np
+from scipy import signal as sps
+import soundfile as sf
+import sounddevice as sd
+import serial
+
+try:
+    from pystoi import stoi as _stoi
+    HAVE_STOI = True
+except Exception:
+    HAVE_STOI = False
+
+
+# ---------------- serial T: hooks ----------------
+class Dev:
+    def __init__(self, port, baud=115200):
+        self.s = serial.Serial(port, baud, timeout=1.0)
+        time.sleep(0.3)
+        self.s.reset_input_buffer()
+
+    def cmd(self, line, wait=0.4):
+        self.s.write((line + "\n").encode())
+        self.s.flush()
+        time.sleep(wait)
+        out = b""
+        while self.s.in_waiting:
+            out += self.s.read(self.s.in_waiting)
+            time.sleep(0.05)
+        return out.decode("utf-8", "replace")
+
+    def close(self):
+        try:
+            self.cmd("T:LOOPBACK off")
+        except Exception:
+            pass
+        self.s.close()
+
+
+# ---------------- UDP multicast receiver ----------------
+class PcmReceiver(threading.Thread):
+    """Collects [uint32 offset][int16 PCM] datagrams into a contiguous buffer."""
+
+    def __init__(self):
+        super().__init__(daemon=True)
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.bind(("", MCAST_PORT))
+        mreq = struct.pack("=4sl", socket.inet_aton(MCAST_GRP), socket.INADDR_ANY)
+        self.sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        self.sock.settimeout(0.5)
+        self.chunks = {}           # offset -> bytes
+        self.max_end = 0
+        self.packets = 0
+        self._run = True
+
+    def run(self):
+        while self._run:
+            try:
+                data, _ = self.sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            if len(data) < 4:
+                continue
+            off = struct.unpack("<I", data[:4])[0]
+            pcm = data[4:]
+            self.chunks[off] = pcm
+            self.packets += 1
+            self.max_end = max(self.max_end, off + len(pcm))
+
+    def stop(self):
+        self._run = False
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+    def assemble(self):
+        """Return int16 PCM with gaps zero-filled, plus a dropped-byte count."""
+        buf = bytearray(self.max_end)
+        filled = bytearray(self.max_end)
+        for off, pcm in self.chunks.items():
+            end = min(off + len(pcm), self.max_end)
+            buf[off:end] = pcm[: end - off]
+            for i in range(off, end):
+                filled[i] = 1
+        dropped = self.max_end - sum(filled)
+        pcm = np.frombuffer(bytes(buf), dtype="<i2").astype(np.float32) / 32768.0
+        return pcm, dropped
+
+
+# ---------------- reference signal ----------------
+def build_reference(speech_text):
+    """[1s log chirp 200-3400 Hz][0.4s silence][speech] at 8 kHz, float32 in [-1,1].
+
+    The chirp gives a sharp cross-correlation peak for alignment + a frequency
+    sweep to see which bands survive. Speech (via macOS `say`) drives intelligibility.
+    """
+    t = np.linspace(0, 1.0, SR, endpoint=False)
+    chirp = 0.6 * sps.chirp(t, f0=200, f1=3400, t1=1.0, method="logarithmic").astype(np.float32)
+    chirp *= np.hanning(len(chirp)).astype(np.float32) ** 0.25
+    gap = np.zeros(int(0.4 * SR), np.float32)
+
+    speech = np.zeros(0, np.float32)
+    try:
+        os.makedirs(OUTDIR, exist_ok=True)
+        aiff = os.path.join(OUTDIR, "_say.aiff")
+        subprocess.run(["say", "-o", aiff, speech_text], check=True)
+        sp, sr0 = sf.read(aiff)
+        if sp.ndim > 1:
+            sp = sp.mean(axis=1)
+        if sr0 != SR:
+            sp = sps.resample(sp, int(len(sp) * SR / sr0))
+        sp = sp.astype(np.float32)
+        sp = 0.7 * sp / (np.max(np.abs(sp)) + 1e-9)
+        speech = sp
+    except Exception as e:
+        print(f"  (say unavailable: {e}; using tone triplet instead)")
+        tt = np.linspace(0, 1.5, int(1.5 * SR), endpoint=False)
+        speech = 0.5 * (np.sin(2 * np.pi * 500 * tt) + np.sin(2 * np.pi * 1200 * tt)
+                        + np.sin(2 * np.pi * 2400 * tt)).astype(np.float32) / 3
+
+    ref = np.concatenate([chirp, gap, speech]).astype(np.float32)
+    return ref, len(chirp)
+
+
+# ---------------- scoring ----------------
+def _env(x):
+    """Smoothed amplitude envelope (~20 Hz). Codec2 is a vocoder — the waveform is
+    NOT preserved, but the energy envelope is, so we align/score on the envelope."""
+    e = np.abs(sps.hilbert(x))
+    b, a = sps.butter(2, 20 / (SR / 2))
+    return sps.filtfilt(b, a, e).astype(np.float32)
+
+
+def align(ref, cap):
+    """Align via energy-envelope cross-correlation (vocoder-safe)."""
+    er, ec = _env(ref), _env(cap)
+    xc = sps.correlate(ec, er, mode="full")
+    lag = int(np.argmax(xc) - (len(er) - 1))
+    if lag < 0:
+        lag = 0
+    cap = cap[lag:]
+    m = min(len(ref), len(cap))
+    return ref[:m], cap[:m], lag
+
+
+def band_energy(x, lo, hi):
+    f, p = sps.welch(x, SR, nperseg=min(1024, len(x)))
+    m = (f >= lo) & (f <= hi)
+    return float(np.sum(p[m]))
+
+
+def score(ref_full, cap_full, chirp_len):
+    """Return a dict of metrics, scoring on the SPEECH part (after the chirp+gap)."""
+    res = {}
+    if len(cap_full) < SR // 2:
+        res["error"] = f"no/short audio captured ({len(cap_full)} samples)"
+        return res, ref_full, cap_full
+    ref, cap, lag = align(ref_full, cap_full)
+    res["lag_ms"] = round(lag * 1000 / SR, 1)
+    if len(cap) < SR:
+        res["error"] = "captured audio too short to score"
+        return res, ref, cap
+
+    # Score the speech region (skip chirp + gap)
+    start = chirp_len + int(0.4 * SR)
+    r = ref[start:] if len(ref) > start else ref
+    c = cap[start:] if len(cap) > start else cap
+    m = min(len(r), len(c))
+    r, c = r[:m], c[:m]
+    if m < SR // 2:
+        res["error"] = "speech region too short"
+        return res, ref, cap
+
+    # env_conf: does the capture actually CONTAIN the reference? (envelope corr after
+    # alignment). Low -> the mic isn't hearing the playback; the rest is then moot.
+    res["env_conf"] = round(float(np.corrcoef(_env(r), _env(c))[0, 1]), 2)
+
+    # spectral-envelope correlation over time (vocoder-appropriate fidelity proxy)
+    _, _, Sr = sps.spectrogram(r, SR, nperseg=256, noverlap=128)
+    _, _, Sc = sps.spectrogram(c, SR, nperseg=256, noverlap=128)
+    mm = min(Sr.shape[1], Sc.shape[1])
+    Lr, Lc = np.log(Sr[:, :mm] + 1e-9), np.log(Sc[:, :mm] + 1e-9)
+    res["spec_corr"] = round(float(np.corrcoef(Lr.flatten(), Lc.flatten())[0, 1]), 3)
+
+    # speech-band survival (energy-normalized)
+    g = np.sqrt((np.dot(r, r) + 1e-9) / (np.dot(c, c) + 1e-9))
+    res["band"] = round((band_energy(c * g, 300, 3400) + 1e-12) / (band_energy(r, 300, 3400) + 1e-12), 2)
+
+    if HAVE_STOI:
+        try:
+            res["stoi"] = round(float(_stoi(r, c, SR, extended=False)), 3)
+        except Exception:
+            res["stoi"] = "err"
+    return res, ref, cap
+
+
+def verdict(res):
+    if "error" in res:
+        return "FAIL (" + res["error"] + ")"
+    if res.get("env_conf", 0) < 0.3:
+        return "NO-CAPTURE (mic not hearing playback)"
+    s = res.get("stoi")
+    if isinstance(s, float):
+        return "INTELLIGIBLE" if s >= 0.55 else ("MARGINAL" if s >= 0.45 else "POOR")
+    return "?"
+
+
+# ---------------- one profile run ----------------
+def run_profile(dev, name, ref, chirp_len, tail_s):
+    print(f"\n=== profile {name} (0x{PROFILES[name]:02X}) ===")
+    print("  set profile:", dev.cmd(f"T:CALL_PROFILE 0x{PROFILES[name]:02X}").strip())
+    rx = PcmReceiver(); rx.start()
+    time.sleep(0.2)
+    print("  loopback on:", dev.cmd("T:LOOPBACK on").strip())
+    time.sleep(0.6)                      # let capture/playback spin up
+    sd.play(ref, SR); sd.wait()          # play reference out the Mac speaker
+    time.sleep(tail_s)                   # drain pipeline latency (~1 s)
+    dev.cmd("T:LOOPBACK off")
+    time.sleep(0.3); rx.stop(); rx.join(timeout=1)
+
+    cap, dropped = rx.assemble()
+    os.makedirs(OUTDIR, exist_ok=True)
+    sf.write(os.path.join(OUTDIR, f"captured_{name}.wav"), cap, SR)
+    res, refA, capA = score(ref, cap, chirp_len)
+    res["packets"] = rx.packets
+    res["cap_sec"] = round(len(cap) / SR, 2)
+    res["dropped_bytes"] = dropped
+    print(f"  packets={rx.packets} cap={res['cap_sec']}s dropped={dropped}B lag={res.get('lag_ms','?')}ms")
+    print(f"  -> {verdict(res)}  {{ " +
+          ", ".join(f"{k}={res[k]}" for k in
+                    ("stoi", "env_conf", "spec_corr", "band", "lag_ms") if k in res) + " }")
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", default="/dev/cu.usbmodem101")
+    ap.add_argument("--profiles", default="ULBW,VLBW,LBW")
+    ap.add_argument("--ref", help="reference WAV (else generated chirp+speech)")
+    ap.add_argument("--text", default="The quick brown fox jumps over the lazy dog. "
+                    "She sells seashells. Numbers: one two three four five.")
+    ap.add_argument("--tail", type=float, default=1.2, help="post-play drain seconds")
+    ap.add_argument("--output", default="speaker",
+                    help="output device name substring (the Mac speaker next to the T-Deck mic)")
+    args = ap.parse_args()
+
+    # Select the output device so audio plays out the speaker (not a monitor/HDMI).
+    out_dev = next((i for i, d in enumerate(sd.query_devices())
+                    if d["max_output_channels"] > 0 and args.output.lower() in d["name"].lower()), None)
+    if out_dev is not None:
+        sd.default.device = (None, out_dev)
+        print(f"output device: {sd.query_devices(out_dev)['name']}")
+    else:
+        print(f"output device: system default (no '{args.output}' match)")
+
+    os.makedirs(OUTDIR, exist_ok=True)
+    if args.ref:
+        ref, sr0 = sf.read(args.ref)
+        if ref.ndim > 1:
+            ref = ref.mean(axis=1)
+        if sr0 != SR:
+            ref = sps.resample(ref, int(len(ref) * SR / sr0))
+        ref = (0.7 * ref / (np.max(np.abs(ref)) + 1e-9)).astype(np.float32)
+        chirp_len = 0
+    else:
+        ref, chirp_len = build_reference(args.text)
+    sf.write(os.path.join(OUTDIR, "reference.wav"), ref, SR)
+    print(f"reference: {len(ref)/SR:.2f}s  STOI={'yes' if HAVE_STOI else 'no (pip install pystoi)'}  out={OUTDIR}")
+
+    dev = Dev(args.port)
+    results = {}
+    try:
+        # The mic-capture FreeRTOS task needs a contiguous internal-heap stack;
+        # BLE holds enough heap to make that allocation fail intermittently. Free it
+        # for the duration of the test, restore after.
+        print("BLE off (free heap):", dev.cmd("T:BLE off", wait=1.8).strip().splitlines()[-1:])
+        for name in [p.strip().upper() for p in args.profiles.split(",") if p.strip()]:
+            if name not in PROFILES:
+                print(f"  skip unknown profile {name}"); continue
+            results[name] = run_profile(dev, name, ref, chirp_len, args.tail)
+    finally:
+        try:
+            dev.cmd("T:BLE on")
+        except Exception:
+            pass
+        dev.close()
+
+    print("\n================ SUMMARY ================")
+    hdr = f"{'profile':7} {'verdict':33} {'stoi':6} {'envConf':7} {'specCorr':8} {'band':5} {'pkts':5}"
+    print(hdr); print("-" * len(hdr))
+    for name, r in results.items():
+        print(f"{name:7} {verdict(r):33} {str(r.get('stoi','-')):6} {str(r.get('env_conf','-')):7} "
+              f"{str(r.get('spec_corr','-')):8} {str(r.get('band','-')):5} {str(r.get('packets','-')):5}")
+    print(f"\nWAVs in {OUTDIR}/ (reference.wav, captured_<profile>.wav) — listen to confirm.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/voice_test/sideband_e2e.py
+++ b/tools/voice_test/sideband_e2e.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+import glob, math, os, re, sys, threading, time
+from types import SimpleNamespace
+
+# Homebrew's arm64 libopus is not in dyld's default search path for the
+# Xcode-provided Python used by the Mac Reticulum venv. Re-exec before LXST is
+# imported so PyOgg can construct the default incoming-call codec.
+if sys.platform == "darwin" and not os.environ.get("PYXIS_DYLD_READY"):
+    env = os.environ.copy()
+    paths = [p for p in env.get("DYLD_LIBRARY_PATH", "").split(":") if p]
+    if "/opt/homebrew/lib" not in paths:
+        paths.insert(0, "/opt/homebrew/lib")
+    env["DYLD_LIBRARY_PATH"] = ":".join(paths)
+    env["PYXIS_DYLD_READY"] = "1"
+    os.execve(sys.executable, [sys.executable] + sys.argv, env)
+
+HOME = os.path.expanduser("~")
+sys.path.insert(0, os.path.join(HOME, "repos", "LXST"))
+sys.path.insert(0, os.path.join(HOME, "repos", "Sideband", "sbapp"))
+sys.path.append(os.path.join(HOME, "Library", "Python", "3.9", "lib", "python", "site-packages"))
+
+import numpy as np
+import serial
+import RNS
+import LXST.Sources as Sources
+import LXST.Sinks as Sinks
+from LXST.Codecs.Codec2 import Codec2
+from LXST.Primitives.Telephony import Profiles
+from sideband.voice import ReticulumTelephone
+
+PORT = os.environ.get("PYXIS_SERIAL_PORT") or sorted(glob.glob("/dev/cu.usbmodem*"))[0]
+PROFILE = Profiles.BANDWIDTH_ULTRA_LOW
+RUN_SECONDS = float(os.environ.get("PYXIS_CALL_SECONDS", "7"))
+
+class Stats:
+    lock = threading.Lock()
+    encodes = 0
+    encode_bytes = 0
+    decodes = 0
+    decode_samples = 0
+    decode_sumsq = 0.0
+    sink_frames = 0
+    sink_samples = 0
+
+orig_encode = Codec2.encode
+orig_decode = Codec2.decode
+
+def counted_encode(self, frame):
+    out = orig_encode(self, frame)
+    with Stats.lock:
+        Stats.encodes += 1
+        Stats.encode_bytes += len(out)
+    return out
+
+def counted_decode(self, frame):
+    out = orig_decode(self, frame)
+    with Stats.lock:
+        Stats.decodes += 1
+        Stats.decode_samples += int(out.size)
+        Stats.decode_sumsq += float(np.sum(np.square(out.astype(np.float64))))
+    return out
+
+Codec2.encode = counted_encode
+Codec2.decode = counted_decode
+
+class FakeRecorder:
+    def __init__(self):
+        self.phase = 0
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def record(self, numframes):
+        n = int(numframes)
+        idx = np.arange(n, dtype=np.float64) + self.phase
+        t = idx / 8000.0
+        env = 0.55 + 0.45*np.sin(2*math.pi*120*t)
+        x = env*(0.55*np.sin(2*math.pi*730*t) + 0.30*np.sin(2*math.pi*1095*t) + 0.15*np.sin(2*math.pi*2409*t))
+        self.phase += n
+        time.sleep(n/8000.0)
+        return (0.35*x).astype(np.float32).reshape(-1,1)
+
+class FakeSourceBackend:
+    SAMPLERATE = 8000
+    def __init__(self, preferred_device=None, samplerate=8000):
+        self.samplerate = 8000
+        self.channels = 1
+        self.bitdepth = 32
+        self.device = SimpleNamespace(channels=1)
+    def get_recorder(self, samples_per_frame=None): return FakeRecorder()
+    def release_recorder(self): pass
+    def flush(self): pass
+    def all_microphones(self): return []
+    def default_microphone(self): return None
+
+class FakePlayer:
+    def __enter__(self): return self
+    def __exit__(self, *args): return False
+    def play(self, frame):
+        with Stats.lock:
+            Stats.sink_frames += 1
+            Stats.sink_samples += int(frame.size)
+
+class FakeSinkBackend:
+    SAMPLERATE = 8000
+    def __init__(self, preferred_device=None, samplerate=8000):
+        self.samplerate = 8000
+        self.device = SimpleNamespace(channels=1)
+    def get_player(self, samples_per_frame=None, low_latency=None): return FakePlayer()
+    def release_player(self): pass
+    def flush(self): pass
+    def all_speakers(self): return []
+    def default_speaker(self): return None
+
+Sources.Backend = FakeSourceBackend
+Sinks.Backend = FakeSinkBackend
+
+class Dev:
+    def __init__(self):
+        self.s = serial.Serial(PORT, 115200, timeout=0.12)
+        self.crash_trace = False
+        time.sleep(0.4)
+        self.s.reset_input_buffer()
+    def cmd(self, line, timeout=4):
+        self.s.write((line+"\n").encode()); self.s.flush()
+        deadline = time.time()+timeout; lines=[]
+        while time.time()<deadline:
+            raw=self.s.readline()
+            if not raw: continue
+            text=raw.decode("utf-8","replace").strip()
+            if text: lines.append(text)
+            if "Guru Meditation" in text:
+                self.crash_trace = True
+            if text and (self.crash_trace or "LXST" in text or "Link" in text or "PANIC" in text):
+                print(f"PYXIS_LOG {text}", flush=True)
+            if self.crash_trace and "ELF file SHA256" in text:
+                self.crash_trace = False
+            if text.startswith("T:OK") or text.startswith("T:ERR"):
+                return text, lines
+        return None, lines
+    def state(self):
+        r,_=self.cmd("T:CALL_STATE")
+        return r.split("state=",1)[1] if r and "state=" in r else "?"
+    def wait_state(self, wanted, timeout=30):
+        deadline=time.time()+timeout; seen=[]
+        while time.time()<deadline:
+            st=self.state(); seen.append(st)
+            if st==wanted: return True,seen
+            time.sleep(0.35)
+        return False,seen
+    def close(self): self.s.close()
+
+def val(resp,key):
+    m=re.search(rf"\b{re.escape(key)}=([0-9]+)",resp or "")
+    return int(m.group(1)) if m else -1
+
+def wait_path_rns(dest, timeout=30):
+    deadline=time.time()+timeout
+    while time.time()<deadline:
+        if RNS.Transport.has_path(dest): return True
+        RNS.Transport.request_path(dest)
+        time.sleep(0.7)
+    return False
+
+def wait_path_pyxis(dev,desthex,timeout=45):
+    deadline=time.time()+timeout
+    while time.time()<deadline:
+        r,_=dev.cmd("T:HASPATH "+desthex)
+        # Firmware includes diagnostic suffixes (`mem=... mem_count=...`).
+        if r and r.startswith("T:OK 1"): return True
+        time.sleep(0.8)
+    return False
+
+class Owner:
+    def __init__(self):
+        self.config={"voice_trusted_only":False}
+        self.events=[]
+    def voice_is_trusted(self,h): return True
+    def setstate(self,*a): self.events.append(("state",a))
+    def incoming_call(self,i): self.events.append(("incoming",i.hash.hex()))
+    def ended_call(self,i): self.events.append(("ended",i.hash.hex()))
+    def missed_call(self,i): self.events.append(("missed",i.hash.hex()))
+
+def snapshot():
+    with Stats.lock:
+        return dict(encodes=Stats.encodes, encode_bytes=Stats.encode_bytes, decodes=Stats.decodes,
+                    decode_samples=Stats.decode_samples, decode_sumsq=Stats.decode_sumsq,
+                    sink_frames=Stats.sink_frames, sink_samples=Stats.sink_samples)
+
+def delta(a,b): return {k:b[k]-a[k] for k in a}
+
+def run_audio(dev, label):
+    before=snapshot()
+    dev.cmd("T:CALL_INJECT on 730 50")
+    time.sleep(RUN_SECONDS)
+    dev.cmd("T:CALL_INJECT off")
+    qos,_=dev.cmd("T:CALL_QOS")
+    stat,_=dev.cmd("T:CALL_STATS")
+    after=snapshot(); d=delta(before,after)
+    rms=(d["decode_sumsq"]/d["decode_samples"])**0.5 if d["decode_samples"]>0 else 0
+    print(f"{label} SIDEBAND_DELTA={d} sideband_decode_rms={rms:.5f}",flush=True)
+    print(f"{label} PYXIS_QOS={qos}",flush=True)
+    print(f"{label} PYXIS_STATS={stat}",flush=True)
+    ok=(d["encodes"]>0 and d["decodes"]>0 and d["decode_samples"]>0 and
+        val(qos,"decode_ok")>0 and val(qos,"decode_fail")==0 and val(qos,"pcm_n")>0)
+    return ok,{"sideband":d,"qos":qos,"stats":stat,"rms":rms}
+
+def main():
+    print(f"PORT={PORT}",flush=True)
+    dev=Dev()
+    owner=Owner()
+    # Use a fresh identity and isolated RNS storage on every run so cached paths
+    # cannot make wait_path_rns() pass before the current Pyxis announce arrives.
+    identity=RNS.Identity()
+    config_dir=f"/tmp/pyxis-sideband-rns-{os.getpid()}"
+    os.makedirs(config_dir,exist_ok=True)
+    rns_host=os.environ.get("PYXIS_RNS_HOST","127.0.0.1")
+    rns_port=int(os.environ.get("PYXIS_RNS_PORT","4242"))
+    with open(os.path.join(config_dir,"config"),"w") as f:
+        f.write(f"""[reticulum]\nenable_transport = No\nshare_instance = No\nshared_instance_port = 48428\ninstance_control_port = 48429\n\n[logging]\nloglevel = 5\n\n[interfaces]\n  [[Pyxis troubleshooting hub]]\n    type = TCPClientInterface\n    enabled = yes\n    target_host = {rns_host}\n    target_port = {rns_port}\n""")
+    print(f"RNS_TEST_HUB={rns_host}:{rns_port}",flush=True)
+    reticulum=RNS.Reticulum(configdir=config_dir,loglevel=5)
+    phone=ReticulumTelephone(identity, owner=owner)
+    phone.telephone.auto_answer=0.6
+    phone.announce()
+    side_id=identity.hash.hex(); side_dest=phone.telephone.destination.hash.hex()
+    py_id=(dev.cmd("T:ID")[0] or "").split()[-1]
+    py_dest=(dev.cmd("T:LXSTDEST")[0] or "").split()[-1]
+    print(f"SIDE_ID={side_id} SIDE_DEST={side_dest}",flush=True)
+    print(f"PYXIS_ID={py_id} PYXIS_DEST={py_dest}",flush=True)
+    dev.cmd("T:BLE off",timeout=5)
+    dev.cmd("T:CALL_PROFILE 0x10")
+    dev.cmd("T:ANNLXST")
+    phone.announce()
+    results=[]
+    try:
+        # Pyxis -> Sideband first. This proves Pyxis learned the fresh peer
+        # announce before testing the reciprocal incoming route.
+        phone.announce(); dev.cmd("T:ANNLXST")
+        assert wait_path_pyxis(dev,side_dest,45),"Pyxis did not learn Sideband LXST path"
+        print("TEST1 dialing Pyxis -> Sideband",flush=True)
+        print("TEST1 call",dev.cmd("T:CALL "+side_dest)[0],flush=True)
+        ok,seen=dev.wait_state("ACTIVE",35); print("TEST1 states_to_active",seen,flush=True); assert ok
+        deadline=time.time()+15
+        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        assert phone.is_in_call,"Sideband did not become active on incoming call"
+        ok,data=run_audio(dev,"TEST1")
+        results.append(("pyxis_to_sideband_bidirectional",ok,data))
+        dev.cmd("T:CALL_HANGUP"); dev.wait_state("IDLE",15); time.sleep(1)
+
+        # Sideband -> Pyxis after a completed outgoing call.
+        dev.cmd("T:ANNLXST"); phone.announce()
+        assert wait_path_rns(bytes.fromhex(py_dest),45),"Sideband did not learn Pyxis LXST path"
+        print("TEST2 dialing Sideband -> Pyxis",flush=True)
+        assert phone.dial(bytes.fromhex(py_id),profile=PROFILE)!="no_path"
+        ok,seen=dev.wait_state("INCOMING_RINGING",25); print("TEST2 states_to_ring",seen,flush=True); assert ok
+        print("TEST2 answer",dev.cmd("T:CALL_ANSWER")[0],flush=True)
+        ok,seen=dev.wait_state("ACTIVE",25); print("TEST2 states_to_active",seen,flush=True); assert ok
+        deadline=time.time()+15
+        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        assert phone.is_in_call,"Sideband did not become active"
+        ok,data=run_audio(dev,"TEST2")
+        results.append(("sideband_to_pyxis_bidirectional",ok,data))
+        phone.hangup(); dev.wait_state("IDLE",15); time.sleep(1)
+
+        # Regression: incoming callback must still work after prior hangups.
+        dev.cmd("T:ANNLXST"); assert wait_path_rns(bytes.fromhex(py_dest),20)
+        print("TEST3 redial Sideband -> Pyxis after completed calls",flush=True)
+        r=phone.dial(bytes.fromhex(py_id),profile=PROFILE)
+        ok,seen=dev.wait_state("INCOMING_RINGING",15); print("TEST3 states_to_ring",seen,flush=True)
+        results.append(("incoming_after_hangups",ok,{"dial":r,"states":seen}))
+        if ok: dev.cmd("T:CALL_HANGUP")
+        elif phone.telephone.active_call: phone.hangup()
+    finally:
+        try: dev.cmd("T:CALL_INJECT off")
+        except Exception: pass
+        try:
+            if phone.telephone and phone.telephone.active_call: phone.hangup()
+            phone.stop()
+        except Exception as e: print("PHONE_CLEANUP",repr(e),flush=True)
+        try: dev.cmd("T:BLE on",timeout=5)
+        except Exception: pass
+        dev.close()
+    print("RESULTS",results,flush=True)
+    return 0 if all(x[1] for x in results) else 1
+
+if __name__=="__main__":
+    try: raise SystemExit(main())
+    except Exception as e:
+        import traceback; traceback.print_exc(); raise SystemExit(2)


### PR DESCRIPTION
## Summary

- stabilizes full-duplex LXST voice calls on the T-Deck within live-device memory limits
- hardens audio capture/playback and call lifecycle behavior used with Sideband
- preserves Reticulum announce paths on ESP32 by enforcing an absolute LittleFS path-store prefix
- includes the physical voice-test harness and input debounce fixes from the validated branch history

## Validation

- `pio run -e tdeck` succeeds
- firmware uploaded successfully and image hash verified
- live Reticulum path table increased from 0 retained paths to 15 after the LittleFS fix
- completed an approximately one-minute full-duplex call with Sideband
- call setup, answer, bidirectional audio, and teardown worked

## Known limitations and risk

- the physical call had a few approximately half-second audio drops; overall quality was judged sufficient for review
- this PR intentionally publishes the complete physically validated seven-commit branch as-is, including test harness and input debounce changes
- mixed-version calls between different Pyxis firmware generations are not claimed as supported by this change

## Rollback

The pre-fix physical baseline remains identifiable at commit `31631b0`. The validated PR head adds the ESP32 path-store correction on top of that baseline.
