### PR TITLE
fix: preserve LXMF messages across reboot and OTA

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/ChatScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/ChatScreen.cpp
@@ -605,11 +605,11 @@ void ChatScreen::on_send_clicked(lv_event_t* event) {
     String message(text);
 
     if (message.length() > 0 && screen->_send_message_callback) {
-        screen->_send_message_callback(message);
-
-        // Clear text area and keep focus for next message
-        lv_textarea_set_text(screen->_text_area, "");
-        lv_group_focus_obj(screen->_text_area);
+        if (screen->_send_message_callback(message)) {
+            // Clear only after persistence and queue admission succeed.
+            lv_textarea_set_text(screen->_text_area, "");
+            lv_group_focus_obj(screen->_text_area);
+        }
     }
 }
 

--- a/lib/tdeck_ui/UI/LXMF/ChatScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/ChatScreen.h
@@ -61,7 +61,7 @@ public:
      * Callback types
      */
     using BackCallback = std::function<void()>;
-    using SendMessageCallback = std::function<void(const String& content)>;
+    using SendMessageCallback = std::function<bool(const String& content)>;
     using CallCallback = std::function<void()>;
 
     /**

--- a/lib/tdeck_ui/UI/LXMF/ComposeScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/ComposeScreen.cpp
@@ -289,12 +289,10 @@ void ComposeScreen::on_send_clicked(lv_event_t* event) {
     Bytes dest_hash;
     dest_hash.assignHex(dest_hash_str.c_str());
 
-    if (screen->_send_callback) {
-        screen->_send_callback(dest_hash, message);
+    if (screen->_send_callback && screen->_send_callback(dest_hash, message)) {
+        // Clear only after persistence and queue admission succeed.
+        screen->clear();
     }
-
-    // Clear form
-    screen->clear();
 }
 
 bool ComposeScreen::validate_destination_hash(const String& hash_str) {

--- a/lib/tdeck_ui/UI/LXMF/ComposeScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/ComposeScreen.h
@@ -42,7 +42,7 @@ public:
      * Callback types
      */
     using CancelCallback = std::function<void()>;
-    using SendCallback = std::function<void(const RNS::Bytes& dest_hash, const String& message)>;
+    using SendCallback = std::function<bool(const RNS::Bytes& dest_hash, const String& message)>;
 
     /**
      * Create compose screen

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -1312,6 +1312,13 @@ void SettingsScreen::set_lxmf_address(const Bytes& hash) {
     _lxmf_address = hash;
 }
 
+void SettingsScreen::set_firmware_version(const String& version) {
+    if (_label_firmware) {
+        String text = "Firmware: " + version;
+        lv_label_set_text(_label_firmware, text.c_str());
+    }
+}
+
 void SettingsScreen::set_gps(TinyGPSPlus* gps) {
     _gps = gps;
 }

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -8,7 +8,7 @@
 
 #include <WiFi.h>
 #include "../LVGL/LVGLLock.h"
-#include <SPIFFS.h>
+#include <LittleFS.h>
 #include <TinyGPSPlus.h>
 #include <microReticulum/Log.h>
 #include <microReticulum/Utilities/OS.h>
@@ -753,7 +753,7 @@ void SettingsScreen::create_system_section(lv_obj_t* parent) {
 
     _label_identity_hash = create_label_row(parent, "Identity: --");
     _label_lxmf_address = create_label_row(parent, "LXMF: --");
-    _label_firmware = create_label_row(parent, "Firmware: v1.0.0");
+    _label_firmware = create_label_row(parent, "Firmware: " FIRMWARE_VERSION);
     _label_storage = create_label_row(parent, "Storage: --");
     _label_ram = create_label_row(parent, "RAM: --");
 }
@@ -1292,10 +1292,15 @@ void SettingsScreen::update_system_info() {
     }
 
     // Storage
-    size_t total = SPIFFS.totalBytes();
-    size_t used = SPIFFS.usedBytes();
-    size_t free = total - used;
-    String storage = "Storage: " + String(free / 1024) + " KB free";
+    size_t total = LittleFS.totalBytes();
+    size_t used = LittleFS.usedBytes();
+    String storage;
+    if (total == 0 || used > total) {
+        storage = "Storage: unavailable";
+    } else {
+        size_t free = total - used;
+        storage = "Storage: " + String(free / 1024) + " KB free";
+    }
     lv_label_set_text(_label_storage, storage.c_str());
 
     // RAM

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
@@ -176,6 +176,9 @@ public:
      */
     void set_lxmf_address(const RNS::Bytes& hash);
 
+    /** Set the exact running firmware build for post-reboot verification. */
+    void set_firmware_version(const String& version);
+
     /**
      * Set GPS pointer for status display
      */

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -930,14 +930,6 @@ void UIManager::on_message_delivered(::LXMF::LXMessage& message) {
     std::string msg = "Message delivered: " + hash_hex + "...";
     INFO(msg.c_str());
 
-    if (!_store.update_message_state(
-            message.hash(), ::LXMF::Type::Message::State::DELIVERED)) {
-        ERROR("Delivered message state persistence failed");
-        LVGL_LOCK();
-        show_storage_error("Delivery status could not be saved. Check device storage.");
-        return;
-    }
-
     LVGL_LOCK();
     // Update UI if we're viewing this conversation
     if (_current_screen == SCREEN_CHAT && _current_peer_hash == message.destination_hash()) {

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -34,6 +34,26 @@ static const char* KEY_STAMP_COST = "stamp_cost";
 namespace UI {
 namespace LXMF {
 
+namespace {
+
+void close_storage_error(lv_event_t* event) {
+    lv_obj_t* message_box = lv_event_get_current_target(event);
+    if (lv_msgbox_get_active_btn(message_box) == 0) {
+        lv_msgbox_close(message_box);
+    }
+}
+
+void show_storage_error(const char* message) {
+    static const char* buttons[] = {"OK", ""};
+    lv_obj_t* message_box = lv_msgbox_create(
+        nullptr, "Message not saved", message, buttons, false
+    );
+    lv_obj_center(message_box);
+    lv_obj_add_event_cb(message_box, close_storage_error, LV_EVENT_VALUE_CHANGED, nullptr);
+}
+
+}  // namespace
+
 // Static singleton for Link callbacks
 UIManager* UIManager::s_call_instance = nullptr;
 
@@ -811,13 +831,18 @@ void UIManager::send_message(const Bytes& dest_hash, const String& content) {
     // Pack the message to generate hash and signature before saving
     message.pack();
 
-    // Add to UI immediately (optimistic update)
+    // Do not transmit or display an outgoing message unless both its payload
+    // and conversation index were committed. Otherwise a reboot makes an
+    // apparently-sent message disappear from history.
+    if (!_store.save_message(message)) {
+        ERROR("Outgoing message persistence failed; message not queued");
+        show_storage_error("Storage is unavailable. The message was not sent.");
+        return;
+    }
+
     if (_current_screen == SCREEN_CHAT && _current_peer_hash == dest_hash) {
         _chat_screen->add_message(message, true);
     }
-
-    // Save to store (now has valid hash from pack())
-    _store.save_message(message);
 
     // Queue for sending (pack already called, will use cached packed data)
     _router.handle_outbound(message);
@@ -844,8 +869,14 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
     // (void)RNS::Identity::mark_persistent(message.source_hash());
 
     // Save to store — no LVGL lock; LittleFS GC is allowed to take its
-    // time without freezing the UI thread.
-    _store.save_message(message);
+    // time without freezing the UI thread. Do not present an in-memory-only
+    // message as durable conversation history.
+    if (!_store.save_message(message)) {
+        ERROR("Incoming message persistence failed; message not added to history");
+        LVGL_LOCK();
+        show_storage_error("An incoming message could not be saved. Check device storage.");
+        return;
+    }
 
     // Take the LVGL lock now for the UI-touching code below.
     LVGL_LOCK();

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -825,9 +825,17 @@ bool UIManager::send_message(const Bytes& dest_hash, const String& content) {
         WARNING("  Destination identity not known, message may fail until peer announces");
     }
 
-    // Create message with destination and source objects
-    // Source is needed for signing
-    ::LXMF::LXMessage message(destination, source, content_bytes, title);
+    // UI messages prefer single-packet opportunistic delivery on LoRa. The
+    // router automatically promotes messages that exceed the LoRa packet MDU
+    // to DIRECT, so this preserves large-message support without forcing every
+    // short message through the heavier link/resource path.
+    ::LXMF::LXMessage message(
+        destination,
+        source,
+        content_bytes,
+        title,
+        ::LXMF::Type::Message::OPPORTUNISTIC
+    );
 
     // If destination identity was unknown, manually set the destination hash
     if (!dest_identity) {

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -849,6 +849,10 @@ bool UIManager::send_message(const Bytes& dest_hash, const String& content) {
     // Do not transmit or display an outgoing message unless both its payload
     // and conversation index were committed. Otherwise a reboot makes an
     // apparently-sent message disappear from history.
+    //
+    // This callback runs on LVGL's 8 KiB task. microLXMF must keep its
+    // transactional ConversationInfo rollback snapshot object-owned rather
+    // than local to save_message(); the snapshot itself is larger than 8 KiB.
     if (!_store.save_message(message)) {
         ERROR("Outgoing message persistence failed; message not queued");
         show_storage_error("Storage is unavailable. The message was not sent.");

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -36,20 +36,26 @@ namespace LXMF {
 
 namespace {
 
+lv_obj_t* storage_error_dialog = nullptr;
+
 void close_storage_error(lv_event_t* event) {
     lv_obj_t* message_box = lv_event_get_current_target(event);
     if (lv_msgbox_get_active_btn(message_box) == 0) {
+        storage_error_dialog = nullptr;
         lv_msgbox_close(message_box);
     }
 }
 
 void show_storage_error(const char* message) {
+    // Coalesce receive bursts into one dialog rather than allocating one per
+    // rejected packet while storage remains unavailable.
+    if (storage_error_dialog) return;
     static const char* buttons[] = {"OK", ""};
-    lv_obj_t* message_box = lv_msgbox_create(
+    storage_error_dialog = lv_msgbox_create(
         nullptr, "Message not saved", message, buttons, false
     );
-    lv_obj_center(message_box);
-    lv_obj_add_event_cb(message_box, close_storage_error, LV_EVENT_VALUE_CHANGED, nullptr);
+    lv_obj_center(storage_error_dialog);
+    lv_obj_add_event_cb(storage_error_dialog, close_storage_error, LV_EVENT_VALUE_CHANGED, nullptr);
 }
 
 }  // namespace
@@ -190,7 +196,7 @@ bool UIManager::init() {
     );
 
     _chat_screen->set_send_message_callback(
-        [this](const String& content) { on_send_message_from_chat(content); }
+        [this](const String& content) { return on_send_message_from_chat(content); }
     );
 
     _chat_screen->set_call_callback(
@@ -204,7 +210,7 @@ bool UIManager::init() {
 
     _compose_screen->set_send_callback(
         [this](const Bytes& dest_hash, const String& message) {
-            on_send_message_from_compose(dest_hash, message);
+            return on_send_message_from_compose(dest_hash, message);
         }
     );
 
@@ -656,8 +662,8 @@ void UIManager::on_back_to_conversation_list() {
     show_conversation_list();
 }
 
-void UIManager::on_send_message_from_chat(const String& content) {
-    send_message(_current_peer_hash, content);
+bool UIManager::on_send_message_from_chat(const String& content) {
+    return send_message(_current_peer_hash, content);
 }
 
 void UIManager::on_call_from_chat() {
@@ -670,11 +676,12 @@ void UIManager::on_call_from_chat() {
     call_initiate(_current_peer_hash);
 }
 
-void UIManager::on_send_message_from_compose(const Bytes& dest_hash, const String& message) {
-    send_message(dest_hash, message);
+bool UIManager::on_send_message_from_compose(const Bytes& dest_hash, const String& message) {
+    if (!send_message(dest_hash, message)) return false;
 
-    // Switch to chat screen for this conversation
+    // Switch to chat screen only after the message is durably accepted.
     show_chat(dest_hash);
+    return true;
 }
 
 void UIManager::on_cancel_compose() {
@@ -787,7 +794,7 @@ void UIManager::set_rns_status(bool connected, const String& server_name) {
     }
 }
 
-void UIManager::send_message(const Bytes& dest_hash, const String& content) {
+bool UIManager::send_message(const Bytes& dest_hash, const String& content) {
     std::string hash_hex = dest_hash.toHex().substr(0, 8);
     std::string msg = "Sending message to " + hash_hex + "...";
     INFO(msg.c_str());
@@ -837,7 +844,7 @@ void UIManager::send_message(const Bytes& dest_hash, const String& content) {
     if (!_store.save_message(message)) {
         ERROR("Outgoing message persistence failed; message not queued");
         show_storage_error("Storage is unavailable. The message was not sent.");
-        return;
+        return false;
     }
 
     if (_current_screen == SCREEN_CHAT && _current_peer_hash == dest_hash) {
@@ -848,6 +855,7 @@ void UIManager::send_message(const Bytes& dest_hash, const String& content) {
     _router.handle_outbound(message);
 
     INFO("  Message queued for delivery");
+    return true;
 }
 
 void UIManager::on_message_received(::LXMF::LXMessage& message) {
@@ -906,11 +914,19 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
 }
 
 void UIManager::on_message_delivered(::LXMF::LXMessage& message) {
-    LVGL_LOCK();
     std::string hash_hex = message.hash().toHex().substr(0, 8);
     std::string msg = "Message delivered: " + hash_hex + "...";
     INFO(msg.c_str());
 
+    if (!_store.update_message_state(
+            message.hash(), ::LXMF::Type::Message::State::DELIVERED)) {
+        ERROR("Delivered message state persistence failed");
+        LVGL_LOCK();
+        show_storage_error("Delivery status could not be saved. Check device storage.");
+        return;
+    }
+
+    LVGL_LOCK();
     // Update UI if we're viewing this conversation
     if (_current_screen == SCREEN_CHAT && _current_peer_hash == message.destination_hash()) {
         _chat_screen->update_message_status(message.hash(), true);
@@ -918,11 +934,19 @@ void UIManager::on_message_delivered(::LXMF::LXMessage& message) {
 }
 
 void UIManager::on_message_failed(::LXMF::LXMessage& message) {
-    LVGL_LOCK();
     std::string hash_hex = message.hash().toHex().substr(0, 8);
     std::string msg = "Message delivery failed: " + hash_hex + "...";
     WARNING(msg.c_str());
 
+    if (!_store.update_message_state(
+            message.hash(), ::LXMF::Type::Message::State::FAILED)) {
+        ERROR("Failed message state persistence failed");
+        LVGL_LOCK();
+        show_storage_error("Delivery failure status could not be saved. Check device storage.");
+        return;
+    }
+
+    LVGL_LOCK();
     // Update UI if we're viewing this conversation
     if (_current_screen == SCREEN_CHAT && _current_peer_hash == message.destination_hash()) {
         _chat_screen->update_message_status(message.hash(), false);

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -318,9 +318,9 @@ private:
     void on_conversation_selected(const RNS::Bytes& peer_hash);
     void on_new_message();
     void on_back_to_conversation_list();
-    void on_send_message_from_chat(const String& content);
+    bool on_send_message_from_chat(const String& content);
     void on_call_from_chat();
-    void on_send_message_from_compose(const RNS::Bytes& dest_hash, const String& message);
+    bool on_send_message_from_compose(const RNS::Bytes& dest_hash, const String& message);
     void on_cancel_compose();
     void on_announce_selected(const RNS::Bytes& dest_hash);
     void on_back_from_announces();
@@ -334,7 +334,7 @@ private:
     void on_propagation_sync();
 
     // LXMF message handling
-    void send_message(const RNS::Bytes& dest_hash, const String& content);
+    bool send_message(const RNS::Bytes& dest_hash, const String& content);
 
     // UI updates
     void refresh_current_screen();

--- a/platformio.ini
+++ b/platformio.ini
@@ -100,9 +100,10 @@ lib_deps =
     ; aad87f5: transactional message persistence and rollback recovery, keeps the
     ; rollback snapshot off the LVGL task stack, bounds-checks empty LXMF fields,
     ; and attaches delivery callbacks to the transport-owned PacketReceipt.
-    ; Native persist-before-route, opportunistic, direct, resource, stack-budget,
-    ; destructive-index rollback, ASan, and UBSan tests cover this exact revision.
-    https://github.com/torlando-tech/microLXMF.git#ac7f75d397197efefcb1396876d876e638b39176
+    ; d9bbc04: merged microLXMF main with transactional persistence, announced
+    ; direct-delivery stamp costs, bounded cache handling, and the combined
+    ; native/conformance regression coverage used for this test build.
+    https://github.com/torlando-tech/microLXMF.git#d9bbc04cf69bfa9b555c3f293b89b440b4820518
     lvgl/lvgl@^8.3.11
     bblanchon/ArduinoJson@^7.4.2
     hideakitai/MsgPack@^0.4.2

--- a/platformio.ini
+++ b/platformio.ini
@@ -101,8 +101,8 @@ lib_deps =
     ; rollback snapshot off the LVGL task stack, bounds-checks empty LXMF fields,
     ; and attaches delivery callbacks to the transport-owned PacketReceipt.
     ; Native persist-before-route, opportunistic, direct, resource, stack-budget,
-    ; ASan, and UBSan tests cover this exact revision.
-    https://github.com/torlando-tech/microLXMF.git#aad87f561304a8627428991c0a513e54773b8570
+    ; destructive-index rollback, ASan, and UBSan tests cover this exact revision.
+    https://github.com/torlando-tech/microLXMF.git#ac7f75d397197efefcb1396876d876e638b39176
     lvgl/lvgl@^8.3.11
     bblanchon/ArduinoJson@^7.4.2
     hideakitai/MsgPack@^0.4.2

--- a/platformio.ini
+++ b/platformio.ini
@@ -97,7 +97,12 @@ lib_deps =
     ; 3cdde79: faster load_message_metadata — single LittleFS open (read_file
     ; returns 0 on miss, no separate file_exists probe) + JSON field filter that
     ; skips the large "packed" blob. ~2x quicker conversation load.
-    https://github.com/torlando-tech/microLXMF.git#3cdde79172af915c4e330be36ff9775550e57fa5
+    ; aad87f5: transactional message persistence and rollback recovery, keeps the
+    ; rollback snapshot off the LVGL task stack, bounds-checks empty LXMF fields,
+    ; and attaches delivery callbacks to the transport-owned PacketReceipt.
+    ; Native persist-before-route, opportunistic, direct, resource, stack-budget,
+    ; ASan, and UBSan tests cover this exact revision.
+    https://github.com/torlando-tech/microLXMF.git#aad87f561304a8627428991c0a513e54773b8570
     lvgl/lvgl@^8.3.11
     bblanchon/ArduinoJson@^7.4.2
     hideakitai/MsgPack@^0.4.2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,7 @@
 #include <esp_system.h>
 #include <esp_heap_caps.h>
 #include <esp_task_wdt.h>
+#include <esp_ota_ops.h>
 #include <new>  // placement new
 #include <soc/rtc_cntl_reg.h>
 
@@ -956,6 +957,30 @@ void setup_hardware() {
     INFO("Power enabled (early init)");
 }
 
+void confirm_running_firmware() {
+    const esp_partition_t* running = esp_ota_get_running_partition();
+    if (!running) {
+        ERROR("Unable to identify running OTA partition");
+        return;
+    }
+
+    esp_ota_img_states_t state = ESP_OTA_IMG_UNDEFINED;
+    esp_err_t state_result = esp_ota_get_state_partition(running, &state);
+    INFOF("Running firmware: version=%s partition=%s subtype=%d address=0x%lx state=%d",
+          FIRMWARE_VERSION, running->label, static_cast<int>(running->subtype),
+          static_cast<unsigned long>(running->address), static_cast<int>(state));
+
+    if (state_result == ESP_OK &&
+        (state == ESP_OTA_IMG_NEW || state == ESP_OTA_IMG_PENDING_VERIFY)) {
+        esp_err_t result = esp_ota_mark_app_valid_cancel_rollback();
+        if (result == ESP_OK) {
+            INFO("Running firmware marked valid; OTA rollback cancelled");
+        } else {
+            ERRORF("Failed to mark running firmware valid: %s", esp_err_to_name(result));
+        }
+    }
+}
+
 void setup_lvgl_and_ui() {
     INFO("\n=== LVGL & UI Initialization ===");
 
@@ -1275,6 +1300,7 @@ void setup_ui_manager() {
     // Configure settings screen
     UI::LXMF::SettingsScreen* settings = ui_manager->get_settings_screen();
     if (settings) {
+        settings->set_firmware_version(FIRMWARE_VERSION);
         // Pass GPS for status display
         settings->set_gps(&gps);
 
@@ -1788,6 +1814,11 @@ void setup() {
         INFO(">>> APP DELIVERED CALLBACK EXIT");
         Serial.flush();
     });
+
+    // Columba writes app0 plus fresh OTA-selection data. This framework has
+    // bootloader rollback enabled, so confirm the app only after filesystem,
+    // LXMF, and UI initialization have all completed successfully.
+    confirm_running_firmware();
 
     // Boot profiling complete
     BOOT_PROFILE_COMPLETE();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1805,7 +1805,10 @@ void setup() {
         if (message_store) {
             INFO(">>> Updating message state in store");
             Serial.flush();
-            message_store->update_message_state(msg_hash, LXMF::Type::Message::DELIVERED);
+            if (!message_store->update_message_state(msg_hash, LXMF::Type::Message::DELIVERED)) {
+				ERROR("Delivered message state persistence failed; UI status not advanced");
+				return;
+            }
             INFO(">>> State updated, loading full message");
             Serial.flush();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1761,11 +1761,6 @@ void setup() {
     setup_ui_manager();
     BOOT_PROFILE_END("ui_manager");
 
-    // Confirm app0 as soon as the persistent store, LXMF router, and UI have
-    // all initialized successfully. Do not defer this behind announces or
-    // callback setup: a reset after this point must not roll back to app1.
-    confirm_running_firmware();
-
     // Now that UIManager has built screens and configured the active
     // one, start the LVGL render task. Doing this any earlier means
     // the LVGL task refreshes its empty default screen on top of the
@@ -1781,6 +1776,14 @@ void setup() {
         while (1) delay(1000);
     }
     INFO("LVGL task started on core 1");
+
+    // Confirm app0 only after the persistent store, LXMF router, UI, and its
+    // render task have all initialized successfully. Starting the task is the
+    // final fallible boot gate; validating the image before it succeeds would
+    // strand the device on an image that can never present a usable UI.
+    // Announcements and callback registration remain outside the rollback
+    // gate because they are recoverable runtime operations.
+    confirm_running_firmware();
 
     // Send initial LXST voice destination announce
     if (ui_manager) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1300,7 +1300,14 @@ void setup_ui_manager() {
     // Configure settings screen
     UI::LXMF::SettingsScreen* settings = ui_manager->get_settings_screen();
     if (settings) {
-        settings->set_firmware_version(FIRMWARE_VERSION);
+        String firmware_info = FIRMWARE_VERSION;
+        const esp_partition_t* running_partition = esp_ota_get_running_partition();
+        if (running_partition) {
+            firmware_info += " [";
+            firmware_info += running_partition->label;
+            firmware_info += "]";
+        }
+        settings->set_firmware_version(firmware_info);
         // Pass GPS for status display
         settings->set_gps(&gps);
 
@@ -1754,6 +1761,11 @@ void setup() {
     setup_ui_manager();
     BOOT_PROFILE_END("ui_manager");
 
+    // Confirm app0 as soon as the persistent store, LXMF router, and UI have
+    // all initialized successfully. Do not defer this behind announces or
+    // callback setup: a reset after this point must not roll back to app1.
+    confirm_running_firmware();
+
     // Now that UIManager has built screens and configured the active
     // one, start the LVGL render task. Doing this any earlier means
     // the LVGL task refreshes its empty default screen on top of the
@@ -1814,11 +1826,6 @@ void setup() {
         INFO(">>> APP DELIVERED CALLBACK EXIT");
         Serial.flush();
     });
-
-    // Columba writes app0 plus fresh OTA-selection data. This framework has
-    // bootloader rollback enabled, so confirm the app only after filesystem,
-    // LXMF, and UI initialization have all completed successfully.
-    confirm_running_firmware();
 
     // Boot profiling complete
     BOOT_PROFILE_COMPLETE();

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 UI_MANAGER = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+CHAT_SCREEN = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ChatScreen.cpp"
+COMPOSE_SCREEN = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ComposeScreen.cpp"
 
 
 def function_body(source: str, signature: str, next_signature: str) -> str:
@@ -17,7 +19,7 @@ def test_outgoing_message_is_committed_before_display_and_send():
     source = UI_MANAGER.read_text()
     body = function_body(
         source,
-        "void UIManager::send_message(",
+        "bool UIManager::send_message(",
         "void UIManager::on_message_received(",
     )
 
@@ -49,3 +51,36 @@ def test_incoming_message_is_committed_before_display():
 def test_no_message_save_result_is_silently_ignored():
     source = UI_MANAGER.read_text()
     assert "\n    _store.save_message(message);" not in source
+
+
+def test_delivery_state_is_committed_before_ui_update():
+    source = UI_MANAGER.read_text()
+    delivered = function_body(
+        source,
+        "void UIManager::on_message_delivered(",
+        "void UIManager::on_message_failed(",
+    )
+    failed = function_body(
+        source,
+        "void UIManager::on_message_failed(",
+        "void UIManager::refresh_current_screen(",
+    )
+    assert delivered.index("_store.update_message_state(") < delivered.index(
+        "_chat_screen->update_message_status(message.hash(), true)"
+    )
+    assert failed.index("_store.update_message_state(") < failed.index(
+        "_chat_screen->update_message_status(message.hash(), false)"
+    )
+
+
+def test_rejected_outgoing_message_keeps_retryable_input():
+    chat = CHAT_SCREEN.read_text()
+    compose = COMPOSE_SCREEN.read_text()
+    assert "if (screen->_send_message_callback(message))" in chat
+    assert "if (screen->_send_callback && screen->_send_callback(dest_hash, message))" in compose
+
+
+def test_storage_error_dialogs_are_coalesced():
+    source = UI_MANAGER.read_text()
+    assert "if (storage_error_dialog) return;" in source
+    assert "storage_error_dialog = nullptr;" in source

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -1,0 +1,51 @@
+"""Source-level regression checks for fail-closed LXMF persistence UI flow."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UI_MANAGER = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+
+
+def function_body(source: str, signature: str, next_signature: str) -> str:
+    start = source.index(signature)
+    end = source.index(next_signature, start)
+    return source[start:end]
+
+
+def test_outgoing_message_is_committed_before_display_and_send():
+    source = UI_MANAGER.read_text()
+    body = function_body(
+        source,
+        "void UIManager::send_message(",
+        "void UIManager::on_message_received(",
+    )
+
+    save = body.index("if (!_store.save_message(message))")
+    display = body.index("_chat_screen->add_message(message, true)")
+    send = body.index("_router.handle_outbound(message)")
+
+    assert save < display < send
+    assert "Outgoing message persistence failed; message not queued" in body
+    assert "The message was not sent" in body
+
+
+def test_incoming_message_is_committed_before_display():
+    source = UI_MANAGER.read_text()
+    body = function_body(
+        source,
+        "void UIManager::on_message_received(",
+        "void UIManager::on_message_delivered(",
+    )
+
+    save = body.index("if (!_store.save_message(message))")
+    display = body.index("_chat_screen->add_message(message, false)")
+
+    assert save < display
+    assert "Incoming message persistence failed; message not added to history" in body
+    assert "An incoming message could not be saved" in body
+
+
+def test_no_message_save_result_is_silently_ignored():
+    source = UI_MANAGER.read_text()
+    assert "\n    _store.save_message(message);" not in source

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -69,6 +69,7 @@ def test_no_message_save_result_is_silently_ignored():
 
 def test_delivery_state_is_committed_before_ui_update():
     source = UI_MANAGER.read_text()
+    main = MAIN.read_text()
     delivered = function_body(
         source,
         "void UIManager::on_message_delivered(",
@@ -79,9 +80,17 @@ def test_delivery_state_is_committed_before_ui_update():
         "void UIManager::on_message_failed(",
         "void UIManager::refresh_current_screen(",
     )
-    assert delivered.index("_store.update_message_state(") < delivered.index(
-        "_chat_screen->update_message_status(message.hash(), true)"
+    callback = function_body(
+        main,
+        "router->register_delivered_callback(",
+        "// Boot profiling complete",
     )
+    assert "if (!message_store->update_message_state(" in callback
+    assert callback.index("message_store->update_message_state(") < callback.index(
+        "ui_manager->on_message_delivered(full_msg)"
+    )
+    assert "_store.update_message_state(" not in delivered
+    assert "_chat_screen->update_message_status(message.hash(), true)" in delivered
     assert failed.index("_store.update_message_state(") < failed.index(
         "_chat_screen->update_message_status(message.hash(), false)"
     )

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -33,6 +33,19 @@ def test_outgoing_message_is_committed_before_display_and_send():
     assert "The message was not sent" in body
 
 
+def test_ui_messages_prefer_lora_safe_opportunistic_delivery():
+    source = UI_MANAGER.read_text()
+    body = function_body(
+        source,
+        "bool UIManager::send_message(",
+        "void UIManager::on_message_received(",
+    )
+    assert "::LXMF::Type::Message::OPPORTUNISTIC" in body
+    assert body.index("::LXMF::Type::Message::OPPORTUNISTIC") < body.index(
+        "_router.handle_outbound(message)"
+    )
+
+
 def test_incoming_message_is_committed_before_display():
     source = UI_MANAGER.read_text()
     body = function_body(

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -99,3 +99,11 @@ def test_successful_boot_cancels_ota_rollback_after_subsystems_initialize():
     setup = function_body(source, "void setup()", "void loop()")
     assert setup.index("setup_lxmf();") < setup.index("setup_ui_manager();")
     assert setup.index("setup_ui_manager();") < setup.index("confirm_running_firmware();")
+
+
+def test_system_info_reports_littlefs_not_unmounted_spiffs():
+    source = (REPO_ROOT / "lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp").read_text()
+    assert '"Firmware: " FIRMWARE_VERSION' in source
+    assert "LittleFS.totalBytes()" in source
+    assert "LittleFS.usedBytes()" in source
+    assert "SPIFFS.totalBytes()" not in source

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -111,7 +111,8 @@ def test_successful_boot_cancels_ota_rollback_after_subsystems_initialize():
     assert "esp_ota_mark_app_valid_cancel_rollback()" in confirm
     setup = function_body(source, "void setup()", "void loop()")
     assert setup.index("setup_lxmf();") < setup.index("setup_ui_manager();")
-    assert setup.index("setup_ui_manager();") < setup.index("confirm_running_firmware();")
+    assert setup.index("setup_ui_manager();") < setup.index("LVGLInit::start_task")
+    assert setup.index("LVGLInit::start_task") < setup.index("confirm_running_firmware();")
 
 
 def test_system_info_reports_littlefs_not_unmounted_spiffs():

--- a/tests/build_scripts/test_message_persistence_contract.py
+++ b/tests/build_scripts/test_message_persistence_contract.py
@@ -7,6 +7,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 UI_MANAGER = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
 CHAT_SCREEN = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ChatScreen.cpp"
 COMPOSE_SCREEN = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ComposeScreen.cpp"
+MAIN = REPO_ROOT / "src/main.cpp"
 
 
 def function_body(source: str, signature: str, next_signature: str) -> str:
@@ -84,3 +85,17 @@ def test_storage_error_dialogs_are_coalesced():
     source = UI_MANAGER.read_text()
     assert "if (storage_error_dialog) return;" in source
     assert "storage_error_dialog = nullptr;" in source
+
+
+def test_successful_boot_cancels_ota_rollback_after_subsystems_initialize():
+    source = MAIN.read_text()
+    confirm = function_body(
+        source,
+        "void confirm_running_firmware()",
+        "void setup_lvgl_and_ui()",
+    )
+    assert "ESP_OTA_IMG_PENDING_VERIFY" in confirm
+    assert "esp_ota_mark_app_valid_cancel_rollback()" in confirm
+    setup = function_body(source, "void setup()", "void loop()")
+    assert setup.index("setup_lxmf();") < setup.index("setup_ui_manager();")
+    assert setup.index("setup_ui_manager();") < setup.index("confirm_running_firmware();")


### PR DESCRIPTION
## Summary
- fail closed when message persistence fails and preserve retryable UI messages
- report active firmware and LittleFS-backed storage state
- confirm OTA images only after critical UI task startup succeeds
- pin the native-validated microLXMF persistence fixes

## Verification
- persistence contract tests: 9 passed
- build-script suite: 22 passed
- native suite: 8 passed
- fresh ESP32-S3 firmware build completed with the pinned local dependency
- firmware v155 was hardware-verified for LXMF send/receive and conversation persistence across reboot

## Dependency
- pins torlando-tech/microLXMF commit aad87f561304a8627428991c0a513e54773b8570

## Risk / rollback
- changes message durability and OTA boot confirmation timing
- rollback by reverting this branch and restoring the prior microLXMF pin