### PR TITLE
fix(voice): harden LXST lifecycle and enforce ULBW

### DIFF
--- a/docs/lxst_termination_extension.md
+++ b/docs/lxst_termination_extension.md
@@ -1,0 +1,27 @@
+# LXST call-termination extension
+
+Pyxis and compatible Columba builds use signalling status `0x07` (`TERMINATED`) as a backward-compatible active-call termination extension.
+
+## Wire behavior
+
+The frame uses the existing LXST signalling field:
+
+```text
+{ 0x00: [0x07] }
+```
+
+A normal local hangup sends three terminal frames with 20 ms bounded drain intervals, then performs the standard Reticulum `Link.teardown()`. The Link close remains the compatibility fallback.
+
+## Receiver behavior
+
+A compatible receiver accepts `TERMINATED` in every owned, non-idle call state and performs idempotent call cleanup. A later Link-close callback or duplicate terminal frame is harmless.
+
+Columba intercepts `TERMINATED` before LXST-kt's legacy status handler. A link-scoped terminal gate suppresses duplicate terminal frames, while one atomic admission transaction and explicit call-generation tokens arbitrate outbound, inbound, terminal, Link-close, local-hangup, disable, and shutdown races. New calls are rejected until the prior Telephone state and Link ownership are both released. Every signalling and media callback must match the exact active Link and generation, so stale frames cannot mutate a replacement call. Exactly one path may invoke `Telephone.hangup()` in setup or active states. This keeps the extension outside the pinned LXST-kt dependency without translating it to `STATUS_AVAILABLE`.
+
+## Compatibility
+
+Current canonical Python LXST and older LXST-kt/Pyxis implementations do not define status `0x07`. Their existing decoders ignore unknown status values, after which the standard Link-close fallback remains available.
+
+The terminal burst substantially reduces dependence on Reticulum's single unacknowledged `LINKCLOSE`, but it is not a remote acknowledgement. Pyxis therefore also expires an `ACTIVE` call after 90 seconds without valid inbound Codec2 media. A liveness refresh requires a non-empty, exactly frame-aligned Codec2 batch that the decoder accepts; truncated or trailing partial subframes do not count. LXST capture streams continuously even during silence, so this is a conservative orphan-call fallback rather than a short silence timer.
+
+Physical acceptance must still verify both call directions, deliberate Link-close loss where practical, terminal loss, and the 90-second liveness path.

--- a/docs/serial_commands.md
+++ b/docs/serial_commands.md
@@ -65,7 +65,7 @@ or `<X>` is misspelled.
 | `T:CALL_STATE` | — | `T:OK <state>` | Current call FSM state name. |
 | `T:CALL_STATS` | — | `T:OK …` | Audio frame counters for the most recent call. |
 | `T:CALL_QOS` | — | `T:OK …` | Wire-level audio fidelity counters (decoded RMS, frame loss, etc). |
-| `T:CALL_PROFILE` | `[hex]` | `T:OK <hex>` | Get (no arg) or set (hex arg) preferred Codec2 profile. Profiles: `0x10` ULBW (700C), `0x20` VLBW (1600), `0x30` LBW (3200). |
+| `T:CALL_PROFILE` | `[hex]` | `T:OK <hex>` | Get (no arg) or set (hex arg) the production Codec2 profile. Only `0x10` ULBW (700C) is supported. |
 | `T:CALL_INJECT` | `<on\|off> [freq_hz] [amp_pct]` | `T:OK inject=<on/off> freq=<f> amp=<a>` | Replace mic capture with a synthesized sine wave for the active call. Useful for end-to-end audio fidelity checks against a bot that decodes pyxis's audio frames. Defaults: 1000 Hz, amp 0.5. |
 
 ### BLE interface

--- a/docs/serial_commands.md
+++ b/docs/serial_commands.md
@@ -29,8 +29,8 @@ or `<X>` is misspelled.
 | `T:ID` | — | `T:OK <hex>` | Local Reticulum identity hash (32 hex). |
 | `T:DEST` | — | `T:OK <hex>` | LXMF delivery destination hash (16 hex). |
 | `T:LXSTDEST` | — | `T:OK <hex>` | LXST telephony destination hash. Used to share with the test bot before `T:CALL`. |
-| `T:ANN` | — | `T:OK announced` | Force a fresh LXMF delivery announce. |
-| `T:ANNLXST` | — | `T:OK announced` | Force a fresh LXST telephony announce. Required before pyxis-as-callee tests because the TCP-reconnect path only re-announces LXMF. |
+| `T:ANN` | — | `T:OK announced` | Force paired fresh LXMF delivery and LXST telephony announces. |
+| `T:ANNLXST` | — | `T:OK announced` | Force only a fresh LXST telephony announce for protocol diagnostics. Normal announce paths publish LXMF and LXST together. |
 | `T:PATHS` | — | `T:OK count=N` then `T:PATH <hex>` per row | Dump the in-memory path table. |
 | `T:HASPATH` | `<hex>` | `T:OK 0/1 mem=0/1 mem_count=N` | Has-path check + diagnostic split between disk-backed `Transport::has_path` and the in-memory `_path_table`. |
 | `T:RECALL` | `<hex>` | `T:OK <hex>` or `T:ERR not recallable` | Try to resolve `<hex>` to its identity hash via `Identity::recall`. |

--- a/lib/lxst_audio/ULBWVoiceProfilePolicy.h
+++ b/lib/lxst_audio/ULBWVoiceProfilePolicy.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Production Pyxis voice policy. LoRa bandwidth is a hard product constraint,
+// so only LXST ULBW (Codec2-700C) is accepted or advertised.
+struct ULBWVoiceProfilePolicy {
+    static constexpr int PROFILE_ULBW = 0x10;
+    static constexpr int PREFERRED_PROFILE = 0xFF;
+    static constexpr int CODEC2_MODE_700C_VALUE = 8;
+    static constexpr int PCM_SAMPLES_PER_PACKET = 3200;  // 400 ms at 8 kHz
+
+    static constexpr bool isSupportedProfile(int profile) {
+        return profile == PROFILE_ULBW;
+    }
+
+    static constexpr int codecModeForProfile(int profile) {
+        return isSupportedProfile(profile) ? CODEC2_MODE_700C_VALUE : -1;
+    }
+
+    static constexpr bool acceptsCodec2ModeHeader(unsigned char header) {
+        return header == 0x00;
+    }
+
+    static constexpr int preferredProfileSignal() {
+        return PREFERRED_PROFILE + PROFILE_ULBW;
+    }
+
+    static constexpr int pcmSamplesPerPacket() {
+        return PCM_SAMPLES_PER_PACKET;
+    }
+
+    static constexpr int framesPerPacket(int samplesPerFrame) {
+        return samplesPerFrame > 0 &&
+                       PCM_SAMPLES_PER_PACKET % samplesPerFrame == 0
+                   ? PCM_SAMPLES_PER_PACKET / samplesPerFrame
+                   : 0;
+    }
+
+    static constexpr int outerBatchBytes(int samplesPerFrame, int bytesPerFrame) {
+        return framesPerPacket(samplesPerFrame) > 0 && bytesPerFrame > 0
+                   ? 2 + framesPerPacket(samplesPerFrame) * bytesPerFrame
+                   : 0;
+    }
+};

--- a/lib/lxst_audio/codec_wrapper.cpp
+++ b/lib/lxst_audio/codec_wrapper.cpp
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #include "codec_wrapper.h"
+#include "ULBWVoiceProfilePolicy.h"
 #include <codec2.h>
 #include <cstring>
+
+static_assert(CODEC2_MODE_700C == ULBWVoiceProfilePolicy::CODEC2_MODE_700C_VALUE,
+              "Pinned Codec2-700C mode value changed");
 
 #ifdef ARDUINO
 #include <esp_log.h>

--- a/lib/lxst_audio/codec_wrapper.cpp
+++ b/lib/lxst_audio/codec_wrapper.cpp
@@ -106,6 +106,14 @@ int Codec2Wrapper::decode(const uint8_t* encoded, int encodedBytes,
     // Skip header byte, decode remaining sub-frames
     const uint8_t* data = encoded + 1;
     int dataLen = encodedBytes - 1;
+    if (dataLen <= 0 || bytesPerFrame_ <= 0 || dataLen % bytesPerFrame_ != 0) {
+        LOGW("Codec2 decode: invalid sub-frame batch (%d bytes, frame size %d)",
+             dataLen, bytesPerFrame_);
+#ifdef ARDUINO
+        if (mutex_) xSemaphoreGive(mutex_);
+#endif
+        return -1;
+    }
     int numFrames = dataLen / bytesPerFrame_;
     int totalSamples = numFrames * samplesPerFrame_;
 

--- a/lib/lxst_audio/i2s_capture.cpp
+++ b/lib/lxst_audio/i2s_capture.cpp
@@ -13,6 +13,7 @@
 #include "codec_wrapper.h"
 #include "audio_filters.h"
 #include "encoded_ring_buffer.h"
+#include "ULBWVoiceProfilePolicy.h"
 #include <Arduino.h>
 #include <freertos/semphr.h>
 
@@ -106,11 +107,19 @@ bool I2SCapture::configureEncoder(Codec2Wrapper* codec, bool enableFilters) {
     }
     codec_ = codec;
 
-    // Accumulate FRAMES_PER_BATCH codec frames before filter+encode.
-    // Columba uses 200ms (1600 samples for Codec2 3200) so the AGC operates
-    // on meaningful block sizes.  With only 160 samples (20ms) the AGC blocks
-    // are 16 samples and gain-pump, producing buzzy audio.
-    frameSamples_ = codec_->samplesPerFrame() * FRAMES_PER_BATCH;
+    // Production Pyxis supports only LXST ULBW/Codec2-700C for LoRa.
+    if (codec_->libraryMode() != ULBWVoiceProfilePolicy::CODEC2_MODE_700C_VALUE) {
+        ESP_LOGE(TAG, "Unsupported non-ULBW Codec2 mode %d", codec_->libraryMode());
+        return false;
+    }
+    const int framesPerBatch =
+        ULBWVoiceProfilePolicy::framesPerPacket(codec_->samplesPerFrame());
+    if (framesPerBatch <= 0 ||
+            PCM_SAMPLES_PER_BATCH != ULBWVoiceProfilePolicy::pcmSamplesPerPacket()) {
+        ESP_LOGE(TAG, "Invalid ULBW Codec2 packet quantum");
+        return false;
+    }
+    frameSamples_ = PCM_SAMPLES_PER_BATCH;
     filtersEnabled_ = enableFilters;
 
     // Queue filtered PCM in PSRAM. Encoding is deferred to loopTask; Codec2's
@@ -144,7 +153,7 @@ bool I2SCapture::configureEncoder(Codec2Wrapper* codec, bool enableFilters) {
     }
 
     ESP_LOGI(TAG, "Encoder configured: Codec2 mode %d, %d samples/batch (%d x %d), %d bytes/frame, filters=%d",
-             codec_->libraryMode(), frameSamples_, FRAMES_PER_BATCH,
+             codec_->libraryMode(), frameSamples_, framesPerBatch,
              codec_->samplesPerFrame(), codec_->bytesPerFrame(), enableFilters);
     return true;
 }

--- a/lib/lxst_audio/i2s_capture.h
+++ b/lib/lxst_audio/i2s_capture.h
@@ -130,7 +130,7 @@ private:
     // Accumulation buffer: I2S delivers variable bursts, we need fixed-size frames
     int16_t* accumBuffer_ = nullptr;
     int accumCount_ = 0;
-    int frameSamples_ = 0;  // Codec2 samples per frame (e.g., 320 for 700C, 160 for 1600/3200)
+    int frameSamples_ = 0;  // PCM samples per LXST packet quantum
 
     // PSRAM staging buffer used by loopTask while encoding queued PCM.
     int16_t* encodePcmBuffer_ = nullptr;
@@ -142,10 +142,8 @@ private:
 
     static constexpr int I2S_SAMPLE_RATE = 16000;  // EXACT-LilyGO test: 16kHz capture, decimated 2:1 to 8kHz. (ES7210 ADC warp unresolved -- see es7210.cpp.)
     static constexpr int CODEC_SAMPLE_RATE = 8000; // Codec2 expects 8kHz
-    // Accumulate this many codec frames before filter+encode.
-    // Matches Columba's 200ms batch (1600 samples for Codec2 3200).
-    // The AGC needs large blocks for stable gain tracking.
-    static constexpr int FRAMES_PER_BATCH = 10;
+    // LXST ULBW packet quantum at 8 kHz: 400 ms of mono PCM.
+    static constexpr int PCM_SAMPLES_PER_BATCH = 3200;
     static constexpr int PCM_RING_SLOTS = 8;
     // Codec2 no longer runs on this task. 8 KiB covers local I2S buffers,
     // filters and bounded diagnostic sendto without starving playback.

--- a/lib/tdeck_ui/UI/LXMF/CallGenerationGuard.h
+++ b/lib/tdeck_ui/UI/LXMF/CallGenerationGuard.h
@@ -10,9 +10,10 @@
 namespace UI {
 namespace LXMF {
 
-// Lock-free admission guard for call setup. Each successful reservation owns a
+// Atomic admission guard for call setup. Each successful reservation owns a
 // generation until that exact generation releases it; generation zero always
-// means "unowned".
+// means "unowned". Generations eventually repeat after the finite token space
+// wraps, so a token retained for a full cycle can exhibit ABA.
 class CallGenerationGuard {
 public:
     static constexpr uint32_t MAX_GENERATION = 0x7fffffffu;

--- a/lib/tdeck_ui/UI/LXMF/CallGenerationGuard.h
+++ b/lib/tdeck_ui/UI/LXMF/CallGenerationGuard.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2024 microReticulum contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef UI_LXMF_CALLGENERATIONGUARD_H
+#define UI_LXMF_CALLGENERATIONGUARD_H
+
+#include <atomic>
+#include <cstdint>
+
+namespace UI {
+namespace LXMF {
+
+// Lock-free admission guard for call setup. Each successful reservation owns a
+// generation until that exact generation releases it; generation zero always
+// means "unowned".
+class CallGenerationGuard {
+public:
+    static constexpr uint32_t MAX_GENERATION = 0x7fffffffu;
+
+    uint32_t tryReserve() {
+        const uint32_t generation = nextGeneration();
+        uint32_t expected = 0;
+        if (!active.compare_exchange_strong(expected, generation,
+                                            std::memory_order_acq_rel,
+                                            std::memory_order_acquire)) {
+            return 0;
+        }
+        return generation;
+    }
+
+    bool owns(uint32_t generation) const {
+        return generation != 0 &&
+               active.load(std::memory_order_acquire) == generation;
+    }
+
+    uint32_t current() const {
+        return active.load(std::memory_order_acquire);
+    }
+
+    bool release(uint32_t generation) {
+        if (generation == 0) return false;
+        return active.compare_exchange_strong(generation, 0,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire);
+    }
+
+private:
+    uint32_t nextGeneration() {
+        uint32_t generation = counter.load(std::memory_order_relaxed);
+        for (;;) {
+            const uint32_t next = generation == MAX_GENERATION
+                                      ? 1u
+                                      : generation + 1u;
+            if (counter.compare_exchange_weak(generation, next,
+                                              std::memory_order_relaxed,
+                                              std::memory_order_relaxed)) {
+                return generation;
+            }
+        }
+    }
+
+    std::atomic<uint32_t> active{0};
+    std::atomic<uint32_t> counter{1};
+};
+
+} // namespace LXMF
+} // namespace UI
+
+#endif // UI_LXMF_CALLGENERATIONGUARD_H

--- a/lib/tdeck_ui/UI/LXMF/CallLinkOwnership.h
+++ b/lib/tdeck_ui/UI/LXMF/CallLinkOwnership.h
@@ -1,0 +1,132 @@
+// Copyright (c) 2024 microReticulum contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef UI_LXMF_CALLLINKOWNERSHIP_H
+#define UI_LXMF_CALLLINKOWNERSHIP_H
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace UI {
+namespace LXMF {
+
+// Lock-free-shaped publication of the exact 128-bit Reticulum link ID together
+// with its call generation. Atomic words avoid data races while the generation
+// acts as a publication seqlock, so readers never accept a torn ID. Writers are
+// serialized by CallGenerationGuard in UIManager.
+class CallLinkOwnership {
+public:
+    using LinkId = std::array<uint8_t, 16>;
+    static constexpr uint32_t MAX_GENERATION = 0x7fffffffu;
+
+    bool publish(uint32_t generation, const LinkId& id) {
+        if (generation == 0 || generation > MAX_GENERATION) return false;
+
+        // Detach the previous publication before changing any ID word. Readers
+        // that began against the old owner reject it on their final generation
+        // read even if they observe a mixture of old and new words.
+        _generation.store(0, std::memory_order_release);
+        for (size_t word = 0; word < _id_words.size(); ++word) {
+            _id_words[word].store(packWord(id, word), std::memory_order_relaxed);
+        }
+        _close_state.store(generation << 1, std::memory_order_release);
+        _generation.store(generation, std::memory_order_release);
+        return true;
+    }
+
+    bool owns(uint32_t generation, const LinkId& id) const {
+        if (generation == 0 ||
+            _generation.load(std::memory_order_acquire) != generation) {
+            return false;
+        }
+
+        for (size_t word = 0; word < _id_words.size(); ++word) {
+            if (_id_words[word].load(std::memory_order_relaxed) !=
+                packWord(id, word)) {
+                return false;
+            }
+        }
+
+        // A writer may have detached and started replacing the ID after the
+        // first generation read. Accept only a stable publication.
+        return _generation.load(std::memory_order_acquire) == generation;
+    }
+
+    uint32_t generationFor(const LinkId& id) const {
+        const uint32_t generation = _generation.load(std::memory_order_acquire);
+        return owns(generation, id) ? generation : 0;
+    }
+
+    bool markClosed(uint32_t generation, const LinkId& id) {
+        if (!owns(generation, id)) return false;
+
+        uint32_t expected = generation << 1;
+        return _close_state.compare_exchange_strong(
+            expected, expected | 1u, std::memory_order_acq_rel,
+            std::memory_order_acquire);
+    }
+
+    // Returns the generation whose pending close was consumed, or zero. The
+    // exact encoded generation prevents an old callback from clearing or
+    // replacing a newer owner's pending close.
+    uint32_t takeClosed() {
+        const uint32_t generation = _generation.load(std::memory_order_acquire);
+        if (generation == 0) return 0;
+
+        uint32_t expected = (generation << 1) | 1u;
+        if (!_close_state.compare_exchange_strong(
+                expected, generation << 1, std::memory_order_acq_rel,
+                std::memory_order_acquire)) {
+            return 0;
+        }
+        return _generation.load(std::memory_order_acquire) == generation
+                   ? generation
+                   : 0;
+    }
+
+    bool clear(uint32_t generation) {
+        if (generation == 0) return false;
+
+        uint32_t expected_generation = generation;
+        if (!_generation.compare_exchange_strong(
+                expected_generation, 0, std::memory_order_acq_rel,
+                std::memory_order_acquire)) {
+            return false;
+        }
+
+        // A validated close callback may pause before its CAS. Keep clearing
+        // only this generation's two exact states until neither remains; a
+        // newer generation's slot is never overwritten.
+        for (;;) {
+            uint32_t state = _close_state.load(std::memory_order_acquire);
+            if ((state >> 1) != generation) break;
+            if (_close_state.compare_exchange_weak(
+                    state, 0, std::memory_order_acq_rel,
+                    std::memory_order_acquire)) {
+                break;
+            }
+        }
+        return true;
+    }
+
+private:
+    static uint32_t packWord(const LinkId& id, size_t word) {
+        const size_t offset = word * 4;
+        return static_cast<uint32_t>(id[offset]) |
+               (static_cast<uint32_t>(id[offset + 1]) << 8) |
+               (static_cast<uint32_t>(id[offset + 2]) << 16) |
+               (static_cast<uint32_t>(id[offset + 3]) << 24);
+    }
+
+    std::array<std::atomic<uint32_t>, 4> _id_words{};
+    std::atomic<uint32_t> _generation{0};
+    // (generation << 1) | pending; generation is bounded to 31 bits.
+    std::atomic<uint32_t> _close_state{0};
+};
+
+} // namespace LXMF
+} // namespace UI
+
+#endif // UI_LXMF_CALLLINKOWNERSHIP_H

--- a/lib/tdeck_ui/UI/LXMF/CallLinkOwnership.h
+++ b/lib/tdeck_ui/UI/LXMF/CallLinkOwnership.h
@@ -12,10 +12,13 @@
 namespace UI {
 namespace LXMF {
 
-// Lock-free-shaped publication of the exact 128-bit Reticulum link ID together
-// with its call generation. Atomic words avoid data races while the generation
-// acts as a publication seqlock, so readers never accept a torn ID. Writers are
-// serialized by CallGenerationGuard in UIManager.
+// Publication of the exact 128-bit Reticulum link ID together with its call
+// generation. Writers are serialized by CallGenerationGuard in UIManager.
+// Every publication-marker and ID-word operation is sequentially consistent:
+// in that single total order, a reader that observes any replacement ID word
+// must have its final generation read after the writer's preceding detach (0),
+// and therefore cannot accept the old nonzero generation. A reader accepts only
+// equal nonzero generation reads around all four exact ID words.
 class CallLinkOwnership {
 public:
     using LinkId = std::array<uint8_t, 16>;
@@ -24,26 +27,26 @@ public:
     bool publish(uint32_t generation, const LinkId& id) {
         if (generation == 0 || generation > MAX_GENERATION) return false;
 
-        // Detach the previous publication before changing any ID word. Readers
-        // that began against the old owner reject it on their final generation
-        // read even if they observe a mixture of old and new words.
-        _generation.store(0, std::memory_order_release);
+        // Detach the previous publication before changing any ID word. The SC
+        // total-order argument documented above makes mixed snapshots reject.
+        _generation.store(0, std::memory_order_seq_cst);
         for (size_t word = 0; word < _id_words.size(); ++word) {
-            _id_words[word].store(packWord(id, word), std::memory_order_relaxed);
+            _id_words[word].store(packWord(id, word),
+                                  std::memory_order_seq_cst);
         }
-        _close_state.store(generation << 1, std::memory_order_release);
-        _generation.store(generation, std::memory_order_release);
+        _close_state.store(generation << 1, std::memory_order_seq_cst);
+        _generation.store(generation, std::memory_order_seq_cst);
         return true;
     }
 
     bool owns(uint32_t generation, const LinkId& id) const {
         if (generation == 0 ||
-            _generation.load(std::memory_order_acquire) != generation) {
+            _generation.load(std::memory_order_seq_cst) != generation) {
             return false;
         }
 
         for (size_t word = 0; word < _id_words.size(); ++word) {
-            if (_id_words[word].load(std::memory_order_relaxed) !=
+            if (_id_words[word].load(std::memory_order_seq_cst) !=
                 packWord(id, word)) {
                 return false;
             }
@@ -51,11 +54,12 @@ public:
 
         // A writer may have detached and started replacing the ID after the
         // first generation read. Accept only a stable publication.
-        return _generation.load(std::memory_order_acquire) == generation;
+        return _generation.load(std::memory_order_seq_cst) == generation;
     }
 
     uint32_t generationFor(const LinkId& id) const {
-        const uint32_t generation = _generation.load(std::memory_order_acquire);
+        const uint32_t generation =
+            _generation.load(std::memory_order_seq_cst);
         return owns(generation, id) ? generation : 0;
     }
 
@@ -64,24 +68,24 @@ public:
 
         uint32_t expected = generation << 1;
         return _close_state.compare_exchange_strong(
-            expected, expected | 1u, std::memory_order_acq_rel,
-            std::memory_order_acquire);
+            expected, expected | 1u, std::memory_order_seq_cst,
+            std::memory_order_seq_cst);
     }
 
     // Returns the generation whose pending close was consumed, or zero. The
     // exact encoded generation prevents an old callback from clearing or
     // replacing a newer owner's pending close.
     uint32_t takeClosed() {
-        const uint32_t generation = _generation.load(std::memory_order_acquire);
+        const uint32_t generation = _generation.load(std::memory_order_seq_cst);
         if (generation == 0) return 0;
 
         uint32_t expected = (generation << 1) | 1u;
         if (!_close_state.compare_exchange_strong(
-                expected, generation << 1, std::memory_order_acq_rel,
-                std::memory_order_acquire)) {
+                expected, generation << 1, std::memory_order_seq_cst,
+                std::memory_order_seq_cst)) {
             return 0;
         }
-        return _generation.load(std::memory_order_acquire) == generation
+        return _generation.load(std::memory_order_seq_cst) == generation
                    ? generation
                    : 0;
     }
@@ -91,8 +95,8 @@ public:
 
         uint32_t expected_generation = generation;
         if (!_generation.compare_exchange_strong(
-                expected_generation, 0, std::memory_order_acq_rel,
-                std::memory_order_acquire)) {
+                expected_generation, 0, std::memory_order_seq_cst,
+                std::memory_order_seq_cst)) {
             return false;
         }
 
@@ -100,11 +104,11 @@ public:
         // only this generation's two exact states until neither remains; a
         // newer generation's slot is never overwritten.
         for (;;) {
-            uint32_t state = _close_state.load(std::memory_order_acquire);
+            uint32_t state = _close_state.load(std::memory_order_seq_cst);
             if ((state >> 1) != generation) break;
             if (_close_state.compare_exchange_weak(
-                    state, 0, std::memory_order_acq_rel,
-                    std::memory_order_acquire)) {
+                    state, 0, std::memory_order_seq_cst,
+                    std::memory_order_seq_cst)) {
                 break;
             }
         }

--- a/lib/tdeck_ui/UI/LXMF/CallLivenessWatchdog.h
+++ b/lib/tdeck_ui/UI/LXMF/CallLivenessWatchdog.h
@@ -32,7 +32,13 @@ public:
     bool expired(uint32_t now_ms, uint32_t timeout_ms) const {
         if (!_armed.load(std::memory_order_acquire)) return false;
         const uint32_t last = _last_observed_ms.load(std::memory_order_relaxed);
-        return static_cast<uint32_t>(now_ms - last) >= timeout_ms;
+        const uint32_t elapsed = static_cast<uint32_t>(now_ms - last);
+        // The UI loop can sample `now_ms` immediately before a signal callback
+        // arms the watchdog. Treat that small backward sample as stale rather
+        // than as almost UINT32_MAX milliseconds elapsed. Genuine millis wrap
+        // remains a small forward delta and is still handled normally.
+        if (elapsed > 0x7FFFFFFFu) return false;
+        return elapsed >= timeout_ms;
     }
 
 private:

--- a/lib/tdeck_ui/UI/LXMF/CallLivenessWatchdog.h
+++ b/lib/tdeck_ui/UI/LXMF/CallLivenessWatchdog.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <atomic>
+
+/**
+ * Wrap-safe liveness guard for continuously streamed LXST call media.
+ *
+ * It is armed only after a call becomes ACTIVE. Every valid inbound audio frame
+ * refreshes the observation timestamp. A long absence therefore provides a
+ * conservative fallback when both the application terminal signal and
+ * Reticulum Link-close notification are lost.
+ */
+class CallLivenessWatchdog {
+public:
+    void arm(uint32_t now_ms) {
+        _last_observed_ms.store(now_ms, std::memory_order_relaxed);
+        _armed.store(true, std::memory_order_release);
+    }
+
+    void observe(uint32_t now_ms) {
+        if (_armed.load(std::memory_order_acquire)) {
+            _last_observed_ms.store(now_ms, std::memory_order_relaxed);
+        }
+    }
+
+    void disarm() {
+        _armed.store(false, std::memory_order_release);
+        _last_observed_ms.store(0, std::memory_order_relaxed);
+    }
+
+    bool expired(uint32_t now_ms, uint32_t timeout_ms) const {
+        if (!_armed.load(std::memory_order_acquire)) return false;
+        const uint32_t last = _last_observed_ms.load(std::memory_order_relaxed);
+        return static_cast<uint32_t>(now_ms - last) >= timeout_ms;
+    }
+
+private:
+    std::atomic<uint32_t> _last_observed_ms{0};
+    std::atomic<bool> _armed{false};
+};

--- a/lib/tdeck_ui/UI/LXMF/CallStartMailbox.h
+++ b/lib/tdeck_ui/UI/LXMF/CallStartMailbox.h
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 microReticulum contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef UI_LXMF_CALLSTARTMAILBOX_H
+#define UI_LXMF_CALLSTARTMAILBOX_H
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace UI {
+namespace LXMF {
+
+// Atomic SPSC handoff for an exact 128-bit peer hash. The producer first owns
+// EMPTY by changing it to WRITING, then publishes all four words before READY.
+// The consumer reads words only while READY and returns the slot to EMPTY only
+// after copying them, so the producer can never overwrite a payload being read.
+// A second request is rejected rather than replacing a pending request.
+class CallStartMailbox {
+public:
+    using PeerHash = std::array<uint8_t, 16>;
+
+    bool request(const PeerHash& peerHash) {
+        uint32_t expected = EMPTY;
+        if (!_state.compare_exchange_strong(
+                expected, WRITING, std::memory_order_seq_cst,
+                std::memory_order_seq_cst)) {
+            return false;
+        }
+
+        for (size_t word = 0; word < _words.size(); ++word) {
+            _words[word].store(packWord(peerHash, word),
+                               std::memory_order_seq_cst);
+        }
+        _state.store(READY, std::memory_order_seq_cst);
+        return true;
+    }
+
+    bool take(PeerHash& peerHash) {
+        if (_state.load(std::memory_order_seq_cst) != READY) return false;
+
+        PeerHash snapshot{};
+        for (size_t word = 0; word < _words.size(); ++word) {
+            unpackWord(_words[word].load(std::memory_order_seq_cst),
+                       snapshot, word);
+        }
+
+        uint32_t expected = READY;
+        if (!_state.compare_exchange_strong(
+                expected, EMPTY, std::memory_order_seq_cst,
+                std::memory_order_seq_cst)) {
+            return false;
+        }
+        peerHash = snapshot;
+        return true;
+    }
+
+private:
+    static constexpr uint32_t EMPTY = 0;
+    static constexpr uint32_t WRITING = 1;
+    static constexpr uint32_t READY = 2;
+
+    static uint32_t packWord(const PeerHash& peerHash, size_t word) {
+        const size_t offset = word * 4;
+        return static_cast<uint32_t>(peerHash[offset]) |
+               (static_cast<uint32_t>(peerHash[offset + 1]) << 8) |
+               (static_cast<uint32_t>(peerHash[offset + 2]) << 16) |
+               (static_cast<uint32_t>(peerHash[offset + 3]) << 24);
+    }
+
+    static void unpackWord(uint32_t packed, PeerHash& peerHash, size_t word) {
+        const size_t offset = word * 4;
+        peerHash[offset] = static_cast<uint8_t>(packed);
+        peerHash[offset + 1] = static_cast<uint8_t>(packed >> 8);
+        peerHash[offset + 2] = static_cast<uint8_t>(packed >> 16);
+        peerHash[offset + 3] = static_cast<uint8_t>(packed >> 24);
+    }
+
+    std::array<std::atomic<uint32_t>, 4> _words{};
+    std::atomic<uint32_t> _state{EMPTY};
+};
+
+} // namespace LXMF
+} // namespace UI
+
+#endif // UI_LXMF_CALLSTARTMAILBOX_H

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -387,10 +387,11 @@ void UIManager::update() {
     }
     LVGL_LOCK();
 
-    // Outgoing starts are initiated only here on loopTask. Reticulum callback
-    // dispatch also runs on loopTask, in a later reticulum->loop() iteration,
-    // so Link construction, exact-ID publication, and state assignment finish
-    // before an establishment response can be processed.
+    // Outgoing starts are initiated here while the recursive LVGL mutex is
+    // held. Interface workers (notably BLE) can synchronously dispatch
+    // Reticulum callbacks on their own tasks, so every call-lifecycle callback
+    // takes this same mutex. A response therefore cannot run until Link
+    // construction, exact-ID publication, and state assignment finish.
     CallStartMailbox::PeerHash startPeerHash{};
     if (_call_starts.take(startPeerHash)) {
         if (_call_state == CallState::IDLE &&
@@ -1059,9 +1060,10 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     lxst_breadcrumb(4, ESP.getFreeHeap());
 
     // Reserve a generation only after the outgoing call has passed its
-    // acceptance checks. Call initiation and Reticulum callback dispatch are
-    // serialized on loopTask; the atomic reservation remains the definitive
-    // admission check against an incoming owner accepted before this update.
+    // acceptance checks. update() holds the recursive LVGL mutex across this
+    // entire initiation, and call-lifecycle callbacks take the same mutex even
+    // when an interface task dispatches them. The atomic reservation remains
+    // the definitive ownership check.
     const uint32_t generation = call_begin_generation();
     if (generation == 0) {
         WARNING("LXST: Another call was accepted concurrently");
@@ -1986,6 +1988,7 @@ void UIManager::call_update() {
 
 void UIManager::on_call_link_established(Link& link) {
     if (!s_call_instance) return;
+    LVGL_LOCK();
     auto* self = s_call_instance;
 
     CallLinkOwnership::LinkId link_id{};
@@ -2019,6 +2022,7 @@ void UIManager::on_call_link_established(Link& link) {
 
 void UIManager::on_call_link_closed(Link& link) {
     if (!s_call_instance) return;
+    LVGL_LOCK();
     auto* self = s_call_instance;
 
     CallLinkOwnership::LinkId link_id{};
@@ -2044,6 +2048,7 @@ void UIManager::on_call_link_closed(Link& link) {
 
 void UIManager::on_call_link_packet(const Bytes& plaintext, const Packet& packet) {
     if (!s_call_instance) return;
+    LVGL_LOCK();
     auto* self = s_call_instance;
     const Link& callback_link = packet.link();
     CallLinkOwnership::LinkId link_id{};
@@ -2067,6 +2072,7 @@ void UIManager::on_lxst_link_established(Link& link) {
         link.teardown();
         return;
     }
+    LVGL_LOCK();
     auto* self = s_call_instance;
 
     CallLinkOwnership::LinkId link_id{};
@@ -2076,9 +2082,9 @@ void UIManager::on_lxst_link_established(Link& link) {
         return;
     }
 
-    // Incoming and outgoing admissions are ordered on loopTask. The atomic
-    // generation reservation remains the definitive decision and protects
-    // against any future callback execution-context changes.
+    // Incoming and outgoing admissions are ordered by the recursive LVGL
+    // mutex, including when an interface worker dispatches this callback. The
+    // atomic generation reservation remains the definitive ownership decision.
     const uint32_t generation = self->call_begin_generation();
     lxst_breadcrumb(10, ESP.getFreeHeap());
     INFO("LXST: Incoming link established");
@@ -2134,6 +2140,7 @@ void UIManager::on_lxst_link_established(Link& link) {
 
 void UIManager::on_lxst_caller_identified(const Link& link, const Identity& identity) {
     if (!s_call_instance) return;
+    LVGL_LOCK();
     auto* self = s_call_instance;
     lxst_breadcrumb(15, ESP.getFreeHeap());
 

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -117,7 +117,6 @@ UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::Me
       _call_timeout_ms(0),
       _call_muted(false),
       _call_answer_pending(false),
-      _call_link_closed_generation(0),
       _call_signal_write(0),
       _call_signal_read(0),
       _call_audio_rx_count(0),
@@ -1044,9 +1043,6 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
         WARNING("LXST: Another call was accepted concurrently");
         return;
     }
-    // Publish link ownership before any state belonging to this call. The
-    // generation guard remains reserved until owner-side teardown completes.
-    _call_link_generation.store(generation, std::memory_order_release);
     _call_peer_hash = peer_hash;
     _call_muted = false;
 
@@ -1064,7 +1060,6 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     _call_answer_pending = false;
     _call_audio_rx_count = 0;
     _call_audio_tx_count = 0;
-    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
     _call_commands.take();
@@ -1078,9 +1073,15 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     }
 
     if (Transport::has_path(peer_dest.hash())) {
-        // Path known — create link immediately
+        // Register lifecycle callbacks in the constructor before the link
+        // request is sent. Publish the exact ID as soon as it returns.
         INFO("LXST: Creating link...");
         _call_link = Link(peer_dest, on_call_link_established, on_call_link_closed);
+        if (!call_publish_link(_call_link, generation)) {
+            WARNING("LXST: Link has invalid ID, aborting call");
+            call_ended();
+            return;
+        }
         _call_state = CallState::LINK_ESTABLISHING;
         _call_timeout_ms = millis() + 30000;
         INFO("LXST: Link establishing, 30s timeout");
@@ -1156,6 +1157,10 @@ void UIManager::call_hangup() {
     const uint32_t generation =
         call_current_generation();
 
+    // Detach callback ownership before touching the shared Link. Keep call
+    // admission reserved until all owner-side teardown completes.
+    _call_link_ownership.clear(generation);
+
     // call_hangup() is an owner operation: production UI paths reach it only
     // through update() on loopTask, which also owns pump_call_tx(). Keep the
     // generation reserved until teardown is complete so a concurrent incoming
@@ -1174,7 +1179,6 @@ void UIManager::call_hangup() {
     _call_timeout_ms = 0;
     _call_muted = false;
     _call_answer_pending = false;
-    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
     _call_audio_rx_count = 0;
@@ -1218,14 +1222,8 @@ uint32_t UIManager::call_begin_generation() {
 }
 
 void UIManager::call_clear_generation(uint32_t expected_generation) {
-    if (!_call_generation_guard.owns(expected_generation)) return;
-
-    // Keep the guard reserved while detaching link ownership. A stale teardown
-    // can neither clear a newer link owner nor release a newer reservation.
-    uint32_t expected_link_generation = expected_generation;
-    _call_link_generation.compare_exchange_strong(
-        expected_link_generation, 0, std::memory_order_acq_rel,
-        std::memory_order_acquire);
+    // Callback ownership was detached before Link teardown/reset. Release call
+    // admission last so a new owner cannot overlap old owner-side cleanup.
     _call_generation_guard.release(expected_generation);
 }
 
@@ -1233,11 +1231,27 @@ uint32_t UIManager::call_current_generation() const {
     return _call_generation_guard.current();
 }
 
-bool UIManager::call_owns_link(const Link& link, uint32_t generation) const {
+bool UIManager::call_extract_link_id(
+    const Link& link, CallLinkOwnership::LinkId& id) {
+    // link_id() asserts on a default/invalid Link in pinned microReticulum.
+    if (!link) return false;
+    const Bytes& link_id = link.link_id();
+    if (link_id.size() != id.size()) return false;
+    for (size_t i = 0; i < id.size(); ++i) id[i] = link_id[i];
+    return true;
+}
+
+bool UIManager::call_publish_link(const Link& link, uint32_t generation) {
+    CallLinkOwnership::LinkId id{};
+    return call_extract_link_id(link, id) &&
+           _call_link_ownership.publish(generation, id);
+}
+
+bool UIManager::call_owns_link(
+    const CallLinkOwnership::LinkId& id, uint32_t generation) const {
     return generation != 0 &&
            _call_generation_guard.owns(generation) &&
-           _call_link_generation.load(std::memory_order_acquire) == generation &&
-           _call_link && _call_link == link;
+           _call_link_ownership.owns(generation, id);
 }
 
 void UIManager::call_teardown_audio() {
@@ -1250,7 +1264,11 @@ void UIManager::call_teardown_audio() {
 }
 
 void UIManager::call_send_signal(int signal) {
-    if (!_call_link || _call_link.status() != Type::Link::ACTIVE) return;
+    call_send_signal_on_link(_call_link, signal);
+}
+
+void UIManager::call_send_signal_on_link(const Link& link, int signal) {
+    if (!link || link.status() != Type::Link::ACTIVE) return;
 
     // Msgpack: {0x00: [signal]}
     // fixmap(1) + key(0) + fixarray(1) + msgpack-encoded integer
@@ -1280,7 +1298,7 @@ void UIManager::call_send_signal(int signal) {
 
     try {
         Bytes signal_data(msgpack_buf, len);
-        Packet packet(_call_link, signal_data);
+        Packet packet(link, signal_data);
         packet.send();
 
         char buf[48];
@@ -1685,6 +1703,10 @@ void UIManager::call_ended() {
     const uint32_t generation =
         call_current_generation();
 
+    // Reject all callbacks before shared Link teardown/reset. Keep the call
+    // generation reserved until owner-side cleanup is complete.
+    _call_link_ownership.clear(generation);
+
     call_teardown_audio();
 
     // Teardown link
@@ -1699,7 +1721,6 @@ void UIManager::call_ended() {
     _call_timeout_ms = 0;
     _call_muted = false;
     _call_answer_pending = false;
-    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
     _call_audio_rx_count = 0;
@@ -1802,13 +1823,9 @@ void UIManager::stop_loopback() {
 void UIManager::call_update() {
     uint32_t now = millis();
 
-    // Consume exactly one deferred close. It may have been stored by an old
-    // callback after teardown cleared the slot, so revalidate both generation
-    // and the current stored owner before allowing it to end a call.
-    const uint32_t closed_generation =
-        _call_link_closed_generation.exchange(0, std::memory_order_acq_rel);
-    if (closed_generation != 0 &&
-        call_owns_link(_call_link, closed_generation)) {
+    // Consume only the current owner's atomically generation-bound close. No
+    // shared Link read is needed on this callback-to-loopTask handoff.
+    if (_call_link_ownership.takeClosed() != 0) {
         call_ended();
         return;
     }
@@ -1856,7 +1873,15 @@ void UIManager::call_update() {
             }
             Destination peer_dest(peer_identity, Type::Destination::OUT,
                                   Type::Destination::SINGLE, "lxst", "telephony");
+            const uint32_t generation = call_current_generation();
+            // Register callbacks before the constructor sends the link request,
+            // then publish its exact ID immediately after construction.
             _call_link = Link(peer_dest, on_call_link_established, on_call_link_closed);
+            if (!call_publish_link(_call_link, generation)) {
+                WARNING("LXST: Link has invalid ID, aborting call");
+                call_ended();
+                return;
+            }
             _call_state = CallState::LINK_ESTABLISHING;
             _call_timeout_ms = millis() + 30000;
             INFO("LXST: Link establishing, 30s timeout");
@@ -1940,9 +1965,14 @@ void UIManager::on_call_link_established(Link& link) {
     if (!s_call_instance) return;
     auto* self = s_call_instance;
 
+    CallLinkOwnership::LinkId link_id{};
+    if (!call_extract_link_id(link, link_id)) {
+        WARNING("LXST: Established link has invalid ID (ignoring)");
+        return;
+    }
     const uint32_t generation =
-        self->_call_link_generation.load(std::memory_order_acquire);
-    if (!self->call_owns_link(link, generation) ||
+        self->_call_link_ownership.generationFor(link_id);
+    if (!self->call_owns_link(link_id, generation) ||
         self->_call_state != CallState::LINK_ESTABLISHING) {
         WARNING("LXST: Stale outgoing link established (ignoring)");
         return;
@@ -1952,10 +1982,10 @@ void UIManager::on_call_link_established(Link& link) {
     snprintf(buf, sizeof(buf), "LXST: Outgoing link established (status=%d)", (int)link.status());
     INFO(buf);
 
-    // The initiating link is already the stored generation owner. Register on
-    // that owner without allowing a callback argument to overwrite it.
-    self->_call_link.set_packet_callback(on_call_link_packet);
-    self->_call_link.set_link_closed_callback(on_call_link_closed);
+    // Register through the validated callback argument; never read the
+    // manager's shared Link object from a transport-thread callback.
+    link.set_packet_callback(on_call_link_packet);
+    link.set_link_closed_callback(on_call_link_closed);
     INFO("LXST: Packet callback registered on outgoing link");
 
     // Transition to waiting for STATUS_AVAILABLE
@@ -1968,27 +1998,39 @@ void UIManager::on_call_link_closed(Link& link) {
     if (!s_call_instance) return;
     auto* self = s_call_instance;
 
+    CallLinkOwnership::LinkId link_id{};
+    if (!call_extract_link_id(link, link_id)) {
+        WARNING("LXST: Closed link has invalid ID (ignoring)");
+        return;
+    }
     const uint32_t generation =
-        self->_call_link_generation.load(std::memory_order_acquire);
-    if (!self->call_owns_link(link, generation)) {
+        self->_call_link_ownership.generationFor(link_id);
+    if (!self->call_owns_link(link_id, generation)) {
         WARNING("LXST: Stale link closed (ignoring)");
         return;
     }
 
     WARNING("LXST: Link closed (deferred)");
 
-    // Don't call call_ended() here — defer the owning generation to
-    // call_update() on loopTask, which revalidates ownership after exchange.
-    self->_call_link_closed_generation.store(generation, std::memory_order_release);
+    // Bind pending and generation in one CAS. If ownership changed after the
+    // validation above, this exact old state cannot overwrite the new slot.
+    if (!self->_call_link_ownership.markClosed(generation, link_id)) {
+        WARNING("LXST: Link owner changed before close deferral (ignoring)");
+    }
 }
 
 void UIManager::on_call_link_packet(const Bytes& plaintext, const Packet& packet) {
     if (!s_call_instance) return;
     auto* self = s_call_instance;
     const Link& callback_link = packet.link();
+    CallLinkOwnership::LinkId link_id{};
+    if (!call_extract_link_id(callback_link, link_id)) {
+        WARNING("LXST: Packet link has invalid ID (ignoring)");
+        return;
+    }
     const uint32_t generation =
-        self->_call_link_generation.load(std::memory_order_acquire);
-    if (!self->call_owns_link(callback_link, generation)) {
+        self->_call_link_ownership.generationFor(link_id);
+    if (!self->call_owns_link(link_id, generation)) {
         WARNING("LXST: Stale link packet (ignoring)");
         return;
     }
@@ -2003,6 +2045,13 @@ void UIManager::on_lxst_link_established(Link& link) {
         return;
     }
     auto* self = s_call_instance;
+
+    CallLinkOwnership::LinkId link_id{};
+    if (!call_extract_link_id(link, link_id)) {
+        WARNING("LXST: Incoming link has invalid ID (rejecting)");
+        link.teardown();
+        return;
+    }
 
     // Incoming callbacks race outgoing initiation and other incoming links.
     // The atomic generation reservation is the definitive admission decision.
@@ -2021,17 +2070,23 @@ void UIManager::on_lxst_link_established(Link& link) {
         return;
     }
 
-    // Publish ownership and the identifying state before installing callbacks
-    // or sending availability. No ringing UI or tone is shown in this state.
+    // Store the accepted Link before publishing its exact 128-bit ID. No
+    // callbacks are installed on the stored owner until publication and call
+    // state initialization are complete.
     lxst_breadcrumb(11, ESP.getFreeHeap());
-    self->_call_link_generation.store(generation, std::memory_order_release);
     self->_call_link = link;
+    if (!self->_call_link_ownership.publish(generation, link_id)) {
+        WARNING("LXST: Incoming link has invalid ID (rejecting)");
+        self->_call_link.teardown();
+        self->_call_link = Link(Type::NONE);
+        self->_call_generation_guard.release(generation);
+        return;
+    }
     self->_call_state = CallState::INCOMING_IDENTIFYING;
     self->_call_peer_hash = Bytes();
     self->_call_dest_hash = Bytes();
     self->_call_muted = false;
     self->_call_answer_pending = false;
-    self->_call_link_closed_generation.store(0, std::memory_order_release);
     self->_call_signal_write = 0;
     self->_call_signal_read = 0;
     self->_call_audio_rx_count = 0;
@@ -2039,14 +2094,14 @@ void UIManager::on_lxst_link_established(Link& link) {
     self->_call_commands.take();
     self->_call_timeout_ms = millis() + INCOMING_IDENTIFY_TIMEOUT_MS;
 
-    // Wait for the accepted caller to identify and observe link closure through
-    // the stored owner link, whose shared-object identity is generation-bound.
-    self->_call_link.set_remote_identified_callback(on_lxst_caller_identified);
-    self->_call_link.set_link_closed_callback(on_call_link_closed);
+    // Wait for the accepted caller to identify and observe closure. Install on
+    // the validated callback argument, not the manager's shared Link handle.
+    link.set_remote_identified_callback(on_lxst_caller_identified);
+    link.set_link_closed_callback(on_call_link_closed);
 
     // Send STATUS_AVAILABLE
     lxst_breadcrumb(12, ESP.getFreeHeap());
-    self->call_send_signal(LXST_STATUS_AVAILABLE);
+    call_send_signal_on_link(link, LXST_STATUS_AVAILABLE);
 
     lxst_breadcrumb(13, ESP.getFreeHeap());
     INFO("LXST: Waiting for caller identity (15s timeout)");
@@ -2058,11 +2113,16 @@ void UIManager::on_lxst_caller_identified(const Link& link, const Identity& iden
     auto* self = s_call_instance;
     lxst_breadcrumb(15, ESP.getFreeHeap());
 
-    // Bind identity to both the current owner link and its generation. A stale
-    // callback must not tear down or mutate a newer call.
+    CallLinkOwnership::LinkId link_id{};
+    if (!call_extract_link_id(link, link_id)) {
+        WARNING("LXST: Identified link has invalid ID (ignoring)");
+        return;
+    }
+    // Bind identity to the exact current owner ID and generation. Validation
+    // never reads the manager's shared Link object.
     const uint32_t generation =
-        self->_call_link_generation.load(std::memory_order_acquire);
-    if (!self->call_owns_link(link, generation) ||
+        self->_call_link_ownership.generationFor(link_id);
+    if (!self->call_owns_link(link_id, generation) ||
         self->_call_state != CallState::INCOMING_IDENTIFYING) {
         WARNING("LXST: Stale caller identified (ignoring)");
         return;
@@ -2074,15 +2134,17 @@ void UIManager::on_lxst_caller_identified(const Link& link, const Identity& iden
     // Store peer info
     self->_call_peer_hash = identity.hash();
 
-    // Set packet callback for signalling + audio on this link
-    self->_call_link.set_packet_callback(on_call_link_packet);
+    // Set callbacks and send through a callback-local shared-object copy, not
+    // through the manager's concurrently resettable Link handle.
+    Link callback_link(link);
+    callback_link.set_packet_callback(on_call_link_packet);
 
     // Identification completed for the reserved owner; ringing can now become
     // visible and actionable on the next call_update().
     self->_call_state = CallState::INCOMING_RINGING;
 
     // Send STATUS_RINGING
-    self->call_send_signal(LXST_STATUS_RINGING);
+    call_send_signal_on_link(callback_link, LXST_STATUS_RINGING);
 
     // Incoming ringing UI will be shown in call_update().
     self->_call_timeout_ms = millis() + 60000;  // 60s ring timeout

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -14,6 +14,7 @@
 #include "Tone.h"
 #include "../LVGL/LVGLLock.h"
 #include "lxst_audio.h"
+#include "ULBWVoiceProfilePolicy.h"
 #include <microReticulum/Packet.h>
 #include <microReticulum/Transport.h>
 #include <microReticulum/Destination.h>
@@ -74,21 +75,12 @@ public:
 };
 static std::shared_ptr<LXSTAnnounceHandler> s_lxst_announce_handler;
 
-// Default preferred profile: Codec2-1600 (VLBW). Good quality at low CPU and the
-// right default for WiFi/IP calls (where most calls run with the app). 700C (ULBW)
-// is BOTH the lowest quality AND the heaviest Codec2 mode (newamp1) -- reserve it for
-// marginal LoRa links by selecting ULBW (via the call profile setting / T:CALL_PROFILE
-// hook). TODO: auto-select per active interface (WiFi->LBW/3200, LoRa-only->ULBW/700C).
-// See the LXST voice audit (2026-06-23).
-int UIManager::_preferred_profile = UIManager::LXST_PROFILE_VLBW;
+// LoRa bandwidth is a production constraint: Pyxis advertises and accepts only
+// LXST ULBW/Codec2-700C.
+int UIManager::_preferred_profile = UIManager::LXST_PROFILE_ULBW;
 
 int UIManager::profile_to_codec2_mode(int profile) {
-    switch (profile) {
-        case LXST_PROFILE_ULBW: return CODEC2_MODE_700C;
-        case LXST_PROFILE_VLBW: return CODEC2_MODE_1600;
-        case LXST_PROFILE_LBW:  return CODEC2_MODE_3200;
-        default:                return -1;
-    }
+    return ULBWVoiceProfilePolicy::codecModeForProfile(profile);
 }
 
 UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::MessageStore& store)
@@ -1383,12 +1375,11 @@ void UIManager::call_send_audio_batch(const uint8_t* batch_data, int batch_len,
     // Match LXST-kt (Columba) wire format exactly:
     //   {0x01: bin8(batch)} for single batch, or
     //   {0x01: fixarray(N)[bin8(b1), bin8(b2), ...]} for multiple batches.
-    // Each batch = [codec_type(0x02)] + [mode_header] + [10 * raw_codec2].
-    // Columba's native ring buffer expects exactly frameSamples (1600) decoded
-    // samples per writeEncodedPacket call.  For Codec2 3200: 10 * 160 = 1600.
+    // Each batch = [codec_type(0x02)] + [mode_header] + [N * raw_codec2].
+    // Production Pyxis sends the ULBW 400 ms quantum: 10 Codec2-700C frames.
     // batch_len is the EXACT byte length of one batch, computed by the caller from
     // the real encoded size (codec_type + mode_header + N*raw_codec2). It VARIES by
-    // Codec2 mode: 42 bytes for 700C (4 bytes/frame), 82 for 1600/3200 (8/frame).
+    // ULBW batch length is 42 bytes: codec type + mode header + 10*4 bytes.
     // (Previously hardcoded to 82, which shipped 40 bytes of uninitialized stack and
     // a lying bin8 length on every 700C packet -- the voice-quality root cause.)
 
@@ -1476,6 +1467,17 @@ void UIManager::call_rx_audio_frame(const uint8_t* frame, size_t frame_len) {
         return;  // Can't decode Opus (0x01) or Raw (0x00) — only Codec2
     }
 
+    // The encoder and decoder deliberately share one Codec2 state object. Never
+    // pass a wider-mode header into decode(), since its dynamic mode switch would
+    // also mutate the transmitter away from the ULBW-only production contract.
+    if (!ULBWVoiceProfilePolicy::acceptsCodec2ModeHeader(codec_data[0])) {
+        char dbg[72];
+        snprintf(dbg, sizeof(dbg),
+                 "LXST: RX audio dropped (non-ULBW mode 0x%02X)", codec_data[0]);
+        WARNING(dbg);
+        return;
+    }
+
     if (_lxst_audio->isPlaying()) {
         if (_lxst_audio->writeEncodedPacket(codec_data, codec_data_len)) {
             _call_audio_rx_count++;
@@ -1546,9 +1548,9 @@ void UIManager::call_on_packet(const Bytes& data) {
             return;
         }
 
-        // Handle PREFERRED_PROFILE signals (0xFF+)
-        // Remote sends PREFERRED_PROFILE + profile_id to request a codec profile.
-        // Pyxis only supports Codec2, so respond with LBW (Codec2 3200bps).
+        // Remote sends PREFERRED_PROFILE + profile_id to request a transmit
+        // profile. Pyxis is ULBW-only for LoRa: never adopt the request, and
+        // respond with ULBW so the peer switches its transmit pipeline to 700C.
         if (signal >= LXST_PREFERRED_PROFILE) {
             int remote_profile = signal - LXST_PREFERRED_PROFILE;
             char dbg[80];
@@ -1556,7 +1558,7 @@ void UIManager::call_on_packet(const Bytes& data) {
                      "LXST: Remote prefers profile 0x%02X, responding 0x%02X",
                      remote_profile, _preferred_profile);
             INFO(dbg);
-            call_send_signal(LXST_PREFERRED_PROFILE + _preferred_profile);
+            call_send_signal(ULBWVoiceProfilePolicy::preferredProfileSignal());
             return;
         }
 
@@ -1674,7 +1676,7 @@ void UIManager::call_process_signal(uint8_t signal) {
             if (signal == LXST_STATUS_RINGING) {
                 INFO("LXST: Remote is ringing");
                 // Tell remote our preferred profile (default ULBW = Codec2-700C)
-                call_send_signal(LXST_PREFERRED_PROFILE + _preferred_profile);
+                call_send_signal(ULBWVoiceProfilePolicy::preferredProfileSignal());
                 _call_state = CallState::RINGING;
                 _call_timeout_ms = millis() + 60000;
                 _call_screen->set_state(CallScreen::CallState::RINGING);
@@ -1835,13 +1837,14 @@ void UIManager::pump_call_tx() {
         }
         if (encoded_len < 2) { available--; continue; }
 
-        // Prepend codec type byte: [0x02] + [encoded: mode_header + 10*8 raw]
+        // Prepend codec type byte: [0x02] + [mode_header + N raw Codec2 frames].
         uint8_t batch_data[128];
         batch_data[0] = LXST_CODEC_CODEC2;
         memcpy(batch_data + 1, encoded_buf, encoded_len);
         int batch_len = 1 + encoded_len;
 
-        call_send_audio_batch(batch_data, batch_len, 1, encoded_len / 8);
+        const int framesPerPacket = ULBWVoiceProfilePolicy::framesPerPacket(320);
+        call_send_audio_batch(batch_data, batch_len, 1, framesPerPacket);
         _call_audio_tx_count++;
         available--;
 
@@ -2296,7 +2299,7 @@ void UIManager::call_answer() {
 
     // Send profile preference (default ULBW = Codec2-700C). Answerer
     // sends last and wins.
-    call_send_signal(LXST_PREFERRED_PROFILE + _preferred_profile);
+    call_send_signal(ULBWVoiceProfilePolicy::preferredProfileSignal());
 
     // Send STATUS_ESTABLISHED
     call_send_signal(LXST_STATUS_ESTABLISHED);

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -130,7 +130,7 @@ UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::Me
 UIManager::~UIManager() {
     // Clean up call state
     if (_call_state != CallState::IDLE ||
-        _call_generation.load(std::memory_order_acquire) != 0) {
+        call_current_generation() != 0) {
         call_hangup();
     }
     call_teardown_audio();
@@ -393,7 +393,7 @@ void UIManager::update() {
 
     // Consume UI commands unconditionally. LVGL callbacks only publish into
     // the mailbox; loopTask remains the sole owner of the audio pipeline.
-    const uint32_t generation = _call_generation.load(std::memory_order_acquire);
+    const uint32_t generation = call_current_generation();
     const CallCommandMailbox::Command command =
         _call_commands.takeForGeneration(generation);
     if (command.action == CallCommandMailbox::Action::HANGUP) {
@@ -405,7 +405,7 @@ void UIManager::update() {
     // Pump voice call state while a call is active or its generation remains
     // reserved during owner-side teardown.
     if (_call_state != CallState::IDLE ||
-        _call_generation.load(std::memory_order_acquire) != 0) {
+        call_current_generation() != 0) {
         call_update();
     }
 
@@ -1039,10 +1039,14 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     // Reserve a generation only after the outgoing call has passed its
     // acceptance checks. Incoming-link callbacks can race this LVGL path, so
     // the atomic reservation is the definitive admission check.
-    if (!call_begin_generation()) {
+    const uint32_t generation = call_begin_generation();
+    if (generation == 0) {
         WARNING("LXST: Another call was accepted concurrently");
         return;
     }
+    // Publish link ownership before any state belonging to this call. The
+    // generation guard remains reserved until owner-side teardown completes.
+    _call_link_generation.store(generation, std::memory_order_release);
     _call_peer_hash = peer_hash;
     _call_muted = false;
 
@@ -1147,7 +1151,7 @@ void UIManager::call_hangup() {
     INFO("LXST: Hanging up");
 
     const uint32_t generation =
-        _call_generation.load(std::memory_order_acquire);
+        call_current_generation();
 
     // call_hangup() is an owner operation: production UI paths reach it only
     // through update() on loopTask, which also owns pump_call_tx(). Keep the
@@ -1162,7 +1166,13 @@ void UIManager::call_hangup() {
     }
 
     _call_peer_hash = Bytes();
+    _call_dest_hash = Bytes();
+    _call_timeout_ms = 0;
+    _call_answer_pending = false;
     _call_link_closed_pending = false;
+    _call_signal_write = 0;
+    _call_signal_read = 0;
+    _call_commands.take();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
 
@@ -1188,31 +1198,39 @@ void UIManager::call_set_mute(bool muted) {
 
 void UIManager::call_request_hangup() {
     _call_commands.requestHangup(
-        _call_generation.load(std::memory_order_acquire));
+        call_current_generation());
 }
 
 void UIManager::call_request_mute(bool muted) {
     _call_commands.requestMute(
-        _call_generation.load(std::memory_order_acquire), muted);
+        call_current_generation(), muted);
 }
 
-bool UIManager::call_begin_generation() {
-    uint32_t generation = 0;
-    while (generation == 0) {
-        generation = _call_generation_counter.fetch_add(
-            1, std::memory_order_relaxed) & CallCommandMailbox::MAX_GENERATION;
-    }
-    uint32_t expected = 0;
-    return _call_generation.compare_exchange_strong(
-        expected, generation, std::memory_order_acq_rel,
-        std::memory_order_acquire);
+uint32_t UIManager::call_begin_generation() {
+    return _call_generation_guard.tryReserve();
 }
 
 void UIManager::call_clear_generation(uint32_t expected_generation) {
-    if (expected_generation == 0) return;
-    _call_generation.compare_exchange_strong(
-        expected_generation, 0, std::memory_order_acq_rel,
+    if (!_call_generation_guard.owns(expected_generation)) return;
+
+    // Keep the guard reserved while detaching link ownership. A stale teardown
+    // can neither clear a newer link owner nor release a newer reservation.
+    uint32_t expected_link_generation = expected_generation;
+    _call_link_generation.compare_exchange_strong(
+        expected_link_generation, 0, std::memory_order_acq_rel,
         std::memory_order_acquire);
+    _call_generation_guard.release(expected_generation);
+}
+
+uint32_t UIManager::call_current_generation() const {
+    return _call_generation_guard.current();
+}
+
+bool UIManager::call_owns_link(const Link& link, uint32_t generation) const {
+    return generation != 0 &&
+           _call_generation_guard.owns(generation) &&
+           _call_link_generation.load(std::memory_order_acquire) == generation &&
+           _call_link && _call_link == link;
 }
 
 void UIManager::call_teardown_audio() {
@@ -1658,7 +1676,7 @@ void UIManager::call_ended() {
     INFO("LXST: Call ended");
 
     const uint32_t generation =
-        _call_generation.load(std::memory_order_acquire);
+        call_current_generation();
 
     call_teardown_audio();
 
@@ -1669,7 +1687,13 @@ void UIManager::call_ended() {
     }
 
     _call_peer_hash = Bytes();
+    _call_dest_hash = Bytes();
+    _call_timeout_ms = 0;
+    _call_answer_pending = false;
     _call_link_closed_pending = false;
+    _call_signal_write = 0;
+    _call_signal_read = 0;
+    _call_commands.take();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
 
@@ -1722,7 +1746,7 @@ void UIManager::start_loopback() {
     // Don't stomp a live real call. (The harness never overlaps the two, but
     // be defensive: a real call owns _lxst_audio and must not be torn down.)
     if (_call_state != CallState::IDLE ||
-        _call_generation.load(std::memory_order_acquire) != 0) {
+        call_current_generation() != 0) {
         WARNING("LXST: Loopback refused — call in progress");
         return;
     }
@@ -1989,12 +2013,14 @@ void UIManager::on_lxst_caller_identified(const Link& link, const Identity& iden
 
     // Reserve admission only once the incoming call is identified and is about
     // to become actionable. A newer accepted call wins this CAS.
-    if (!self->call_begin_generation()) {
+    const uint32_t generation = self->call_begin_generation();
+    if (generation == 0) {
         WARNING("LXST: Caller identified after another call was accepted (ignoring)");
         return;
     }
 
     // The generation is now reserved for this current identified link.
+    self->_call_link_generation.store(generation, std::memory_order_release);
     self->_call_state = CallState::INCOMING_RINGING;
 
     // Store peer info

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -227,6 +227,7 @@ bool UIManager::init() {
             INFO("Sending LXMF announce...");
             try {
                 _router.announce();
+                announce_lxst();
                 INFO("LXMF announce sent successfully");
             } catch (const std::exception& e) {
                 ERRORF("LXMF announce failed: %s", e.what());
@@ -1193,6 +1194,12 @@ void UIManager::call_hangup() {
     const uint32_t generation =
         call_current_generation();
 
+    // Normal call termination gets an application-level terminal signal before
+    // the one-shot, unacknowledged Reticulum LINKCLOSE. Repetition and the
+    // bounded drain interval reduce packet-loss races without blocking the
+    // owner task indefinitely. Older peers ignore unknown status 0x07.
+    call_send_terminal_burst();
+
     // Detach callback ownership before touching the shared Link. Keep call
     // admission reserved until all owner-side teardown completes.
     _call_link_ownership.clear(generation);
@@ -1220,6 +1227,7 @@ void UIManager::call_hangup() {
     _call_audio_rx_count = 0;
     _call_audio_tx_count = 0;
     _call_commands.take();
+    _call_liveness.disarm();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
 
@@ -1301,6 +1309,17 @@ void UIManager::call_teardown_audio() {
 
 void UIManager::call_send_signal(int signal) {
     call_send_signal_on_link(_call_link, signal);
+}
+
+void UIManager::call_send_terminal_burst() {
+    if (!_call_link || _call_link.status() != Type::Link::ACTIVE) return;
+
+    for (int attempt = 0; attempt < TERMINAL_SIGNAL_SEND_COUNT; ++attempt) {
+        call_send_signal(LXST_STATUS_TERMINATED);
+        if (attempt + 1 < TERMINAL_SIGNAL_SEND_COUNT) {
+            delay(TERMINAL_SIGNAL_DRAIN_MS);
+        }
+    }
 }
 
 void UIManager::call_send_signal_on_link(const Link& link, int signal) {
@@ -1435,6 +1454,10 @@ void UIManager::call_rx_audio_frame(const uint8_t* frame, size_t frame_len) {
     // Guard: packets can arrive after hangup from the network pipeline.
     // In loopback mode _call_state stays IDLE, so bypass the IDLE guard.
     if (!_lxst_audio || (!_call_loopback && _call_state == CallState::IDLE)) return;
+    if (!frame || frame_len < 2) {
+        WARNING("LXST: RX audio dropped (truncated frame)");
+        return;
+    }
 
     // Wire format: [codec_type_byte] + [mode_header + codec2_subframes...]
     // codec_type: 0x00=Raw, 0x01=Opus, 0x02=Codec2 (matches LXST Codecs/__init__.py)
@@ -1453,14 +1476,20 @@ void UIManager::call_rx_audio_frame(const uint8_t* frame, size_t frame_len) {
         return;  // Can't decode Opus (0x01) or Raw (0x00) — only Codec2
     }
 
-    if (_lxst_audio && _lxst_audio->isPlaying()) {
-        _lxst_audio->writeEncodedPacket(codec_data, codec_data_len);
-        _call_audio_rx_count++;
-        if (_call_audio_rx_count <= 3) {
-            char dbg[80];
-            snprintf(dbg, sizeof(dbg), "LXST: RX audio #%lu mode=0x%02X len=%d",
-                     (unsigned long)_call_audio_rx_count, codec_data[0], (int)codec_data_len);
-            INFO(dbg);
+    if (_lxst_audio->isPlaying()) {
+        if (_lxst_audio->writeEncodedPacket(codec_data, codec_data_len)) {
+            _call_audio_rx_count++;
+            if (!_call_loopback && _call_state == CallState::ACTIVE) {
+                _call_liveness.observe(millis());
+            }
+            if (_call_audio_rx_count <= 3) {
+                char dbg[80];
+                snprintf(dbg, sizeof(dbg), "LXST: RX audio #%lu mode=0x%02X len=%d",
+                         (unsigned long)_call_audio_rx_count, codec_data[0], (int)codec_data_len);
+                INFO(dbg);
+            }
+        } else {
+            WARNING("LXST: RX audio dropped (invalid Codec2 frame)");
         }
     } else if (_call_audio_rx_count == 0) {
         WARNING("LXST: RX audio dropped (playback not active)");
@@ -1616,6 +1645,18 @@ void UIManager::call_process_signal(uint8_t signal) {
         INFO(dbg);
     }
 
+    // Terminal is generation-scoped and valid in every owned non-idle call
+    // state. call_ended() is idempotent with the subsequent Link-close callback
+    // because it clears link ownership before teardown.
+    if (signal == LXST_STATUS_TERMINATED) {
+        if (_call_state != CallState::IDLE ||
+            call_current_generation() != 0) {
+            INFO("LXST: Remote terminated call");
+            call_ended();
+        }
+        return;
+    }
+
     switch (_call_state) {
         case CallState::WAIT_AVAILABLE:
             if (signal == LXST_STATUS_AVAILABLE) {
@@ -1677,6 +1718,7 @@ void UIManager::call_process_signal(uint8_t signal) {
                 INFO("LXST: Call established!");
                 _call_state = CallState::ACTIVE;
                 _call_start_ms = millis();
+                _call_liveness.arm(_call_start_ms);
                 _call_screen->set_state(CallScreen::CallState::ACTIVE);
                 lxst_breadcrumb(24, ESP.getFreeHeap());
 
@@ -1713,6 +1755,7 @@ void UIManager::call_process_signal(uint8_t signal) {
                 INFO("LXST: Call established!");
                 _call_state = CallState::ACTIVE;
                 _call_start_ms = millis();
+                _call_liveness.arm(_call_start_ms);
                 _call_screen->set_state(CallScreen::CallState::ACTIVE);
 
                 // Ensure full-duplex is running
@@ -1762,6 +1805,7 @@ void UIManager::call_ended() {
     _call_audio_rx_count = 0;
     _call_audio_tx_count = 0;
     _call_commands.take();
+    _call_liveness.disarm();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
 
@@ -1961,6 +2005,13 @@ void UIManager::call_update() {
     if (_call_state == CallState::ACTIVE || _call_state == CallState::CONNECTING) {
         if (!_call_link || _call_link.status() == Type::Link::CLOSED) {
             WARNING("LXST: Link closed during call");
+            call_ended();
+            return;
+        }
+
+        if (_call_state == CallState::ACTIVE &&
+            _call_liveness.expired(now, CALL_MEDIA_LIVENESS_TIMEOUT_MS)) {
+            WARNING("LXST: Call media liveness timed out");
             call_ended();
             return;
         }
@@ -2253,6 +2304,7 @@ void UIManager::call_answer() {
     // Transition to active call
     _call_state = CallState::ACTIVE;
     _call_start_ms = millis();
+    _call_liveness.arm(_call_start_ms);
     INFO("LXST: Call active (answerer, full-duplex)");
 }
 

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -117,7 +117,7 @@ UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::Me
       _call_timeout_ms(0),
       _call_muted(false),
       _call_answer_pending(false),
-      _call_link_closed_pending(false),
+      _call_link_closed_generation(0),
       _call_signal_write(0),
       _call_signal_read(0),
       _call_audio_rx_count(0),
@@ -1061,11 +1061,13 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     lxst_breadcrumb(5, ESP.getFreeHeap());
 
     _call_dest_hash = peer_dest.hash();
+    _call_answer_pending = false;
     _call_audio_rx_count = 0;
     _call_audio_tx_count = 0;
-    _call_link_closed_pending = false;
+    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
+    _call_commands.take();
 
     {
         std::string dh = peer_dest.hash().toHex().substr(0, 16);
@@ -1168,11 +1170,15 @@ void UIManager::call_hangup() {
 
     _call_peer_hash = Bytes();
     _call_dest_hash = Bytes();
+    _call_start_ms = 0;
     _call_timeout_ms = 0;
+    _call_muted = false;
     _call_answer_pending = false;
-    _call_link_closed_pending = false;
+    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
+    _call_audio_rx_count = 0;
+    _call_audio_tx_count = 0;
     _call_commands.take();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
@@ -1689,11 +1695,15 @@ void UIManager::call_ended() {
 
     _call_peer_hash = Bytes();
     _call_dest_hash = Bytes();
+    _call_start_ms = 0;
     _call_timeout_ms = 0;
+    _call_muted = false;
     _call_answer_pending = false;
-    _call_link_closed_pending = false;
+    _call_link_closed_generation.store(0, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
+    _call_audio_rx_count = 0;
+    _call_audio_tx_count = 0;
     _call_commands.take();
     _call_state = CallState::IDLE;
     call_clear_generation(generation);
@@ -1792,9 +1802,13 @@ void UIManager::stop_loopback() {
 void UIManager::call_update() {
     uint32_t now = millis();
 
-    // Process deferred link closed (set by Reticulum callback, consumed here under LVGL lock)
-    if (_call_link_closed_pending) {
-        _call_link_closed_pending = false;
+    // Consume exactly one deferred close. It may have been stored by an old
+    // callback after teardown cleared the slot, so revalidate both generation
+    // and the current stored owner before allowing it to end a call.
+    const uint32_t closed_generation =
+        _call_link_closed_generation.exchange(0, std::memory_order_acq_rel);
+    if (closed_generation != 0 &&
+        call_owns_link(_call_link, closed_generation)) {
         call_ended();
         return;
     }
@@ -1924,45 +1938,61 @@ void UIManager::call_update() {
 
 void UIManager::on_call_link_established(Link& link) {
     if (!s_call_instance) return;
+    auto* self = s_call_instance;
+
+    const uint32_t generation =
+        self->_call_link_generation.load(std::memory_order_acquire);
+    if (!self->call_owns_link(link, generation) ||
+        self->_call_state != CallState::LINK_ESTABLISHING) {
+        WARNING("LXST: Stale outgoing link established (ignoring)");
+        return;
+    }
 
     char buf[80];
     snprintf(buf, sizeof(buf), "LXST: Outgoing link established (status=%d)", (int)link.status());
     INFO(buf);
 
-    // Update stored link with the established reference and register callbacks
-    s_call_instance->_call_link = link;
-    s_call_instance->_call_link.set_packet_callback(on_call_link_packet);
-    s_call_instance->_call_link.set_link_closed_callback(on_call_link_closed);
+    // The initiating link is already the stored generation owner. Register on
+    // that owner without allowing a callback argument to overwrite it.
+    self->_call_link.set_packet_callback(on_call_link_packet);
+    self->_call_link.set_link_closed_callback(on_call_link_closed);
     INFO("LXST: Packet callback registered on outgoing link");
 
     // Transition to waiting for STATUS_AVAILABLE
-    s_call_instance->_call_state = CallState::WAIT_AVAILABLE;
-    s_call_instance->_call_timeout_ms = millis() + 10000;  // 10s timeout
+    self->_call_state = CallState::WAIT_AVAILABLE;
+    self->_call_timeout_ms = millis() + 10000;  // 10s timeout
     INFO("LXST: Waiting for STATUS_AVAILABLE (10s timeout)");
 }
 
 void UIManager::on_call_link_closed(Link& link) {
     if (!s_call_instance) return;
+    auto* self = s_call_instance;
 
-    // Ignore stale link closures (e.g. old link teardown completing after a
-    // new call started). A missing current link is stale too: teardown may
-    // have reset _call_link before its later close callback is dispatched.
-    if (!s_call_instance->_call_link || link != s_call_instance->_call_link) {
+    const uint32_t generation =
+        self->_call_link_generation.load(std::memory_order_acquire);
+    if (!self->call_owns_link(link, generation)) {
         WARNING("LXST: Stale link closed (ignoring)");
         return;
     }
 
     WARNING("LXST: Link closed (deferred)");
 
-    // Don't call call_ended() here — defer to call_update() on loopTask.
-    if (s_call_instance->_call_state != CallState::IDLE) {
-        s_call_instance->_call_link_closed_pending = true;
-    }
+    // Don't call call_ended() here — defer the owning generation to
+    // call_update() on loopTask, which revalidates ownership after exchange.
+    self->_call_link_closed_generation.store(generation, std::memory_order_release);
 }
 
 void UIManager::on_call_link_packet(const Bytes& plaintext, const Packet& packet) {
     if (!s_call_instance) return;
-    s_call_instance->call_on_packet(plaintext);
+    auto* self = s_call_instance;
+    const Link& callback_link = packet.link();
+    const uint32_t generation =
+        self->_call_link_generation.load(std::memory_order_acquire);
+    if (!self->call_owns_link(callback_link, generation)) {
+        WARNING("LXST: Stale link packet (ignoring)");
+        return;
+    }
+    self->call_on_packet(plaintext);
 }
 
 // ── LXST Incoming Call Callbacks ──
@@ -2001,7 +2031,7 @@ void UIManager::on_lxst_link_established(Link& link) {
     self->_call_dest_hash = Bytes();
     self->_call_muted = false;
     self->_call_answer_pending = false;
-    self->_call_link_closed_pending = false;
+    self->_call_link_closed_generation.store(0, std::memory_order_release);
     self->_call_signal_write = 0;
     self->_call_signal_read = 0;
     self->_call_audio_rx_count = 0;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -1024,6 +1024,9 @@ static void lxst_breadcrumb(uint8_t step, uint32_t heap) {
 }
 
 void UIManager::call_initiate(const Bytes& peer_hash) {
+#ifdef PYXIS_TEST_HOOKS
+    _test_call_initiate_result = TestCallInitiateResult::FAILED;
+#endif
     {
         std::string h = peer_hash.toHex().substr(0, 16);
         INFO(("LXST: Initiating call to " + h + "...").c_str());
@@ -1066,6 +1069,9 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     // the definitive ownership check.
     const uint32_t generation = call_begin_generation();
     if (generation == 0) {
+#ifdef PYXIS_TEST_HOOKS
+        _test_call_initiate_result = TestCallInitiateResult::BUSY;
+#endif
         WARNING("LXST: Another call was accepted concurrently");
         return;
     }
@@ -1118,6 +1124,10 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
         _call_state = CallState::PATH_REQUESTING;
         _call_timeout_ms = millis() + 10000;
     }
+
+#ifdef PYXIS_TEST_HOOKS
+    _test_call_initiate_result = TestCallInitiateResult::STARTED;
+#endif
 
     lxst_breadcrumb(7, ESP.getFreeHeap());
 }

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -1139,6 +1139,7 @@ const char* UIManager::test_call_state_name() const {
         case CallState::WAIT_AVAILABLE:     return "WAIT_AVAILABLE";
         case CallState::WAIT_RINGING:       return "WAIT_RINGING";
         case CallState::RINGING:            return "RINGING";
+        case CallState::INCOMING_IDENTIFYING: return "INCOMING_IDENTIFYING";
         case CallState::INCOMING_RINGING:   return "INCOMING_RINGING";
         case CallState::CONNECTING:         return "CONNECTING";
         case CallState::ACTIVE:             return "ACTIVE";
@@ -1868,6 +1869,10 @@ void UIManager::call_update() {
                 WARNING("LXST: Ring timed out (no answer)");
                 call_ended();
                 return;
+            case CallState::INCOMING_IDENTIFYING:
+                WARNING("LXST: Incoming caller identification timed out");
+                call_ended();
+                return;
             case CallState::INCOMING_RINGING:
                 WARNING("LXST: Incoming call timed out (no answer)");
                 call_ended();
@@ -1963,13 +1968,20 @@ void UIManager::on_call_link_packet(const Bytes& plaintext, const Packet& packet
 // ── LXST Incoming Call Callbacks ──
 
 void UIManager::on_lxst_link_established(Link& link) {
-    if (!s_call_instance) return;
+    if (!s_call_instance) {
+        link.teardown();
+        return;
+    }
     auto* self = s_call_instance;
+
+    // Incoming callbacks race outgoing initiation and other incoming links.
+    // The atomic generation reservation is the definitive admission decision.
+    const uint32_t generation = self->call_begin_generation();
     lxst_breadcrumb(10, ESP.getFreeHeap());
     INFO("LXST: Incoming link established");
-
-    if (self->_call_state != CallState::IDLE) {
-        // Already in a call — send busy directly on the new link
+    if (generation == 0) {
+        // Another call owns the manager. Reject using only this callback's link;
+        // never touch the stored owner link or any owner-side call state.
         INFO("LXST: Busy, rejecting incoming link");
         uint8_t busy_buf[4] = { 0x81, 0x00, 0x91, LXST_STATUS_BUSY };
         Bytes busy_data(busy_buf, 4);
@@ -1979,19 +1991,35 @@ void UIManager::on_lxst_link_established(Link& link) {
         return;
     }
 
-    // Accept the incoming link
+    // Publish ownership and the identifying state before installing callbacks
+    // or sending availability. No ringing UI or tone is shown in this state.
     lxst_breadcrumb(11, ESP.getFreeHeap());
+    self->_call_link_generation.store(generation, std::memory_order_release);
     self->_call_link = link;
+    self->_call_state = CallState::INCOMING_IDENTIFYING;
+    self->_call_peer_hash = Bytes();
+    self->_call_dest_hash = Bytes();
     self->_call_muted = false;
+    self->_call_answer_pending = false;
+    self->_call_link_closed_pending = false;
+    self->_call_signal_write = 0;
+    self->_call_signal_read = 0;
+    self->_call_audio_rx_count = 0;
+    self->_call_audio_tx_count = 0;
+    self->_call_commands.take();
+    self->_call_timeout_ms = millis() + INCOMING_IDENTIFY_TIMEOUT_MS;
+
+    // Wait for the accepted caller to identify and observe link closure through
+    // the stored owner link, whose shared-object identity is generation-bound.
+    self->_call_link.set_remote_identified_callback(on_lxst_caller_identified);
+    self->_call_link.set_link_closed_callback(on_call_link_closed);
 
     // Send STATUS_AVAILABLE
     lxst_breadcrumb(12, ESP.getFreeHeap());
     self->call_send_signal(LXST_STATUS_AVAILABLE);
 
-    // Wait for caller to identify themselves
     lxst_breadcrumb(13, ESP.getFreeHeap());
-    link.set_remote_identified_callback(on_lxst_caller_identified);
-    link.set_link_closed_callback(on_call_link_closed);
+    INFO("LXST: Waiting for caller identity (15s timeout)");
     lxst_breadcrumb(14, ESP.getFreeHeap());
 }
 
@@ -2000,10 +2028,12 @@ void UIManager::on_lxst_caller_identified(const Link& link, const Identity& iden
     auto* self = s_call_instance;
     lxst_breadcrumb(15, ESP.getFreeHeap());
 
-    // Identification can arrive after another call replaced this pending link.
-    // Reticulum invokes this callback synchronously from loopTask, so equality
-    // with the current owner link is sufficient here; do not mutate newer state.
-    if (!self->_call_link || link != self->_call_link) {
+    // Bind identity to both the current owner link and its generation. A stale
+    // callback must not tear down or mutate a newer call.
+    const uint32_t generation =
+        self->_call_link_generation.load(std::memory_order_acquire);
+    if (!self->call_owns_link(link, generation) ||
+        self->_call_state != CallState::INCOMING_IDENTIFYING) {
         WARNING("LXST: Stale caller identified (ignoring)");
         return;
     }
@@ -2011,23 +2041,15 @@ void UIManager::on_lxst_caller_identified(const Link& link, const Identity& iden
     std::string hash_hex = identity.hash().toHex().substr(0, 16);
     INFO(("LXST: Caller identified: " + hash_hex + "...").c_str());
 
-    // Reserve admission only once the incoming call is identified and is about
-    // to become actionable. A newer accepted call wins this CAS.
-    const uint32_t generation = self->call_begin_generation();
-    if (generation == 0) {
-        WARNING("LXST: Caller identified after another call was accepted (ignoring)");
-        return;
-    }
-
-    // The generation is now reserved for this current identified link.
-    self->_call_link_generation.store(generation, std::memory_order_release);
-    self->_call_state = CallState::INCOMING_RINGING;
-
     // Store peer info
     self->_call_peer_hash = identity.hash();
 
     // Set packet callback for signalling + audio on this link
     self->_call_link.set_packet_callback(on_call_link_packet);
+
+    // Identification completed for the reserved owner; ringing can now become
+    // visible and actionable on the next call_update().
+    self->_call_state = CallState::INCOMING_RINGING;
 
     // Send STATUS_RINGING
     self->call_send_signal(LXST_STATUS_RINGING);

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -332,7 +332,9 @@ bool UIManager::init() {
 
     // Set up answer callback for incoming calls (deferred to main loop)
     _call_screen->set_answer_callback(
-        [this]() { _call_answer_pending = true; }
+        [this]() {
+            _call_answer_pending.store(true, std::memory_order_release);
+        }
     );
 
     // Load conversations and show conversation list
@@ -384,6 +386,21 @@ void UIManager::update() {
         _settings_screen->tick();  // keep the live clock / GPS / system readouts ticking
     }
     LVGL_LOCK();
+
+    // Outgoing starts are initiated only here on loopTask. Reticulum callback
+    // dispatch also runs on loopTask, in a later reticulum->loop() iteration,
+    // so Link construction, exact-ID publication, and state assignment finish
+    // before an establishment response can be processed.
+    CallStartMailbox::PeerHash startPeerHash{};
+    if (_call_starts.take(startPeerHash)) {
+        if (_call_state == CallState::IDLE &&
+            call_current_generation() == 0) {
+            call_initiate(Bytes(startPeerHash.data(), startPeerHash.size()));
+        } else {
+            WARNING("LXST: Discarding stale/busy call start request");
+        }
+    }
+
     // Process outbound LXMF messages
     _router.process_outbound();
 
@@ -667,12 +684,18 @@ bool UIManager::on_send_message_from_chat(const String& content) {
 
 void UIManager::on_call_from_chat() {
     if (!_current_peer_hash) return;
-    if (_call_state != CallState::IDLE) {
-        WARNING("Already in a call");
+    if (_current_peer_hash.size() != CallStartMailbox::PeerHash{}.size()) {
+        WARNING("LXST: Call peer hash is not exactly 16 bytes");
         return;
     }
 
-    call_initiate(_current_peer_hash);
+    CallStartMailbox::PeerHash peerHash{};
+    for (size_t i = 0; i < peerHash.size(); ++i) {
+        peerHash[i] = _current_peer_hash[i];
+    }
+    if (!_call_starts.request(peerHash)) {
+        WARNING("LXST: Call start already pending");
+    }
 }
 
 bool UIManager::on_send_message_from_compose(const Bytes& dest_hash, const String& message) {
@@ -1036,8 +1059,9 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     lxst_breadcrumb(4, ESP.getFreeHeap());
 
     // Reserve a generation only after the outgoing call has passed its
-    // acceptance checks. Incoming-link callbacks can race this LVGL path, so
-    // the atomic reservation is the definitive admission check.
+    // acceptance checks. Call initiation and Reticulum callback dispatch are
+    // serialized on loopTask; the atomic reservation remains the definitive
+    // admission check against an incoming owner accepted before this update.
     const uint32_t generation = call_begin_generation();
     if (generation == 0) {
         WARNING("LXST: Another call was accepted concurrently");
@@ -1057,7 +1081,7 @@ void UIManager::call_initiate(const Bytes& peer_hash) {
     lxst_breadcrumb(5, ESP.getFreeHeap());
 
     _call_dest_hash = peer_dest.hash();
-    _call_answer_pending = false;
+    _call_answer_pending.store(false, std::memory_order_release);
     _call_audio_rx_count = 0;
     _call_audio_tx_count = 0;
     _call_signal_write = 0;
@@ -1125,7 +1149,7 @@ bool UIManager::test_call_set_profile(int profile) {
 
 bool UIManager::test_call_answer() {
     if (_call_state != CallState::INCOMING_RINGING) return false;
-    _call_answer_pending = true;
+    _call_answer_pending.store(true, std::memory_order_release);
     return true;
 }
 
@@ -1178,7 +1202,7 @@ void UIManager::call_hangup() {
     _call_start_ms = 0;
     _call_timeout_ms = 0;
     _call_muted = false;
-    _call_answer_pending = false;
+    _call_answer_pending.store(false, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
     _call_audio_rx_count = 0;
@@ -1720,7 +1744,7 @@ void UIManager::call_ended() {
     _call_start_ms = 0;
     _call_timeout_ms = 0;
     _call_muted = false;
-    _call_answer_pending = false;
+    _call_answer_pending.store(false, std::memory_order_release);
     _call_signal_write = 0;
     _call_signal_read = 0;
     _call_audio_rx_count = 0;
@@ -1839,8 +1863,7 @@ void UIManager::call_update() {
     }
 
     // Process deferred answer (set by LVGL task, consumed here on main thread)
-    if (_call_answer_pending) {
-        _call_answer_pending = false;
+    if (_call_answer_pending.exchange(false, std::memory_order_acq_rel)) {
         call_answer();
     }
 
@@ -2053,8 +2076,9 @@ void UIManager::on_lxst_link_established(Link& link) {
         return;
     }
 
-    // Incoming callbacks race outgoing initiation and other incoming links.
-    // The atomic generation reservation is the definitive admission decision.
+    // Incoming and outgoing admissions are ordered on loopTask. The atomic
+    // generation reservation remains the definitive decision and protects
+    // against any future callback execution-context changes.
     const uint32_t generation = self->call_begin_generation();
     lxst_breadcrumb(10, ESP.getFreeHeap());
     INFO("LXST: Incoming link established");
@@ -2086,7 +2110,7 @@ void UIManager::on_lxst_link_established(Link& link) {
     self->_call_peer_hash = Bytes();
     self->_call_dest_hash = Bytes();
     self->_call_muted = false;
-    self->_call_answer_pending = false;
+    self->_call_answer_pending.store(false, std::memory_order_release);
     self->_call_signal_write = 0;
     self->_call_signal_read = 0;
     self->_call_audio_rx_count = 0;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -22,6 +22,7 @@
 #include "CallStartMailbox.h"
 #include "CallGenerationGuard.h"
 #include "CallLinkOwnership.h"
+#include "CallLivenessWatchdog.h"
 #include "LXMF/LXMRouter.h"
 #include "LXMF/PropagationNodeManager.h"
 #include "LXMF/MessageStore.h"
@@ -362,9 +363,17 @@ private:
     static constexpr uint8_t LXST_STATUS_RINGING      = 0x04;
     static constexpr uint8_t LXST_STATUS_CONNECTING   = 0x05;
     static constexpr uint8_t LXST_STATUS_ESTABLISHED  = 0x06;
+    // Backward-compatible extension. Legacy peers ignore this status and still
+    // receive the Reticulum Link-close fallback.
+    static constexpr uint8_t LXST_STATUS_TERMINATED   = 0x07;
+    static constexpr int TERMINAL_SIGNAL_SEND_COUNT = 3;
+    static constexpr uint32_t TERMINAL_SIGNAL_DRAIN_MS = 20;
 
     // An accepted incoming link must identify before it can start ringing.
     static constexpr uint32_t INCOMING_IDENTIFY_TIMEOUT_MS = 15000;
+    // Codec2 media is continuous even during silence. Ninety seconds permits
+    // substantial temporary impairment while bounding orphaned active calls.
+    static constexpr uint32_t CALL_MEDIA_LIVENESS_TIMEOUT_MS = 90000;
 
     // LXST codec type bytes (match LXST Codecs/__init__.py)
     static constexpr uint8_t LXST_CODEC_CODEC2 = 0x02;
@@ -415,6 +424,7 @@ private:
     CallCommandMailbox _call_commands;
     CallGenerationGuard _call_generation_guard;
     CallLinkOwnership _call_link_ownership;
+    CallLivenessWatchdog _call_liveness;
 #ifdef PYXIS_TEST_HOOKS
     TestCallInitiateResult _test_call_initiate_result =
         TestCallInitiateResult::FAILED;
@@ -459,6 +469,7 @@ private:
     // Send a signalling byte over the call link
     void call_send_signal(int signal);
     static void call_send_signal_on_link(const RNS::Link& link, int signal);
+    void call_send_terminal_burst();
 
     // Send batched audio frames over the call link (10 sub-frames per batch)
     void call_send_audio_batch(const uint8_t* batch_data, int batch_len, int batch_count, int total_frames);

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -19,6 +19,7 @@
 #include "CallScreen.h"
 #include "CallCommandMailbox.h"
 #include "CallGenerationGuard.h"
+#include "CallLinkOwnership.h"
 #include "LXMF/LXMRouter.h"
 #include "LXMF/PropagationNodeManager.h"
 #include "LXMF/MessageStore.h"
@@ -401,15 +402,12 @@ private:
     LXSTAudio* _lxst_audio;
     CallCommandMailbox _call_commands;
     CallGenerationGuard _call_generation_guard;
-    std::atomic<uint32_t> _call_link_generation{0};
+    CallLinkOwnership _call_link_ownership;
     uint32_t _call_start_ms;       // millis() when call became ACTIVE
     uint32_t _call_timeout_ms;     // millis() deadline for current wait state
     bool _call_muted;
     volatile bool _call_answer_pending;  // Set by LVGL task, consumed by main loop
-    // Owning generation set by the link callback and consumed by call_update.
-    // A generation, rather than a boolean, prevents a delayed close from ending
-    // a subsequently admitted call.
-    std::atomic<uint32_t> _call_link_closed_generation{0};
+
     // Signal queue: written by Reticulum thread, consumed by call_update under LVGL lock
     static constexpr int SIGNAL_QUEUE_SIZE = 8;
     volatile uint8_t _call_signal_queue[SIGNAL_QUEUE_SIZE];
@@ -430,7 +428,11 @@ private:
     uint32_t call_begin_generation();
     void call_clear_generation(uint32_t expected_generation);
     uint32_t call_current_generation() const;
-    bool call_owns_link(const RNS::Link& link, uint32_t generation) const;
+    static bool call_extract_link_id(
+        const RNS::Link& link, CallLinkOwnership::LinkId& id);
+    bool call_publish_link(const RNS::Link& link, uint32_t generation);
+    bool call_owns_link(
+        const CallLinkOwnership::LinkId& id, uint32_t generation) const;
     void call_teardown_audio();
     void call_update();  // Called from update() — pumps audio packets + state machine
 
@@ -439,6 +441,7 @@ private:
 
     // Send a signalling byte over the call link
     void call_send_signal(int signal);
+    static void call_send_signal_on_link(const RNS::Link& link, int signal);
 
     // Send batched audio frames over the call link (10 sub-frames per batch)
     void call_send_audio_batch(const uint8_t* batch_data, int batch_len, int batch_count, int total_frames);

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -18,6 +18,7 @@
 #include "PropagationNodesScreen.h"
 #include "CallScreen.h"
 #include "CallCommandMailbox.h"
+#include "CallGenerationGuard.h"
 #include "LXMF/LXMRouter.h"
 #include "LXMF/PropagationNodeManager.h"
 #include "LXMF/MessageStore.h"
@@ -395,8 +396,8 @@ private:
     RNS::Link _call_link{RNS::Type::NONE};
     LXSTAudio* _lxst_audio;
     CallCommandMailbox _call_commands;
-    std::atomic<uint32_t> _call_generation{0};
-    std::atomic<uint32_t> _call_generation_counter{1};
+    CallGenerationGuard _call_generation_guard;
+    std::atomic<uint32_t> _call_link_generation{0};
     uint32_t _call_start_ms;       // millis() when call became ACTIVE
     uint32_t _call_timeout_ms;     // millis() deadline for current wait state
     bool _call_muted;
@@ -419,8 +420,10 @@ private:
     void call_set_mute(bool muted);
     void call_request_hangup();
     void call_request_mute(bool muted);
-    bool call_begin_generation();
+    uint32_t call_begin_generation();
     void call_clear_generation(uint32_t expected_generation);
+    uint32_t call_current_generation() const;
+    bool call_owns_link(const RNS::Link& link, uint32_t generation) const;
     void call_teardown_audio();
     void call_update();  // Called from update() — pumps audio packets + state machine
 

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -202,8 +202,17 @@ public:
      * commands defined in main.cpp under PYXIS_TEST_HOOKS.
      */
 
-    /** Initiate an outgoing call to peer (calls private call_initiate). */
-    void test_call_initiate(const RNS::Bytes& peer_hash) { call_initiate(peer_hash); }
+    enum class TestCallInitiateResult {
+        FAILED,
+        BUSY,
+        STARTED,
+    };
+
+    /** Initiate an outgoing call and report its exact admission outcome. */
+    TestCallInitiateResult test_call_initiate(const RNS::Bytes& peer_hash) {
+        call_initiate(peer_hash);
+        return _test_call_initiate_result;
+    }
 
     /** Hang up the active call on loopTask (calls private call_hangup). */
     void test_call_hangup() { call_hangup(); }
@@ -406,6 +415,10 @@ private:
     CallCommandMailbox _call_commands;
     CallGenerationGuard _call_generation_guard;
     CallLinkOwnership _call_link_ownership;
+#ifdef PYXIS_TEST_HOOKS
+    TestCallInitiateResult _test_call_initiate_result =
+        TestCallInitiateResult::FAILED;
+#endif
     uint32_t _call_start_ms;       // millis() when call became ACTIVE
     uint32_t _call_timeout_ms;     // millis() deadline for current wait state
     bool _call_muted;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -273,10 +273,8 @@ public:
     void test_call_set_inject_sine(bool enabled, int freq = 1000, float amp = 0.5f);
 
     /**
-     * Get/set the preferred Codec2 profile pyxis advertises and uses
-     * for the next call. Valid values: LXST_PROFILE_ULBW (0x10,
-     * Codec2-700C, LoRa-friendly default), LXST_PROFILE_VLBW (0x20,
-     * Codec2-1600), LXST_PROFILE_LBW (0x30, Codec2-3200, used pre-2026).
+     * Get/set the production voice profile. Only ULBW (0x10,
+     * Codec2-700C) is accepted; wider profiles violate the LoRa budget.
      */
     int test_call_get_profile() const { return _preferred_profile; }
     bool test_call_set_profile(int profile);
@@ -380,14 +378,11 @@ private:
 
     // LXST profile negotiation
     static constexpr int LXST_PREFERRED_PROFILE = 0xFF;
-    static constexpr int LXST_PROFILE_ULBW      = 0x10;  // Codec2 700C  (~700 bps)  — heaviest CPU; reserve for marginal LoRa
-    static constexpr int LXST_PROFILE_VLBW      = 0x20;  // Codec2 1600bps — DEFAULT (good quality, low CPU)
-    static constexpr int LXST_PROFILE_LBW       = 0x30;  // Codec2 3200bps — best quality + lowest CPU; fast links
+    static constexpr int LXST_PROFILE_ULBW      = 0x10;  // Codec2 700C; sole production profile
+    static constexpr int LXST_PROFILE_VLBW      = 0x20;  // protocol value; unsupported locally
+    static constexpr int LXST_PROFILE_LBW       = 0x30;  // protocol value; unsupported locally
 
-    // The profile we ASK the remote for and CONFIGURE locally on every new call.
-    // Defaults to VLBW (Codec2-1600): 700C is the heaviest AND lowest-quality mode,
-    // so it is reserved for marginal LoRa links (select ULBW there). Test harness can
-    // override via T:CALL_PROFILE.
+    // The sole profile Pyxis asks the peer for and configures locally.
     static int _preferred_profile;
 
     // Map profile byte to the Codec2 library mode constant

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -7,6 +7,7 @@
 #ifdef ARDUINO
 #include <Arduino.h>
 #include <lvgl.h>
+#include <atomic>
 #include <functional>
 #include "ConversationListScreen.h"
 #include "ChatScreen.h"
@@ -18,6 +19,7 @@
 #include "PropagationNodesScreen.h"
 #include "CallScreen.h"
 #include "CallCommandMailbox.h"
+#include "CallStartMailbox.h"
 #include "CallGenerationGuard.h"
 #include "CallLinkOwnership.h"
 #include "LXMF/LXMRouter.h"
@@ -400,13 +402,15 @@ private:
     // takes the safe NoneConstructor branch. Same fix as DirectLinkSlot.
     RNS::Link _call_link{RNS::Type::NONE};
     LXSTAudio* _lxst_audio;
+    CallStartMailbox _call_starts;
     CallCommandMailbox _call_commands;
     CallGenerationGuard _call_generation_guard;
     CallLinkOwnership _call_link_ownership;
     uint32_t _call_start_ms;       // millis() when call became ACTIVE
     uint32_t _call_timeout_ms;     // millis() deadline for current wait state
     bool _call_muted;
-    volatile bool _call_answer_pending;  // Set by LVGL task, consumed by main loop
+    // Set by the LVGL task and consumed/reset by loopTask.
+    std::atomic<bool> _call_answer_pending;
 
     // Signal queue: written by Reticulum thread, consumed by call_update under LVGL lock
     static constexpr int SIGNAL_QUEUE_SIZE = 8;

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -351,6 +351,9 @@ private:
     static constexpr uint8_t LXST_STATUS_CONNECTING   = 0x05;
     static constexpr uint8_t LXST_STATUS_ESTABLISHED  = 0x06;
 
+    // An accepted incoming link must identify before it can start ringing.
+    static constexpr uint32_t INCOMING_IDENTIFY_TIMEOUT_MS = 15000;
+
     // LXST codec type bytes (match LXST Codecs/__init__.py)
     static constexpr uint8_t LXST_CODEC_CODEC2 = 0x02;
 
@@ -377,6 +380,7 @@ private:
         WAIT_AVAILABLE,     // Outgoing: link up, waiting for STATUS_AVAILABLE
         WAIT_RINGING,       // Outgoing: sent identify, waiting for STATUS_RINGING
         RINGING,            // Outgoing: remote is ringing
+        INCOMING_IDENTIFYING, // Incoming: link reserved, waiting for caller identity
         INCOMING_RINGING,   // Incoming: waiting for user to answer/reject
         CONNECTING,         // Both: opening audio pipelines
         ACTIVE,             // Both: voice flowing

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -406,7 +406,10 @@ private:
     uint32_t _call_timeout_ms;     // millis() deadline for current wait state
     bool _call_muted;
     volatile bool _call_answer_pending;  // Set by LVGL task, consumed by main loop
-    volatile bool _call_link_closed_pending;  // Set by link callback, consumed by call_update
+    // Owning generation set by the link callback and consumed by call_update.
+    // A generation, rather than a boolean, prevents a delayed close from ending
+    // a subsequently admitted call.
+    std::atomic<uint32_t> _call_link_closed_generation{0};
     // Signal queue: written by Reticulum thread, consumed by call_update under LVGL lock
     static constexpr int SIGNAL_QUEUE_SIZE = 8;
     volatile uint8_t _call_signal_queue[SIGNAL_QUEUE_SIZE];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,6 +138,16 @@ uint32_t last_announce = 0;
 uint32_t last_sync = 0;
 uint32_t last_status_check = 0;
 const uint32_t STATUS_CHECK_INTERVAL = 1000;  // 1 second
+
+void announce_reachable_destinations() {
+    if (!router) return;
+
+    router->announce();
+    if (ui_manager) {
+        ui_manager->announce_lxst();
+    }
+    last_announce = millis();
+}
 const uint32_t INITIAL_SYNC_DELAY = 45000;    // 45 seconds after boot before first sync
 bool initial_sync_done = false;
 
@@ -1231,13 +1241,10 @@ void setup_lxmf() {
         delay(3000);
         BOOT_PROFILE_WAIT_END("tcp_stabilize");
 
-        // Check TCP status before announcing
+        // Record whether TCP stabilized during boot. Destination announces are
+        // deferred until UIManager has constructed lxst.telephony.
         if (tcp_interface->online()) {
             INFO("TCP interface online: YES");
-            // Announce delivery destination
-            INFO("Sending LXMF announce...");
-            router->announce();
-            last_announce = millis();
         } else {
             INFO("TCP interface online: NO");
         }
@@ -1785,10 +1792,9 @@ void setup() {
     // gate because they are recoverable runtime operations.
     confirm_running_firmware();
 
-    // Send initial LXST voice destination announce
-    if (ui_manager) {
-        ui_manager->announce_lxst();
-    }
+    // Publish both reachable destinations together after UIManager has created
+    // the LXST destination. Earlier boot stages deliberately do not announce.
+    announce_reachable_destinations();
 
     // Register delivered callback to update message status in storage and UI
     router->register_delivered_callback([](LXMF::LXMessage& msg) {
@@ -1995,16 +2001,13 @@ static void handle_test_hook_command(const String& line) {
     }
     else if (cmd == "T:ANN") {
         if (!router) { Serial.println("T:ERR no router"); return; }
-        router->announce();
+        announce_reachable_destinations();
         Serial.println("T:OK announced");
     }
     else if (cmd == "T:ANNLXST") {
         // T:ANNLXST — force a fresh announce of the lxst.telephony
-        // destination. Required before pyxis-as-callee tests because
-        // the TCP-reconnect path at main.cpp:963 only announces LXMF;
-        // a brand-new boot ends up with the LXST destination absent
-        // from rnsd's cache, so the bot can resolve a path but the
-        // path doesn't actually route to pyxis.
+        // destination independently for protocol diagnostics. Normal LXMF
+        // announce paths publish both destinations together.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
         ui_manager->announce_lxst();
         Serial.println("T:OK announced");
@@ -2754,11 +2757,7 @@ void loop() {
                                         (lora_interface && lora_interface->online()) ||
                                         (ble_interface && ble_interface->online());
             if (router && has_online_interface) {
-                router->announce();
-                if (ui_manager) {
-                    ui_manager->announce_lxst();
-                }
-                last_announce = millis();
+                announce_reachable_destinations();
                 INFO("Periodic announce sent (interval: " + std::to_string(app_settings.announce_interval) + "s)");
             }
         }
@@ -2799,8 +2798,7 @@ void loop() {
         INFO("TCP interface reconnected - sending announce");
         if (router) {
             delay(500);  // Brief stabilization delay
-            router->announce();
-            last_announce = millis();
+            announce_reachable_destinations();
         }
         last_tcp_online = true;
     }
@@ -2863,6 +2861,15 @@ void loop() {
 
         bool tcp_online = tcp_interface && tcp_interface->online();
         bool lora_online = lora_interface && lora_interface->online();
+
+        // The boot-time LXST announce can run before the asynchronous TCP
+        // client reaches ONLINE. Re-announce both destinations on every TCP
+        // offline->online edge so peers that can exchange LXMF messages also
+        // receive a routable lxst.telephony path without waiting for the
+        // periodic announce interval.
+        if (tcp_online && !last_tcp_online) {
+            announce_reachable_destinations();
+        }
 
         // Check if status changed
         if (tcp_online != last_tcp_online || lora_online != last_lora_online) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2175,8 +2175,15 @@ static void handle_test_hook_command(const String& line) {
         // Serial hooks run on loopTask, outside the LVGL task. The production
         // call path mutates screens immediately, so hold the same LVGL lock as
         // other cross-task UI operations.
-        { LVGL_LOCK(); ui_manager->test_call_initiate(dest_hash); }
-        Serial.println(String("T:OK calling=") + args);
+        UI::LXMF::UIManager::TestCallInitiateResult result;
+        { LVGL_LOCK(); result = ui_manager->test_call_initiate(dest_hash); }
+        if (result == UI::LXMF::UIManager::TestCallInitiateResult::BUSY) {
+            Serial.println("T:ERR busy");
+        } else if (result == UI::LXMF::UIManager::TestCallInitiateResult::STARTED) {
+            Serial.println(String("T:OK calling=") + args);
+        } else {
+            Serial.println("T:ERR call_failed");
+        }
     }
     else if (cmd == "T:CALL_STATE") {
         // T:CALL_STATE — print the current call FSM state name.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2307,9 +2307,9 @@ static void handle_test_hook_command(const String& line) {
         Serial.println(ui_manager->test_call_state_name());
     }
     else if (cmd == "T:CALL_PROFILE") {
-        // T:CALL_PROFILE [hex] — get/set pyxis's preferred Codec2 profile.
+        // T:CALL_PROFILE [hex] — get/set pyxis's production Codec2 profile.
         // No arg: print current. With arg: set.
-        // Valid: 0x10 (ULBW/700C), 0x20 (VLBW/1600), 0x30 (LBW/3200).
+        // Only 0x10 (ULBW/700C) is valid; wider profiles violate the LoRa budget.
         if (!ui_manager) { Serial.println("T:ERR no ui_manager"); return; }
         if (args.length() == 0) {
             int p = ui_manager->test_call_get_profile();
@@ -2320,7 +2320,7 @@ static void handle_test_hook_command(const String& line) {
         }
         int profile = (int)strtol(args.c_str(), nullptr, 0);
         if (!ui_manager->test_call_set_profile(profile)) {
-            Serial.println("T:ERR unknown profile");
+            Serial.println("T:ERR unsupported profile (ULBW 0x10 required)");
             return;
         }
         Serial.print("T:OK profile=0x");

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,7 @@ System Python 3.9 has pytest pre-installed; Homebrew Python does not.
 - `native/test_ring_buffers.{cpp,py}` — PCM + encoded SPSC ring buffers, including 100k-frame multithreaded producer/consumer stress
 - `native/test_audio_filters.{cpp,py}` — VoiceFilterChain frequency response, peak limiting, multichannel
 - `native/test_call_command_mailbox.{cpp,py}` — generation-scoped LXST hangup/mute command handoff and producer/consumer stress
+- `native/test_call_generation_guard.{cpp,py}` — lock-free, generation-scoped call admission, stale-owner protection, and two-thread reservation races
 
 ### Adding a new native C++ test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,7 +21,7 @@ System Python 3.9 has pytest pre-installed; Homebrew Python does not.
 - `native/test_ring_buffers.{cpp,py}` — PCM + encoded SPSC ring buffers, including 100k-frame multithreaded producer/consumer stress
 - `native/test_audio_filters.{cpp,py}` — VoiceFilterChain frequency response, peak limiting, multichannel
 - `native/test_call_command_mailbox.{cpp,py}` — generation-scoped LXST hangup/mute command handoff and producer/consumer stress
-- `native/test_call_generation_guard.{cpp,py}` — lock-free, generation-scoped call admission, stale-owner protection, and two-thread reservation races
+- `native/test_call_generation_guard.{cpp,py}` — atomic, generation-scoped call admission, stale-owner protection, and repeated two-thread reservation races
 
 ### Adding a new native C++ test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,8 +21,9 @@ System Python 3.9 has pytest pre-installed; Homebrew Python does not.
 - `native/test_ring_buffers.{cpp,py}` — PCM + encoded SPSC ring buffers, including 100k-frame multithreaded producer/consumer stress
 - `native/test_audio_filters.{cpp,py}` — VoiceFilterChain frequency response, peak limiting, multichannel
 - `native/test_call_command_mailbox.{cpp,py}` — generation-scoped LXST hangup/mute command handoff and producer/consumer stress
+- `native/test_call_start_mailbox.{cpp,py}` — exact 16-byte LXST outgoing-call handoff, duplicate rejection, and reusable producer/consumer stress
 - `native/test_call_generation_guard.{cpp,py}` — atomic, generation-scoped call admission, stale-owner protection, and repeated two-thread reservation races
-- `native/test_call_link_ownership.{cpp,py}` — exact 128-bit LXST link ownership publication and generation-bound deferred-close concurrency
+- `native/test_call_link_ownership.{cpp,py}` — exact 128-bit LXST link ownership publication, mixed-ID publication stress, and generation-bound deferred-close concurrency
 
 ### Adding a new native C++ test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,7 @@ System Python 3.9 has pytest pre-installed; Homebrew Python does not.
 - `native/test_audio_filters.{cpp,py}` — VoiceFilterChain frequency response, peak limiting, multichannel
 - `native/test_call_command_mailbox.{cpp,py}` — generation-scoped LXST hangup/mute command handoff and producer/consumer stress
 - `native/test_call_generation_guard.{cpp,py}` — atomic, generation-scoped call admission, stale-owner protection, and repeated two-thread reservation races
+- `native/test_call_link_ownership.{cpp,py}` — exact 128-bit LXST link ownership publication and generation-bound deferred-close concurrency
 
 ### Adding a new native C++ test
 

--- a/tests/build_scripts/test_voice_announce_contract.py
+++ b/tests/build_scripts/test_voice_announce_contract.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = (ROOT / "src" / "main.cpp").read_text()
+UI_MANAGER = (ROOT / "lib" / "tdeck_ui" / "UI" / "LXMF" / "UIManager.cpp").read_text()
+
+
+def test_all_main_loop_announces_use_the_paired_destination_helper():
+    helper_start = MAIN.index("void announce_reachable_destinations()")
+    helper_end = MAIN.index("\n}\n", helper_start) + 2
+    helper = MAIN[helper_start:helper_end]
+
+    assert "router->announce();" in helper
+    assert "ui_manager->announce_lxst();" in helper
+    assert MAIN.count("router->announce();") == 1
+
+
+def test_tcp_online_edge_reannounces_both_destinations():
+    status_block = MAIN[MAIN.index("bool tcp_online ="): MAIN.index("// Update BLE peer info")]
+
+    assert "tcp_online && !last_tcp_online" in status_block
+    assert "announce_reachable_destinations();" in status_block
+
+
+def test_manual_announce_action_pairs_lxmf_and_lxst():
+    callback_start = UI_MANAGER.index("_announce_list_screen->set_send_announce_callback")
+    callback_end = UI_MANAGER.index("// Set up callbacks for status screen", callback_start)
+    callback = UI_MANAGER[callback_start:callback_end]
+
+    assert "_router.announce();" in callback
+    assert "announce_lxst();" in callback

--- a/tests/build_scripts/test_voice_batch_quantum_contract.py
+++ b/tests/build_scripts/test_voice_batch_quantum_contract.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CAPTURE_HEADER = ROOT / "lib/lxst_audio/i2s_capture.h"
+CAPTURE_CPP = ROOT / "lib/lxst_audio/i2s_capture.cpp"
+UI_MANAGER_CPP = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+
+
+def test_production_voice_is_ulbw_only():
+    capture_header = CAPTURE_HEADER.read_text()
+    capture_source = CAPTURE_CPP.read_text()
+    ui_source = UI_MANAGER_CPP.read_text()
+
+    assert "PCM_SAMPLES_PER_BATCH = 3200" in capture_header
+    assert "ULBWVoiceProfilePolicy::CODEC2_MODE_700C_VALUE" in capture_source
+    assert "UIManager::_preferred_profile = UIManager::LXST_PROFILE_ULBW" in ui_source
+    assert "return ULBWVoiceProfilePolicy::codecModeForProfile(profile);" in ui_source
+
+
+def test_ulbw_tx_uses_real_42_byte_batch_shape():
+    ui_source = UI_MANAGER_CPP.read_text()
+
+    assert "uint8_t encoded_buf[128]" in ui_source
+    assert "uint8_t batch_data[128]" in ui_source
+    assert "ULBWVoiceProfilePolicy::framesPerPacket(320)" in ui_source

--- a/tests/build_scripts/test_voice_harness_profile_contract.py
+++ b/tests/build_scripts/test_voice_harness_profile_contract.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+VOICE_TEST_DIR = Path(__file__).resolve().parents[2] / "tools/voice_test"
+sys.path.insert(0, str(VOICE_TEST_DIR))
+
+from voice_profile_contract import require_ulbw_confirmation, validate_requested_profiles
+
+
+def test_harness_accepts_only_ulbw_request():
+    assert validate_requested_profiles("ULBW") == ["ULBW"]
+
+
+@pytest.mark.parametrize("requested", ["VLBW", "LBW", "ULBW,VLBW", ""])
+def test_harness_rejects_non_ulbw_profile_sets(requested):
+    with pytest.raises(ValueError):
+        validate_requested_profiles(requested)
+
+
+def test_harness_requires_exact_ulbw_firmware_confirmation():
+    assert require_ulbw_confirmation("noise\nT:OK profile=0x10\n") == 0x10
+
+
+@pytest.mark.parametrize(
+    "response",
+    ["T:ERR unknown profile", "T:OK profile=0x20", "", "T:OK profile=0x1"],
+)
+def test_harness_aborts_on_rejection_or_mismatched_confirmation(response):
+    with pytest.raises(RuntimeError):
+        require_ulbw_confirmation(response)

--- a/tests/build_scripts/test_voice_liveness_contract.py
+++ b/tests/build_scripts/test_voice_liveness_contract.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.h"
+SOURCE = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+CODEC_SOURCE = ROOT / "lib/lxst_audio/codec_wrapper.cpp"
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def test_voice_liveness_watchdog_is_conservative_and_wired_to_media():
+    header = HEADER.read_text()
+    source = SOURCE.read_text()
+    update = _function_body(source, "void UIManager::call_update()")
+    receive = _function_body(source, "void UIManager::call_rx_audio_frame")
+
+    assert "CALL_MEDIA_LIVENESS_TIMEOUT_MS = 90000" in header
+    assert source.count("_call_liveness.arm(_call_start_ms);") == 3
+    assert "frame_len < 2" in receive
+    assert re.search(
+        r"if\s*\(_lxst_audio->writeEncodedPacket\([^;]+\)\)\s*\{[^}]*"
+        r"_call_liveness\.observe\(millis\(\)\);",
+        receive,
+        re.DOTALL,
+    )
+    assert "_call_liveness.expired(now, CALL_MEDIA_LIVENESS_TIMEOUT_MS)" in update
+    assert "call_ended();" in update
+
+
+def test_every_owner_cleanup_disarms_liveness_before_releasing_generation():
+    source = SOURCE.read_text()
+    for signature in ("void UIManager::call_hangup()", "void UIManager::call_ended()"):
+        body = _function_body(source, signature)
+        assert body.index("_call_liveness.disarm();") < body.index("call_clear_generation(generation);")
+
+
+def test_codec2_decoder_rejects_empty_and_partial_subframe_batches():
+    source = CODEC_SOURCE.read_text()
+    decode = _function_body(source, "int Codec2Wrapper::decode")
+
+    validation = decode.index("dataLen <= 0 || bytesPerFrame_ <= 0 || dataLen % bytesPerFrame_ != 0")
+    frame_count = decode.index("int numFrames = dataLen / bytesPerFrame_;")
+    assert validation < frame_count

--- a/tests/build_scripts/test_voice_terminal_signal_contract.py
+++ b/tests/build_scripts/test_voice_terminal_signal_contract.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.h"
+SOURCE = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace + 1 : index]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def test_terminal_status_is_backward_compatible_extension():
+    header = HEADER.read_text()
+    assert re.search(r"LXST_STATUS_TERMINATED\s*=\s*0x07", header)
+
+
+def test_local_hangup_sends_bounded_terminal_burst_before_link_teardown():
+    source = SOURCE.read_text()
+    hangup = _function_body(source, "void UIManager::call_hangup()")
+    burst = _function_body(source, "void UIManager::call_send_terminal_burst()")
+
+    assert hangup.index("call_send_terminal_burst();") < hangup.index("_call_link_ownership.clear")
+    assert hangup.index("call_send_terminal_burst();") < hangup.index("_call_link.teardown()")
+    assert "TERMINAL_SIGNAL_SEND_COUNT = 3" in HEADER.read_text()
+    assert "TERMINAL_SIGNAL_DRAIN_MS = 20" in HEADER.read_text()
+    assert "call_send_signal(LXST_STATUS_TERMINATED)" in burst
+    assert "delay(TERMINAL_SIGNAL_DRAIN_MS)" in burst
+
+
+def test_terminal_signal_ends_every_owned_non_idle_call_before_state_switch():
+    source = SOURCE.read_text()
+    handler = _function_body(source, "void UIManager::call_process_signal(uint8_t signal)")
+
+    terminal = handler.index("signal == LXST_STATUS_TERMINATED")
+    state_switch = handler.index("switch (_call_state)")
+    assert terminal < state_switch
+    terminal_block = handler[terminal:state_switch]
+    assert "call_current_generation() != 0" in terminal_block
+    assert "call_ended();" in terminal_block
+    assert "return;" in terminal_block

--- a/tests/interop/conftest.py
+++ b/tests/interop/conftest.py
@@ -61,6 +61,12 @@ PROFILE_MQ = 0x40
 
 
 @pytest.fixture
+def codec2_700():
+    """Create a pycodec2 instance for the production ULBW/700C mode."""
+    return pycodec2.Codec2(700)
+
+
+@pytest.fixture
 def codec2_3200():
     """Create a pycodec2 instance for 3200 bps mode."""
     return pycodec2.Codec2(3200)

--- a/tests/interop/test_wire_format.py
+++ b/tests/interop/test_wire_format.py
@@ -293,6 +293,23 @@ class TestSignallingFormat:
 class TestWireFormatEdgeCases:
     """Edge cases and boundary conditions."""
 
+    def test_production_ulbw_packet_is_exact_42_byte_batch(self, codec2_700, sine_8khz_1s):
+        """Pyxis ULBW TX matches Python LXST's 400 ms Codec2-700C quantum."""
+        pcm = sine_8khz_1s[:3200]
+        subframes = encode_codec2_subframes(codec2_700, pcm, MODE_HEADERS[700])
+        batch = batch_subframes_pyxis_style(subframes, MODE_HEADERS[700])
+        wire = build_pyxis_audio_packet(batch)
+
+        assert len(subframes) == 10
+        assert all(len(frame) == 5 for frame in subframes)
+        assert len(batch) == 41
+        assert batch[0] == 0x00
+        assert wire[:6] == bytes([0x81, 0x01, 0xC4, 42, CODEC_CODEC2, 0x00])
+
+        for parser in (parse_lxst_python_rx, parse_pyxis_rx):
+            parsed = parser(wire)
+            assert parsed["frames"] == [(CODEC_CODEC2, batch)]
+
     def test_max_bin8_payload(self, codec2_3200, sine_8khz_1s):
         """Test maximum bin8 payload (255 bytes)."""
         # 30 sub-frames: [mode(1)] + [30*8] = 241 bytes + codec_type(1) = 242 bytes

--- a/tests/native/test_call_generation_guard.cpp
+++ b/tests/native/test_call_generation_guard.cpp
@@ -146,69 +146,6 @@ static void incoming_then_outgoing_admission_sequence() {
     EXPECT_EQ(guard.current(), 0u);
 }
 
-enum class CallbackEvent {
-    Identity,
-    Close,
-    Packet,
-};
-
-// Portable model of UIManager's callback admission predicate. LinkKey models
-// Reticulum shared-object identity without importing the embedded dependency.
-enum class LinkKey {
-    None,
-    A,
-    B,
-};
-
-class CallbackOwnershipModel {
-public:
-    void admit(LinkKey link, uint32_t generation) {
-        _link = link;
-        _generation = generation;
-    }
-
-    void release(uint32_t generation) {
-        if (_generation == generation) {
-            _link = LinkKey::None;
-            _generation = 0;
-        }
-    }
-
-    bool accepts(CallbackEvent, LinkKey link, uint32_t generation) const {
-        return generation != 0 && generation == _generation &&
-               link != LinkKey::None && link == _link;
-    }
-
-private:
-    LinkKey _link{LinkKey::None};
-    uint32_t _generation{0};
-};
-
-static void callbacks_require_current_link_and_generation() {
-    constexpr uint32_t g1 = 1;
-    constexpr uint32_t g2 = 2;
-    constexpr CallbackEvent events[] = {
-        CallbackEvent::Identity,
-        CallbackEvent::Close,
-        CallbackEvent::Packet,
-    };
-
-    CallbackOwnershipModel model;
-    model.admit(LinkKey::A, g1);
-    for (CallbackEvent event : events) {
-        EXPECT_TRUE(model.accepts(event, LinkKey::A, g1));
-    }
-
-    model.release(g1);
-    model.admit(LinkKey::B, g2);
-    for (CallbackEvent event : events) {
-        EXPECT_TRUE(!model.accepts(event, LinkKey::A, g1));
-        EXPECT_TRUE(!model.accepts(event, LinkKey::B, g1));
-        EXPECT_TRUE(!model.accepts(event, LinkKey::A, g2));
-        EXPECT_TRUE(model.accepts(event, LinkKey::B, g2));
-    }
-}
-
 int main() {
     RUN(first_reservation_is_nonzero_and_owned);
     RUN(reservation_while_owned_fails);
@@ -218,7 +155,6 @@ int main() {
     RUN(exactly_one_thread_wins_reservation_race);
     RUN(stale_token_cannot_release_new_winner);
     RUN(incoming_then_outgoing_admission_sequence);
-    RUN(callbacks_require_current_link_and_generation);
     std::printf("%d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/native/test_call_generation_guard.cpp
+++ b/tests/native/test_call_generation_guard.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
 #include <stdexcept>
 #include <thread>
 
@@ -89,23 +90,34 @@ static void next_reservation_has_distinct_generation() {
 }
 
 static void exactly_one_thread_wins_reservation_race() {
-    CallGenerationGuard guard;
-    std::atomic<bool> start{false};
-    uint32_t first = 0;
-    uint32_t second = 0;
-    std::thread a([&] {
-        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-        first = guard.tryReserve();
-    });
-    std::thread b([&] {
-        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
-        second = guard.tryReserve();
-    });
-    start.store(true, std::memory_order_release);
-    a.join();
-    b.join();
-    EXPECT_TRUE((first == 0) != (second == 0));
-    EXPECT_EQ(guard.current(), first != 0 ? first : second);
+    constexpr int kRaceIterations = 1000;
+    for (int iteration = 0; iteration < kRaceIterations; ++iteration) {
+        CallGenerationGuard guard;
+        std::atomic<unsigned> ready{0};
+        std::atomic<bool> start{false};
+        uint32_t first = 0;
+        uint32_t second = 0;
+
+        auto reserve = [&](uint32_t& result) {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            result = guard.tryReserve();
+        };
+
+        std::thread a(reserve, std::ref(first));
+        std::thread b(reserve, std::ref(second));
+        while (ready.load(std::memory_order_acquire) != 2) {
+            std::this_thread::yield();
+        }
+        start.store(true, std::memory_order_release);
+        a.join();
+        b.join();
+
+        EXPECT_TRUE((first == 0) != (second == 0));
+        EXPECT_EQ(guard.current(), first != 0 ? first : second);
+    }
 }
 
 static void stale_token_cannot_release_new_winner() {

--- a/tests/native/test_call_generation_guard.cpp
+++ b/tests/native/test_call_generation_guard.cpp
@@ -1,0 +1,148 @@
+#include "../../lib/tdeck_ui/UI/LXMF/CallGenerationGuard.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <thread>
+
+using UI::LXMF::CallGenerationGuard;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static void first_reservation_is_nonzero_and_owned() {
+    CallGenerationGuard guard;
+    const uint32_t generation = guard.tryReserve();
+    EXPECT_TRUE(generation != 0);
+    EXPECT_TRUE(generation <= CallGenerationGuard::MAX_GENERATION);
+    EXPECT_TRUE(guard.owns(generation));
+    EXPECT_EQ(guard.current(), generation);
+}
+
+static void reservation_while_owned_fails() {
+    CallGenerationGuard guard;
+    const uint32_t generation = guard.tryReserve();
+    EXPECT_TRUE(generation != 0);
+    EXPECT_EQ(guard.tryReserve(), 0u);
+    EXPECT_EQ(guard.current(), generation);
+}
+
+static void zero_and_stale_release_do_not_clear_owner() {
+    CallGenerationGuard guard;
+    const uint32_t generation = guard.tryReserve();
+    EXPECT_TRUE(!guard.release(0));
+    EXPECT_TRUE(!guard.release(generation + 1));
+    EXPECT_TRUE(guard.owns(generation));
+}
+
+static void active_release_clears_owner() {
+    CallGenerationGuard guard;
+    const uint32_t generation = guard.tryReserve();
+    EXPECT_TRUE(guard.release(generation));
+    EXPECT_EQ(guard.current(), 0u);
+    EXPECT_TRUE(!guard.owns(generation));
+    EXPECT_TRUE(!guard.release(generation));
+}
+
+static void next_reservation_has_distinct_generation() {
+    CallGenerationGuard guard;
+    const uint32_t first = guard.tryReserve();
+    EXPECT_TRUE(guard.release(first));
+    const uint32_t second = guard.tryReserve();
+    EXPECT_TRUE(second != 0);
+    EXPECT_TRUE(second != first);
+}
+
+static void exactly_one_thread_wins_reservation_race() {
+    CallGenerationGuard guard;
+    std::atomic<bool> start{false};
+    uint32_t first = 0;
+    uint32_t second = 0;
+    std::thread a([&] {
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        first = guard.tryReserve();
+    });
+    std::thread b([&] {
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        second = guard.tryReserve();
+    });
+    start.store(true, std::memory_order_release);
+    a.join();
+    b.join();
+    EXPECT_TRUE((first == 0) != (second == 0));
+    EXPECT_EQ(guard.current(), first != 0 ? first : second);
+}
+
+static void stale_token_cannot_release_new_winner() {
+    CallGenerationGuard guard;
+    const uint32_t stale = guard.tryReserve();
+    EXPECT_TRUE(guard.release(stale));
+    const uint32_t winner = guard.tryReserve();
+    EXPECT_TRUE(winner != stale);
+    EXPECT_TRUE(!guard.release(stale));
+    EXPECT_TRUE(guard.owns(winner));
+}
+
+static void incoming_then_outgoing_admission_sequence() {
+    CallGenerationGuard guard;
+    const uint32_t incoming = guard.tryReserve();
+    EXPECT_TRUE(incoming != 0);
+    EXPECT_EQ(guard.tryReserve(), 0u); // outgoing rejected while incoming owns it
+    EXPECT_TRUE(guard.release(incoming));
+
+    const uint32_t outgoing = guard.tryReserve();
+    EXPECT_TRUE(outgoing != 0);
+    EXPECT_TRUE(outgoing != incoming);
+    EXPECT_TRUE(!guard.release(incoming)); // late incoming cleanup is harmless
+    EXPECT_TRUE(guard.owns(outgoing));
+    EXPECT_TRUE(guard.release(outgoing));
+    EXPECT_EQ(guard.current(), 0u);
+}
+
+int main() {
+    RUN(first_reservation_is_nonzero_and_owned);
+    RUN(reservation_while_owned_fails);
+    RUN(zero_and_stale_release_do_not_clear_owner);
+    RUN(active_release_clears_owner);
+    RUN(next_reservation_has_distinct_generation);
+    RUN(exactly_one_thread_wins_reservation_race);
+    RUN(stale_token_cannot_release_new_winner);
+    RUN(incoming_then_outgoing_admission_sequence);
+    std::printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_call_generation_guard.cpp
+++ b/tests/native/test_call_generation_guard.cpp
@@ -146,6 +146,69 @@ static void incoming_then_outgoing_admission_sequence() {
     EXPECT_EQ(guard.current(), 0u);
 }
 
+enum class CallbackEvent {
+    Identity,
+    Close,
+    Packet,
+};
+
+// Portable model of UIManager's callback admission predicate. LinkKey models
+// Reticulum shared-object identity without importing the embedded dependency.
+enum class LinkKey {
+    None,
+    A,
+    B,
+};
+
+class CallbackOwnershipModel {
+public:
+    void admit(LinkKey link, uint32_t generation) {
+        _link = link;
+        _generation = generation;
+    }
+
+    void release(uint32_t generation) {
+        if (_generation == generation) {
+            _link = LinkKey::None;
+            _generation = 0;
+        }
+    }
+
+    bool accepts(CallbackEvent, LinkKey link, uint32_t generation) const {
+        return generation != 0 && generation == _generation &&
+               link != LinkKey::None && link == _link;
+    }
+
+private:
+    LinkKey _link{LinkKey::None};
+    uint32_t _generation{0};
+};
+
+static void callbacks_require_current_link_and_generation() {
+    constexpr uint32_t g1 = 1;
+    constexpr uint32_t g2 = 2;
+    constexpr CallbackEvent events[] = {
+        CallbackEvent::Identity,
+        CallbackEvent::Close,
+        CallbackEvent::Packet,
+    };
+
+    CallbackOwnershipModel model;
+    model.admit(LinkKey::A, g1);
+    for (CallbackEvent event : events) {
+        EXPECT_TRUE(model.accepts(event, LinkKey::A, g1));
+    }
+
+    model.release(g1);
+    model.admit(LinkKey::B, g2);
+    for (CallbackEvent event : events) {
+        EXPECT_TRUE(!model.accepts(event, LinkKey::A, g1));
+        EXPECT_TRUE(!model.accepts(event, LinkKey::B, g1));
+        EXPECT_TRUE(!model.accepts(event, LinkKey::A, g2));
+        EXPECT_TRUE(model.accepts(event, LinkKey::B, g2));
+    }
+}
+
 int main() {
     RUN(first_reservation_is_nonzero_and_owned);
     RUN(reservation_while_owned_fails);
@@ -155,6 +218,7 @@ int main() {
     RUN(exactly_one_thread_wins_reservation_race);
     RUN(stale_token_cannot_release_new_winner);
     RUN(incoming_then_outgoing_admission_sequence);
+    RUN(callbacks_require_current_link_and_generation);
     std::printf("%d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/native/test_call_generation_guard.py
+++ b/tests/native/test_call_generation_guard.py
@@ -1,0 +1,32 @@
+"""Compile and execute the portable LXST call-generation guard regression."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TEST_SOURCE = HERE / "test_call_generation_guard.cpp"
+
+
+def test_call_generation_guard(tmp_path):
+    cxx = shutil.which("c++")
+    if not cxx:
+        pytest.skip("no C++ compiler found")
+    binary = tmp_path / "test_call_generation_guard"
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-pthread",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(cmd, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "8 passed, 0 failed" in ran.stdout

--- a/tests/native/test_call_generation_guard.py
+++ b/tests/native/test_call_generation_guard.py
@@ -20,6 +20,7 @@ def test_call_generation_guard(tmp_path):
         "-std=c++17",
         "-Wall",
         "-Wextra",
+        "-Werror",
         "-pthread",
         str(TEST_SOURCE),
         "-o",

--- a/tests/native/test_call_generation_guard.py
+++ b/tests/native/test_call_generation_guard.py
@@ -30,4 +30,4 @@ def test_call_generation_guard(tmp_path):
     assert compiled.returncode == 0, compiled.stderr
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert "8 passed, 0 failed" in ran.stdout
+    assert "9 passed, 0 failed" in ran.stdout

--- a/tests/native/test_call_link_ownership.cpp
+++ b/tests/native/test_call_link_ownership.cpp
@@ -1,0 +1,222 @@
+#include "../../lib/tdeck_ui/UI/LXMF/CallLinkOwnership.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <stdexcept>
+#include <thread>
+
+using UI::LXMF::CallLinkOwnership;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static CallLinkOwnership::LinkId id(uint8_t first, uint8_t last) {
+    CallLinkOwnership::LinkId result{};
+    for (size_t i = 0; i < result.size(); ++i) {
+        result[i] = static_cast<uint8_t>(first + i);
+    }
+    result.back() = last;
+    return result;
+}
+
+static void replacement_rejects_all_stale_id_generation_pairs() {
+    CallLinkOwnership ownership;
+    const auto a = id(0x10, 0xa1);
+    const auto b = id(0x10, 0xb2); // differs only in the final ID byte
+
+    EXPECT_TRUE(ownership.publish(1, a));
+    EXPECT_TRUE(ownership.owns(1, a));
+    EXPECT_EQ(ownership.generationFor(a), 1u);
+
+    EXPECT_TRUE(ownership.publish(2, b));
+    EXPECT_TRUE(!ownership.owns(1, a));
+    EXPECT_TRUE(!ownership.owns(1, b));
+    EXPECT_TRUE(!ownership.owns(2, a));
+    EXPECT_TRUE(ownership.owns(2, b));
+    EXPECT_EQ(ownership.generationFor(a), 0u);
+    EXPECT_EQ(ownership.generationFor(b), 2u);
+}
+
+static void distinct_non_null_synthetic_links_require_exact_full_id() {
+    CallLinkOwnership ownership;
+    const auto a = id(0x40, 0xee);
+    auto b = a;
+    b[15] ^= 1u;
+
+    // Both IDs model links whose bool conversion is true. Their exact 128-bit
+    // identities, not that shared truth value or a truncated prefix, decide.
+    EXPECT_TRUE(ownership.publish(7, a));
+    EXPECT_TRUE(ownership.owns(7, a));
+    EXPECT_TRUE(!ownership.owns(7, b));
+}
+
+static void stale_close_cannot_set_or_overwrite_new_owner_slot() {
+    CallLinkOwnership ownership;
+    const auto a = id(0x20, 0xa1);
+    const auto b = id(0x30, 0xb2);
+
+    EXPECT_TRUE(ownership.publish(1, a));
+    EXPECT_TRUE(ownership.owns(1, a)); // old callback validated, then paused
+    EXPECT_TRUE(ownership.publish(2, b));
+    EXPECT_TRUE(!ownership.markClosed(1, a));
+    EXPECT_EQ(ownership.takeClosed(), 0u);
+
+    EXPECT_TRUE(ownership.markClosed(2, b));
+    EXPECT_TRUE(!ownership.markClosed(1, a));
+    EXPECT_EQ(ownership.takeClosed(), 2u);
+    EXPECT_EQ(ownership.takeClosed(), 0u);
+}
+
+static void current_close_survives_stale_attempts_before_and_after() {
+    CallLinkOwnership ownership;
+    const auto a = id(0x51, 0xa1);
+    const auto b = id(0x61, 0xb2);
+
+    EXPECT_TRUE(ownership.publish(1, a));
+    EXPECT_TRUE(ownership.publish(2, b));
+    EXPECT_TRUE(!ownership.markClosed(1, a));
+    EXPECT_TRUE(ownership.markClosed(2, b));
+    EXPECT_TRUE(!ownership.markClosed(1, a));
+    EXPECT_EQ(ownership.takeClosed(), 2u);
+}
+
+static void stale_clear_cannot_detach_or_clear_new_owner_close() {
+    CallLinkOwnership ownership;
+    const auto a = id(0x71, 0xa1);
+    const auto b = id(0x81, 0xb2);
+
+    EXPECT_TRUE(ownership.publish(1, a));
+    EXPECT_TRUE(ownership.clear(1));
+    EXPECT_TRUE(ownership.publish(2, b));
+    EXPECT_TRUE(ownership.markClosed(2, b));
+    EXPECT_TRUE(!ownership.clear(1));
+    EXPECT_TRUE(ownership.owns(2, b));
+    EXPECT_EQ(ownership.takeClosed(), 2u);
+}
+
+static void concurrent_stale_and_current_close_publication_is_exact() {
+    constexpr int kIterations = 1000;
+    const auto a = id(0x91, 0xa1);
+    const auto b = id(0xa1, 0xb2);
+
+    for (int iteration = 0; iteration < kIterations; ++iteration) {
+        CallLinkOwnership ownership;
+        EXPECT_TRUE(ownership.publish(1, a));
+        EXPECT_TRUE(ownership.publish(2, b));
+
+        std::atomic<unsigned> ready{0};
+        std::atomic<bool> start{false};
+        bool stale_result = true;
+        bool current_result = false;
+        auto mark = [&](uint32_t generation,
+                        const CallLinkOwnership::LinkId& link_id,
+                        bool& result) {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            result = ownership.markClosed(generation, link_id);
+        };
+
+        std::thread stale(mark, 1u, std::cref(a), std::ref(stale_result));
+        std::thread current(mark, 2u, std::cref(b), std::ref(current_result));
+        while (ready.load(std::memory_order_acquire) != 2) {
+            std::this_thread::yield();
+        }
+        start.store(true, std::memory_order_release);
+        stale.join();
+        current.join();
+
+        EXPECT_TRUE(!stale_result);
+        EXPECT_TRUE(current_result);
+        EXPECT_EQ(ownership.takeClosed(), 2u);
+    }
+}
+
+static void invalid_generations_are_never_published() {
+    CallLinkOwnership ownership;
+    const auto a = id(0xb1, 0xc2);
+    EXPECT_TRUE(!ownership.publish(0, a));
+    EXPECT_TRUE(!ownership.publish(CallLinkOwnership::MAX_GENERATION + 1u, a));
+    EXPECT_EQ(ownership.generationFor(a), 0u);
+}
+
+static void concurrent_publication_never_accepts_a_torn_128_bit_id() {
+    CallLinkOwnership ownership;
+    CallLinkOwnership::LinkId a{};
+    CallLinkOwnership::LinkId b{};
+    CallLinkOwnership::LinkId torn{};
+    a.fill(0x11);
+    b.fill(0xee);
+    for (size_t i = 0; i < torn.size(); ++i) {
+        torn[i] = i < torn.size() / 2 ? a[i] : b[i];
+    }
+    EXPECT_TRUE(ownership.publish(1, a));
+
+    std::atomic<bool> done{false};
+    std::atomic<bool> accepted_torn{false};
+    std::thread reader([&] {
+        while (!done.load(std::memory_order_acquire)) {
+            if (ownership.generationFor(torn) != 0) {
+                accepted_torn.store(true, std::memory_order_release);
+                return;
+            }
+        }
+    });
+    for (uint32_t generation = 2; generation < 100002; ++generation) {
+        EXPECT_TRUE(ownership.publish(
+            generation, (generation & 1u) == 0 ? b : a));
+    }
+    done.store(true, std::memory_order_release);
+    reader.join();
+    EXPECT_TRUE(!accepted_torn.load(std::memory_order_acquire));
+}
+
+int main() {
+    RUN(replacement_rejects_all_stale_id_generation_pairs);
+    RUN(distinct_non_null_synthetic_links_require_exact_full_id);
+    RUN(stale_close_cannot_set_or_overwrite_new_owner_slot);
+    RUN(current_close_survives_stale_attempts_before_and_after);
+    RUN(stale_clear_cannot_detach_or_clear_new_owner_close);
+    RUN(concurrent_stale_and_current_close_publication_is_exact);
+    RUN(invalid_generations_are_never_published);
+    RUN(concurrent_publication_never_accepts_a_torn_128_bit_id);
+    std::printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_call_link_ownership.cpp
+++ b/tests/native/test_call_link_ownership.cpp
@@ -177,35 +177,56 @@ static void invalid_generations_are_never_published() {
     EXPECT_EQ(ownership.generationFor(a), 0u);
 }
 
-static void concurrent_publication_never_accepts_a_torn_128_bit_id() {
+static void concurrent_publication_never_accepts_mixed_128_bit_ids() {
     CallLinkOwnership ownership;
     CallLinkOwnership::LinkId a{};
     CallLinkOwnership::LinkId b{};
-    CallLinkOwnership::LinkId torn{};
     a.fill(0x11);
     b.fill(0xee);
-    for (size_t i = 0; i < torn.size(); ++i) {
-        torn[i] = i < torn.size() / 2 ? a[i] : b[i];
+
+    std::array<CallLinkOwnership::LinkId, 4> mixed{};
+    for (size_t i = 0; i < a.size(); ++i) {
+        mixed[0][i] = i < 8 ? a[i] : b[i];
+        mixed[1][i] = (i & 1u) == 0 ? a[i] : b[i];
+        mixed[2][i] = i < 4 || (i >= 8 && i < 12) ? a[i] : b[i];
+        mixed[3][i] = i < 12 ? b[i] : a[i];
     }
     EXPECT_TRUE(ownership.publish(1, a));
 
+    std::atomic<bool> publishing{false};
     std::atomic<bool> done{false};
-    std::atomic<bool> accepted_torn{false};
+    std::atomic<bool> acceptedMixed{false};
+    std::atomic<uint64_t> completedChecks{0};
+    std::atomic<uint64_t> concurrentChecks{0};
     std::thread reader([&] {
         while (!done.load(std::memory_order_acquire)) {
-            if (ownership.generationFor(torn) != 0) {
-                accepted_torn.store(true, std::memory_order_release);
-                return;
+            for (const auto& candidate : mixed) {
+                if (ownership.generationFor(candidate) != 0) {
+                    acceptedMixed.store(true, std::memory_order_release);
+                    return;
+                }
+                completedChecks.fetch_add(1, std::memory_order_relaxed);
+                if (publishing.load(std::memory_order_acquire)) {
+                    concurrentChecks.fetch_add(1, std::memory_order_relaxed);
+                }
             }
         }
     });
+
+    publishing.store(true, std::memory_order_release);
+    while (concurrentChecks.load(std::memory_order_acquire) == 0) {
+        std::this_thread::yield();
+    }
     for (uint32_t generation = 2; generation < 100002; ++generation) {
         EXPECT_TRUE(ownership.publish(
             generation, (generation & 1u) == 0 ? b : a));
     }
+    publishing.store(false, std::memory_order_release);
     done.store(true, std::memory_order_release);
     reader.join();
-    EXPECT_TRUE(!accepted_torn.load(std::memory_order_acquire));
+    EXPECT_TRUE(completedChecks.load(std::memory_order_acquire) > 0);
+    EXPECT_TRUE(concurrentChecks.load(std::memory_order_acquire) > 0);
+    EXPECT_TRUE(!acceptedMixed.load(std::memory_order_acquire));
 }
 
 int main() {
@@ -216,7 +237,7 @@ int main() {
     RUN(stale_clear_cannot_detach_or_clear_new_owner_close);
     RUN(concurrent_stale_and_current_close_publication_is_exact);
     RUN(invalid_generations_are_never_published);
-    RUN(concurrent_publication_never_accepts_a_torn_128_bit_id);
+    RUN(concurrent_publication_never_accepts_mixed_128_bit_ids);
     std::printf("%d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/tests/native/test_call_link_ownership.py
+++ b/tests/native/test_call_link_ownership.py
@@ -1,4 +1,4 @@
-"""Compile and execute the portable LXST call-generation guard regression."""
+"""Compile and execute exact LXST link ownership/close regressions."""
 
 import shutil
 import subprocess
@@ -7,14 +7,14 @@ from pathlib import Path
 import pytest
 
 HERE = Path(__file__).resolve().parent
-TEST_SOURCE = HERE / "test_call_generation_guard.cpp"
+TEST_SOURCE = HERE / "test_call_link_ownership.cpp"
 
 
-def test_call_generation_guard(tmp_path):
+def test_call_link_ownership(tmp_path):
     cxx = shutil.which("c++")
     if not cxx:
         pytest.skip("no C++ compiler found")
-    binary = tmp_path / "test_call_generation_guard"
+    binary = tmp_path / "test_call_link_ownership"
     cmd = [
         cxx,
         "-std=c++17",

--- a/tests/native/test_call_liveness_watchdog.cpp
+++ b/tests/native/test_call_liveness_watchdog.cpp
@@ -1,0 +1,43 @@
+#include <cstdint>
+#include <iostream>
+
+#include "../../lib/tdeck_ui/UI/LXMF/CallLivenessWatchdog.h"
+
+namespace {
+int passed = 0;
+int failed = 0;
+
+void expect(bool condition, const char* name) {
+    if (condition) {
+        ++passed;
+    } else {
+        ++failed;
+        std::cerr << "FAIL: " << name << '\n';
+    }
+}
+}
+
+int main() {
+    constexpr uint32_t timeout = 90000;
+    CallLivenessWatchdog watchdog;
+
+    expect(!watchdog.expired(100000, timeout), "disarmed watchdog does not expire");
+
+    watchdog.arm(1000);
+    expect(!watchdog.expired(90999, timeout), "active just below timeout");
+    expect(watchdog.expired(91000, timeout), "active expires at timeout");
+
+    watchdog.observe(50000);
+    expect(!watchdog.expired(100000, timeout), "received media resets deadline");
+    expect(watchdog.expired(140000, timeout), "reset deadline eventually expires");
+
+    watchdog.disarm();
+    expect(!watchdog.expired(UINT32_MAX, timeout), "disarm suppresses expiry");
+
+    watchdog.arm(UINT32_MAX - 1000);
+    expect(!watchdog.expired(1000, timeout), "millis wrap below timeout");
+    expect(watchdog.expired(90000, timeout), "millis wrap reaches timeout");
+
+    std::cout << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/native/test_call_liveness_watchdog.cpp
+++ b/tests/native/test_call_liveness_watchdog.cpp
@@ -24,6 +24,7 @@ int main() {
     expect(!watchdog.expired(100000, timeout), "disarmed watchdog does not expire");
 
     watchdog.arm(1000);
+    expect(!watchdog.expired(999, timeout), "stale pre-arm timestamp does not expire");
     expect(!watchdog.expired(90999, timeout), "active just below timeout");
     expect(watchdog.expired(91000, timeout), "active expires at timeout");
 

--- a/tests/native/test_call_liveness_watchdog.py
+++ b/tests/native/test_call_liveness_watchdog.py
@@ -29,4 +29,4 @@ def test_call_liveness_watchdog(tmp_path):
     assert compiled.returncode == 0, compiled.stderr
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert "8 passed, 0 failed" in ran.stdout
+    assert "9 passed, 0 failed" in ran.stdout

--- a/tests/native/test_call_liveness_watchdog.py
+++ b/tests/native/test_call_liveness_watchdog.py
@@ -1,0 +1,32 @@
+"""Compile and execute the portable LXST call-liveness watchdog regression."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TEST_SOURCE = HERE / "test_call_liveness_watchdog.cpp"
+
+
+def test_call_liveness_watchdog(tmp_path):
+    cxx = shutil.which("c++")
+    if not cxx:
+        pytest.skip("no C++ compiler found")
+    binary = tmp_path / "test_call_liveness_watchdog"
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(cmd, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "8 passed, 0 failed" in ran.stdout

--- a/tests/native/test_call_start_mailbox.cpp
+++ b/tests/native/test_call_start_mailbox.cpp
@@ -1,0 +1,128 @@
+#include "../../lib/tdeck_ui/UI/LXMF/CallStartMailbox.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <stdexcept>
+#include <thread>
+
+using UI::LXMF::CallStartMailbox;
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define EXPECT_EQ(actual, expected)                                            \
+    do {                                                                       \
+        auto _a = (actual);                                                    \
+        auto _e = (expected);                                                  \
+        if (!(_a == _e)) {                                                     \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: %s != %s",                 \
+                          __FILE__, __LINE__, #actual, #expected);             \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define EXPECT_TRUE(cond)                                                      \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            char buf[256];                                                     \
+            std::snprintf(buf, sizeof(buf), "%s:%d: expected %s",              \
+                          __FILE__, __LINE__, #cond);                          \
+            throw std::runtime_error(buf);                                     \
+        }                                                                      \
+    } while (0)
+
+#define RUN(name)                                                              \
+    do {                                                                       \
+        try {                                                                  \
+            name();                                                            \
+            ++g_pass;                                                          \
+            std::printf("PASS %s\n", #name);                                   \
+        } catch (const std::exception& e) {                                    \
+            ++g_fail;                                                          \
+            std::printf("FAIL %s: %s\n", #name, e.what());                     \
+        }                                                                      \
+    } while (0)
+
+static CallStartMailbox::PeerHash pattern(uint32_t sequence) {
+    CallStartMailbox::PeerHash result{};
+    for (size_t i = 0; i < result.size(); ++i) {
+        const uint32_t shift = static_cast<uint32_t>((i % 4) * 8);
+        result[i] = static_cast<uint8_t>((sequence >> shift) ^
+                                         (0x5au + 37u * i));
+    }
+    return result;
+}
+
+static void roundtrip_preserves_all_16_bytes() {
+    CallStartMailbox mailbox;
+    const auto sent = pattern(0x1234abcdu);
+    CallStartMailbox::PeerHash received{};
+    EXPECT_TRUE(mailbox.request(sent));
+    EXPECT_TRUE(mailbox.take(received));
+    EXPECT_EQ(received, sent);
+}
+
+static void duplicate_pending_is_rejected_and_preserves_first() {
+    CallStartMailbox mailbox;
+    const auto first = pattern(1);
+    const auto second = pattern(2);
+    CallStartMailbox::PeerHash received{};
+    EXPECT_TRUE(mailbox.request(first));
+    EXPECT_TRUE(!mailbox.request(second));
+    EXPECT_TRUE(mailbox.take(received));
+    EXPECT_EQ(received, first);
+}
+
+static void empty_take_leaves_output_unchanged() {
+    CallStartMailbox mailbox;
+    auto output = pattern(99);
+    const auto before = output;
+    EXPECT_TRUE(!mailbox.take(output));
+    EXPECT_EQ(output, before);
+}
+
+static void producer_consumer_stress_has_no_torn_payload() {
+    CallStartMailbox mailbox;
+    constexpr uint32_t total = 100000;
+    std::atomic<uint32_t> errors{0};
+    std::atomic<uint32_t> consumed{0};
+
+    std::thread producer([&] {
+        for (uint32_t sequence = 1; sequence <= total; ++sequence) {
+            const auto payload = pattern(sequence);
+            while (!mailbox.request(payload)) std::this_thread::yield();
+        }
+    });
+
+    std::thread consumer([&] {
+        uint32_t expected = 1;
+        while (expected <= total) {
+            CallStartMailbox::PeerHash received{};
+            if (!mailbox.take(received)) {
+                std::this_thread::yield();
+                continue;
+            }
+            if (received != pattern(expected)) {
+                errors.fetch_add(1, std::memory_order_relaxed);
+            }
+            ++expected;
+            consumed.fetch_add(1, std::memory_order_relaxed);
+        }
+    });
+
+    producer.join();
+    consumer.join();
+    EXPECT_EQ(errors.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(consumed.load(std::memory_order_relaxed), total);
+}
+
+int main() {
+    RUN(roundtrip_preserves_all_16_bytes);
+    RUN(duplicate_pending_is_rejected_and_preserves_first);
+    RUN(empty_take_leaves_output_unchanged);
+    RUN(producer_consumer_stress_has_no_torn_payload);
+    std::printf("%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/tests/native/test_call_start_mailbox.py
+++ b/tests/native/test_call_start_mailbox.py
@@ -1,0 +1,33 @@
+"""Compile and execute the portable LXST call-start mailbox regression."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TEST_SOURCE = HERE / "test_call_start_mailbox.cpp"
+
+
+def test_call_start_mailbox(tmp_path):
+    cxx = shutil.which("clang++") or shutil.which("g++")
+    if not cxx:
+        pytest.skip("no C++ compiler found")
+    binary = tmp_path / "test_call_start_mailbox"
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        "-pthread",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(cmd, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "4 passed, 0 failed" in ran.stdout

--- a/tests/native/test_codec2_packet_quantum.cpp
+++ b/tests/native/test_codec2_packet_quantum.cpp
@@ -1,0 +1,32 @@
+#include <iostream>
+
+#include "../../lib/lxst_audio/ULBWVoiceProfilePolicy.h"
+
+namespace {
+int passed = 0;
+int failed = 0;
+void expect(bool condition, const char* name) {
+    if (condition) ++passed;
+    else { ++failed; std::cerr << "FAIL: " << name << '\n'; }
+}
+}
+
+int main() {
+    expect(ULBWVoiceProfilePolicy::isSupportedProfile(0x10), "ULBW supported");
+    expect(!ULBWVoiceProfilePolicy::isSupportedProfile(0x20), "VLBW rejected");
+    expect(!ULBWVoiceProfilePolicy::isSupportedProfile(0x30), "LBW rejected");
+    expect(ULBWVoiceProfilePolicy::codecModeForProfile(0x10) == 8, "ULBW maps to Codec2 700C");
+    expect(ULBWVoiceProfilePolicy::codecModeForProfile(0x20) == -1, "VLBW has no codec mapping");
+    expect(ULBWVoiceProfilePolicy::pcmSamplesPerPacket() == 3200, "ULBW packet is 400ms at 8kHz");
+    expect(ULBWVoiceProfilePolicy::framesPerPacket(320) == 10, "ULBW packet has ten frames");
+    expect(ULBWVoiceProfilePolicy::framesPerPacket(0) == 0, "zero frame size rejected");
+    expect(ULBWVoiceProfilePolicy::outerBatchBytes(320, 4) == 42, "ULBW outer batch is 42 bytes");
+    expect(ULBWVoiceProfilePolicy::acceptsCodec2ModeHeader(0x00), "ULBW media header accepted");
+    expect(!ULBWVoiceProfilePolicy::acceptsCodec2ModeHeader(0x04), "VLBW media header rejected");
+    expect(!ULBWVoiceProfilePolicy::acceptsCodec2ModeHeader(0x06), "LBW media header rejected");
+    expect(ULBWVoiceProfilePolicy::preferredProfileSignal() == 0x10F,
+           "profile response always requests ULBW");
+
+    std::cout << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/native/test_codec2_packet_quantum.py
+++ b/tests/native/test_codec2_packet_quantum.py
@@ -1,0 +1,26 @@
+"""Compile and execute the portable ULBW-only voice profile policy regression."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TEST_SOURCE = HERE / "test_codec2_packet_quantum.cpp"
+
+
+def test_ulbw_voice_profile_policy(tmp_path):
+    cxx = shutil.which("c++")
+    if not cxx:
+        pytest.skip("no C++ compiler found")
+    binary = tmp_path / "test_codec2_packet_quantum"
+    compiled = subprocess.run(
+        [cxx, "-std=c++17", "-Wall", "-Wextra", "-Werror", str(TEST_SOURCE), "-o", str(binary)],
+        capture_output=True,
+        text=True,
+    )
+    assert compiled.returncode == 0, compiled.stderr
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "13 passed, 0 failed" in ran.stdout

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -47,6 +47,15 @@ T-Deck serial hooks to verify:
 - Sideband calls Pyxis and exchanges synthetic Codec2 audio in both directions.
 - Pyxis still accepts another incoming call after both calls and hangups.
 - Every Pyxis decode succeeds and produces non-zero PCM.
+- A raw LXST caller can hold the incoming reservation without identifying; a
+  second raw link receives `STATUS_BUSY` and cannot replace it.
+- A local `T:CALL` request cannot displace an incoming link that is still
+  identifying.
+- Closing reserved caller A and then ringing caller B isolates B from a feasible
+  late action and queued callback drain from A.
+- A non-identifying caller is closed after the 15-second firmware timeout, and a
+  subsequent normal call still rings, answers, reaches `ACTIVE`, exchanges audio
+  in both directions, and hangs up cleanly.
 
 Build the test firmware with the Mac TCP server baked in, then upload it:
 
@@ -63,8 +72,17 @@ Run from the Mac with its Reticulum venv (defaults to the local TCP server on
 ```
 
 Optional overrides: `PYXIS_SERIAL_PORT`, `PYXIS_RNS_HOST`,
-`PYXIS_RNS_PORT`, and `PYXIS_CALL_SECONDS`. Each run uses a fresh Sideband
-identity and isolated RNS storage so stale cached paths cannot false-pass setup.
+`PYXIS_RNS_PORT`, `PYXIS_CALL_SECONDS`, and
+`PYXIS_IDENTIFY_TIMEOUT_MARGIN` (seconds beyond the fixed 15-second firmware
+identification timeout; default `3`, must be positive). Each run uses a fresh
+Sideband identity and isolated RNS storage so stale cached paths cannot false-pass setup.
 On Apple Silicon the harness re-executes itself with `/opt/homebrew/lib` on
 `DYLD_LIBRARY_PATH`, allowing LXST/PyOgg to load Homebrew `libopus` for incoming
 calls.
+
+The contention cases use the pinned Reticulum 1.3.8 `Identity`, `Destination`,
+and `Link` APIs directly. They require current Pyxis and Sideband LXST announces,
+the TCP Reticulum hub, a serial-connected T-Deck running the test-hooks firmware,
+and the Mac Reticulum environment shown above. Run the host-native generation
+guard tests separately for the deterministic portable stale-callback model; the
+raw-link stale-action case is an additional physical integration check.

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -14,12 +14,12 @@ harness re-aligns and scores the round-trip.
 ## Firmware contract (`T:LOOPBACK` test mode)
 - UDP multicast `239.0.99.99:9998`, each datagram = `[uint32 LE byte-offset][int16 LE
   mono @ 8 kHz PCM]`, ≤1284 B.
-- Serial hooks: `T:CALL_PROFILE 0x10|0x20|0x30` (ULBW/VLBW/LBW), `T:LOOPBACK on|off`.
+- Serial hooks: `T:CALL_PROFILE 0x10` (ULBW/Codec2-700C only), `T:LOOPBACK on|off`.
 
 ## Run
 ```bash
 cd tools/voice_test
-.venv/bin/python run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW,VLBW,LBW
+.venv/bin/python run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW
 # options: --ref my.wav   --text "..."   --output "Mac mini Speakers"   --tail 1.2
 ```
 
@@ -34,8 +34,8 @@ summary table.
 - **hf**: high-band (2–3.4 kHz) survival — Codec2 low profiles roll off the top.
 - **pkts / dropped**: UDP delivery health.
 
-Lower-bitrate profiles (700C) score lower by design; compare profiles and before/after
-firmware changes. The venv was created with `uv venv --python 3.12` +
+Codec2-700C scores lower than wider codecs by design; compare before/after firmware
+changes, not alternate profiles. The venv was created with `uv venv --python 3.12` +
 `numpy scipy soundfile sounddevice pyserial pystoi`.
 
 ## Sideband/LXST end-to-end regression

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -51,8 +51,9 @@ T-Deck serial hooks to verify:
   second raw link receives `STATUS_BUSY` and cannot replace it.
 - A local `T:CALL` request cannot displace an incoming link that is still
   identifying.
-- Closing reserved caller A and then ringing caller B isolates B from a feasible
-  late action and queued callback drain from A.
+- Closing reserved caller A and then ringing caller B proves that closed-link
+  `identify()` is a no-op and that B remains stable while A's queued callbacks
+  drain. The harness does not inject a fabricated stale callback.
 - A non-identifying caller is closed after the 15-second firmware timeout, and a
   subsequent normal call still rings, answers, reaches `ACTIVE`, exchanges audio
   in both directions, and hangs up cleanly.
@@ -63,6 +64,10 @@ Build the test firmware with the Mac TCP server baked in, then upload it:
 export PYXIS_TEST_TCP_HOST=10.0.0.145 PYXIS_TEST_TCP_PORT=4242
 /opt/homebrew/bin/pio run -e tdeck -t upload --upload-port /dev/cu.usbmodem101
 ```
+
+After testing, remove/disable `PYXIS_TEST_HOOKS` and the test TCP overrides and
+restore the normal release firmware on the device. Do not leave test-hook
+firmware deployed as the normal user build.
 
 Run from the Mac with its Reticulum venv (defaults to the local TCP server on
 `127.0.0.1:4242`):
@@ -80,9 +85,17 @@ On Apple Silicon the harness re-executes itself with `/opt/homebrew/lib` on
 `DYLD_LIBRARY_PATH`, allowing LXST/PyOgg to load Homebrew `libopus` for incoming
 calls.
 
-The contention cases use the pinned Reticulum 1.3.8 `Identity`, `Destination`,
-and `Link` APIs directly. They require current Pyxis and Sideband LXST announces,
-the TCP Reticulum hub, a serial-connected T-Deck running the test-hooks firmware,
-and the Mac Reticulum environment shown above. Run the host-native generation
-guard tests separately for the deterministic portable stale-callback model; the
-raw-link stale-action case is an additional physical integration check.
+The contention cases use the ordinary Reticulum `Identity`, `Destination`, and
+`Link` APIs directly and print the observed `RNS.__version__` at startup. The
+legacy Sideband environment was validated with RNS 1.3.8 for API compatibility;
+that is an observation, not a pin or downgrade recommendation. Torlando's
+security-patched deployments require RNS 1.3.9 or newer for Luthen. Use the
+current security-patched version and do not force an insecure rollback merely
+to run this harness.
+
+The physical run requires current Pyxis and Sideband LXST announces, the TCP
+Reticulum hub, a serial-connected T-Deck running the test-hooks firmware, and
+the Mac Reticulum environment shown above. Run the host-native generation guard
+tests separately for the deterministic portable stale-callback model. The
+physical closed-link case proves close/B-redial stability plus callback drain;
+it does not inject a stale callback.

--- a/tools/voice_test/README.md
+++ b/tools/voice_test/README.md
@@ -61,7 +61,7 @@ T-Deck serial hooks to verify:
 Build the test firmware with the Mac TCP server baked in, then upload it:
 
 ```bash
-export PYXIS_TEST_TCP_HOST=10.0.0.145 PYXIS_TEST_TCP_PORT=4242
+export PYXIS_TEST_TCP_HOST="<RNSD-HOST>" PYXIS_TEST_TCP_PORT=4242
 /opt/homebrew/bin/pio run -e tdeck -t upload --upload-port /dev/cu.usbmodem101
 ```
 

--- a/tools/voice_test/run_voice_test.py
+++ b/tools/voice_test/run_voice_test.py
@@ -7,18 +7,18 @@ This harness plays a known reference signal out the Mac speaker; the T-Deck mic
 captures it, runs the real pipeline (ES7210 -> filters/AGC -> Codec2 encode ->
 call_send_audio_batch framing -> call_on_packet parse -> Codec2 decode), and dumps
 the decoded PCM back over UDP multicast. We re-align and score the round-trip so we
-can (a) confirm a profile produces intelligible audio and (b) compare profiles and
-before/after a firmware change.
+can confirm the production ULBW profile produces intelligible audio before/after
+a firmware change.
 
 Firmware contract (T:LOOPBACK test mode):
   - UDP multicast 239.0.99.99:9998, each datagram = [uint32 LE byte_offset][int16 LE
     mono PCM @ 8 kHz], payload <= 1284 bytes.
-  - Serial T: hooks: `T:CALL_PROFILE 0x10|0x20|0x30` (ULBW/VLBW/LBW),
+  - Serial T: hooks: `T:CALL_PROFILE 0x10` (ULBW only),
     `T:LOOPBACK on`, `T:LOOPBACK off`.
 
 Usage:
-  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW,VLBW,LBW
-  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles LBW --ref my.wav
+  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW
+  python3 run_voice_test.py --port /dev/cu.usbmodem101 --profiles ULBW --ref my.wav
 
 Deps:  pip install numpy scipy soundfile sounddevice pyserial    (optional: pystoi)
 Make sure the Mac OUTPUT device is the built-in speaker next to the T-Deck, and
@@ -26,10 +26,11 @@ turn the volume to a consistent, moderate level.
 """
 
 import argparse, socket, struct, sys, time, threading, subprocess, os
+from voice_profile_contract import require_ulbw_confirmation, validate_requested_profiles
 
 SR = 8000                         # Codec2 / pipeline sample rate
 MCAST_GRP, MCAST_PORT = "239.0.99.99", 9998
-PROFILES = {"ULBW": 0x10, "VLBW": 0x20, "LBW": 0x30}   # 700C / 1600 / 3200
+PROFILES = {"ULBW": 0x10}   # Codec2-700C; sole production profile
 OUTDIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
 
 
@@ -258,7 +259,9 @@ def verdict(res):
 # ---------------- one profile run ----------------
 def run_profile(dev, name, ref, chirp_len, tail_s):
     print(f"\n=== profile {name} (0x{PROFILES[name]:02X}) ===")
-    print("  set profile:", dev.cmd(f"T:CALL_PROFILE 0x{PROFILES[name]:02X}").strip())
+    profile_response = dev.cmd(f"T:CALL_PROFILE 0x{PROFILES[name]:02X}")
+    require_ulbw_confirmation(profile_response)
+    print("  set profile:", profile_response.strip())
     rx = PcmReceiver(); rx.start()
     time.sleep(0.2)
     print("  loopback on:", dev.cmd("T:LOOPBACK on").strip())
@@ -285,7 +288,7 @@ def run_profile(dev, name, ref, chirp_len, tail_s):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--port", default="/dev/cu.usbmodem101")
-    ap.add_argument("--profiles", default="ULBW,VLBW,LBW")
+    ap.add_argument("--profiles", default="ULBW", help="must be ULBW")
     ap.add_argument("--ref", help="reference WAV (else generated chirp+speech)")
     ap.add_argument("--text", default="The quick brown fox jumps over the lazy dog. "
                     "She sells seashells. Numbers: one two three four five.")
@@ -293,6 +296,10 @@ def main():
     ap.add_argument("--output", default="speaker",
                     help="output device name substring (the Mac speaker next to the T-Deck mic)")
     args = ap.parse_args()
+    try:
+        requested_profiles = validate_requested_profiles(args.profiles)
+    except ValueError as exc:
+        ap.error(str(exc))
 
     # Select the output device so audio plays out the speaker (not a monitor/HDMI).
     out_dev = next((i for i, d in enumerate(sd.query_devices())
@@ -324,9 +331,7 @@ def main():
         # BLE holds enough heap to make that allocation fail intermittently. Free it
         # for the duration of the test, restore after.
         print("BLE off (free heap):", dev.cmd("T:BLE off", wait=1.8).strip().splitlines()[-1:])
-        for name in [p.strip().upper() for p in args.profiles.split(",") if p.strip()]:
-            if name not in PROFILES:
-                print(f"  skip unknown profile {name}"); continue
+        for name in requested_profiles:
             results[name] = run_profile(dev, name, ref, chirp_len, args.tail)
     finally:
         try:

--- a/tools/voice_test/sideband_e2e.py
+++ b/tools/voice_test/sideband_e2e.py
@@ -498,9 +498,19 @@ def main():
         while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
         assert phone.is_in_call,"Sideband did not become active after identification timeout"
         ok,data=run_audio(dev,"TEST_IDENTIFY_TIMEOUT")
+        phone.hangup()
+        idle_ok,hangup_states=dev.wait_state("IDLE",15)
+        assert idle_ok, \
+            f"timeout recovery hangup did not return Pyxis to IDLE; states={hangup_states}"
+        hangup_deadline=time.time()+15
+        while (phone.is_in_call or phone.telephone.active_call) and time.time()<hangup_deadline:
+            time.sleep(.2)
+        assert not phone.is_in_call and not phone.telephone.active_call, \
+            "timeout recovery hangup did not close the Sideband call/link"
         results.append(("identification_timeout_recovery_bidirectional",ok,
-                        {"dial":recovery_dial,"ring_states":seen,"audio":data}))
-        phone.hangup(); dev.wait_state("IDLE",15); time.sleep(1)
+                        {"dial":recovery_dial,"ring_states":seen,"audio":data,
+                         "hangup_states":hangup_states}))
+        time.sleep(1)
 
         # Pyxis -> Sideband first. This proves Pyxis learned the fresh peer
         # announce before testing the reciprocal incoming route.

--- a/tools/voice_test/sideband_e2e.py
+++ b/tools/voice_test/sideband_e2e.py
@@ -197,8 +197,9 @@ class RawCaller:
             established_callback=self._on_established,
             closed_callback=self._on_closed)
         # Ordinary Link packets are dropped when no packet callback is present.
-        # Register synchronously after construction so STATUS_AVAILABLE/BUSY
-        # cannot race the asynchronous established callback.
+        # Register at the earliest point supported by the public RNS API. A very
+        # small constructor-return window remains because Link.__init__() does
+        # not accept a packet callback.
         self.link.set_packet_callback(self._on_packet)
 
     def _on_established(self, link):
@@ -263,18 +264,25 @@ class RawCaller:
                         f"{self.label}: raw link did not establish in {timeout}s "
                         f"(status={self.link.status}, signals={self._signals}, "
                         f"closed={self._closed.is_set()})")
-                self._condition.wait(max(0, remaining))
+                # Poll status too: some proof-validation failures set CLOSED
+                # without invoking the close callback.
+                self._condition.wait(min(0.1, max(0, remaining)))
         return self
 
     def wait_signal(self, signal, timeout=8):
         deadline = time.monotonic()+timeout
+        close_drain_deadline = None
         with self._condition:
             while signal not in self._signals:
+                now = time.monotonic()
                 if self._closed.is_set() or self.link.status == RNS.Link.CLOSED:
-                    raise AssertionError(
-                        f"{self.label}: link closed before signal 0x{signal:02x}; "
-                        f"received={self._signals}")
-                remaining = deadline-time.monotonic()
+                    # Packet callbacks run on worker threads while close can be
+                    # synchronous. Allow an already-queued BUSY packet to drain.
+                    if close_drain_deadline is None:
+                        close_drain_deadline = min(deadline, now+1.0)
+                effective_deadline = (min(deadline, close_drain_deadline)
+                                      if close_drain_deadline is not None else deadline)
+                remaining = effective_deadline-now
                 if remaining <= 0:
                     break
                 self._condition.wait(max(0, remaining))
@@ -282,9 +290,10 @@ class RawCaller:
                 raise AssertionError(
                     f"{self.label}: failed to decode LXST packet(s): {self._packet_errors}")
             if signal not in self._signals:
+                closed = self._closed.is_set() or self.link.status == RNS.Link.CLOSED
                 raise AssertionError(
                     f"{self.label}: did not receive signal 0x{signal:02x} in {timeout}s; "
-                    f"received={self._signals}, closed={self._closed.is_set()}")
+                    f"received={self._signals}, closed={closed}")
         return self
 
     def wait_closed(self, timeout=8):
@@ -410,6 +419,7 @@ def main():
     print(f"RNS_VERSION={RNS.__version__}",flush=True)
     dev=None
     phone=None
+    initial_ble_enabled=None
     results=[]
     try:
         dev=Dev()
@@ -433,7 +443,14 @@ def main():
         py_dest=(dev.cmd("T:LXSTDEST")[0] or "").split()[-1]
         print(f"SIDE_ID={side_id} SIDE_DEST={side_dest}",flush=True)
         print(f"PYXIS_ID={py_id} PYXIS_DEST={py_dest}",flush=True)
-        dev.cmd("T:BLE off",timeout=5)
+        ble_response,_=dev.cmd("T:BLE",timeout=5)
+        ble_match=re.search(r"\bble_enabled=([01])\b",ble_response or "")
+        assert ble_match, f"could not query initial BLE state: {ble_response!r}"
+        initial_ble_enabled = ble_match.group(1) == "1"
+        if initial_ble_enabled:
+            response,_=dev.cmd("T:BLE off",timeout=5)
+            assert response and response.startswith("T:OK"), \
+                f"could not disable BLE for voice harness: {response!r}"
         dev.cmd("T:CALL_PROFILE 0x10")
         dev.cmd("T:ANNLXST")
         phone.announce()
@@ -613,9 +630,14 @@ def main():
                 cleanup_errors.append(f"phone hangup: {exc!r}")
             try: phone.stop()
             except BaseException as exc: cleanup_errors.append(f"phone stop: {exc!r}")
-        if dev is not None:
-            try: dev.cmd("T:BLE on",timeout=5)
+        if dev is not None and initial_ble_enabled is not None:
+            try:
+                restore = "on" if initial_ble_enabled else "off"
+                response,_=dev.cmd("T:BLE "+restore,timeout=5)
+                if not response or not response.startswith("T:OK"):
+                    raise AssertionError(f"unexpected response {response!r}")
             except BaseException as exc: cleanup_errors.append(f"BLE restore: {exc!r}")
+        if dev is not None:
             try: dev.close()
             except BaseException as exc: cleanup_errors.append(f"serial close: {exc!r}")
         if cleanup_errors:

--- a/tools/voice_test/sideband_e2e.py
+++ b/tools/voice_test/sideband_e2e.py
@@ -22,6 +22,7 @@ sys.path.append(os.path.join(HOME, "Library", "Python", "3.9", "lib", "python", 
 import numpy as np
 import serial
 import RNS
+from RNS.vendor import umsgpack as msgpack
 import LXST.Sources as Sources
 import LXST.Sinks as Sinks
 from LXST.Codecs.Codec2 import Codec2
@@ -31,6 +32,16 @@ from sideband.voice import ReticulumTelephone
 PORT = os.environ.get("PYXIS_SERIAL_PORT") or sorted(glob.glob("/dev/cu.usbmodem*"))[0]
 PROFILE = Profiles.BANDWIDTH_ULTRA_LOW
 RUN_SECONDS = float(os.environ.get("PYXIS_CALL_SECONDS", "7"))
+IDENTIFY_TIMEOUT_SECONDS = 15.0
+IDENTIFY_TIMEOUT_MARGIN = float(os.environ.get("PYXIS_IDENTIFY_TIMEOUT_MARGIN", "3"))
+
+if not math.isfinite(IDENTIFY_TIMEOUT_MARGIN) or IDENTIFY_TIMEOUT_MARGIN <= 0:
+    raise ValueError("PYXIS_IDENTIFY_TIMEOUT_MARGIN must be a positive finite number")
+
+FIELD_SIGNALLING = 0x00
+STATUS_BUSY = 0x00
+STATUS_AVAILABLE = 0x03
+STATUS_RINGING = 0x04
 
 class Stats:
     lock = threading.Lock()
@@ -148,6 +159,152 @@ class Dev:
         return False,seen
     def close(self): self.s.close()
 
+class RawCaller:
+    """A deliberately manual LXST caller backed by one fresh RNS identity.
+
+    This uses the RNS 1.3.8 Link API directly instead of Telephone, since
+    Telephone automatically identifies as soon as STATUS_AVAILABLE arrives.
+    """
+    def __init__(self, destination_hash, label):
+        self.label = label
+        self.identity = RNS.Identity()
+        self.destination_hash = bytes(destination_hash)
+        remote_identity = RNS.Identity.recall(self.destination_hash)
+        if remote_identity is None:
+            raise RuntimeError(
+                f"{label}: no recalled identity for LXST destination "
+                f"{self.destination_hash.hex()}; wait for a current Pyxis announce"
+            )
+        self.destination = RNS.Destination(
+            remote_identity, RNS.Destination.OUT, RNS.Destination.SINGLE,
+            "lxst", "telephony")
+        if self.destination.hash != self.destination_hash:
+            raise RuntimeError(
+                f"{label}: recalled identity produced {self.destination.hash.hex()}, "
+                f"expected {self.destination_hash.hex()}"
+            )
+        self._established = threading.Event()
+        self._closed = threading.Event()
+        self._condition = threading.Condition()
+        self._signals = []
+        self._packet_errors = []
+        self.link = RNS.Link(
+            self.destination,
+            established_callback=self._on_established,
+            closed_callback=self._on_closed)
+
+    def _on_established(self, link):
+        link.set_packet_callback(self._on_packet)
+        self._established.set()
+        print(f"{self.label} RAW_LINK_ESTABLISHED id={link.link_id.hex()}", flush=True)
+
+    def _on_closed(self, link):
+        self._closed.set()
+        with self._condition:
+            self._condition.notify_all()
+        print(f"{self.label} RAW_LINK_CLOSED reason={link.teardown_reason}", flush=True)
+
+    def _on_packet(self, data, packet):
+        try:
+            unpacked = msgpack.unpackb(data)
+            if not isinstance(unpacked, dict) or FIELD_SIGNALLING not in unpacked:
+                return
+            signals = unpacked[FIELD_SIGNALLING]
+            if not isinstance(signals, list):
+                signals = [signals]
+            if not all(isinstance(signal, int) for signal in signals):
+                raise ValueError(f"non-integer signalling values: {signals!r}")
+            with self._condition:
+                self._signals.extend(signals)
+                self._condition.notify_all()
+            print(f"{self.label} RAW_SIGNALS={signals}", flush=True)
+        except Exception as exc:
+            with self._condition:
+                self._packet_errors.append(repr(exc))
+                self._condition.notify_all()
+            print(f"{self.label} RAW_PACKET_ERROR={exc!r}", flush=True)
+
+    @property
+    def signals(self):
+        with self._condition:
+            return tuple(self._signals)
+
+    @property
+    def is_open(self):
+        return self.link.status != RNS.Link.CLOSED
+
+    def wait_established(self, timeout=20):
+        if not self._established.wait(timeout):
+            raise AssertionError(
+                f"{self.label}: raw link did not establish in {timeout}s "
+                f"(status={self.link.status}, closed={self._closed.is_set()})")
+        return self
+
+    def wait_signal(self, signal, timeout=8):
+        deadline = time.time()+timeout
+        with self._condition:
+            while signal not in self._signals and time.time() < deadline:
+                self._condition.wait(deadline-time.time())
+            if self._packet_errors:
+                raise AssertionError(
+                    f"{self.label}: failed to decode LXST packet(s): {self._packet_errors}")
+            if signal not in self._signals:
+                raise AssertionError(
+                    f"{self.label}: did not receive signal 0x{signal:02x} in {timeout}s; "
+                    f"received={self._signals}, closed={self._closed.is_set()}")
+        return self
+
+    def wait_closed(self, timeout=8):
+        if not self._closed.wait(timeout):
+            raise AssertionError(
+                f"{self.label}: link did not close in {timeout}s "
+                f"(status={self.link.status}, signals={self.signals})")
+        return self
+
+    def identify(self, allow_closed=False):
+        if not self._established.is_set():
+            raise RuntimeError(f"{self.label}: cannot identify before link establishment")
+        if not self.is_open:
+            if allow_closed:
+                # RNS 1.3.8 identify() intentionally becomes a no-op unless the
+                # initiator link is ACTIVE. Calling it exercises the feasible
+                # late-action path without fabricating a Reticulum callback.
+                self.link.identify(self.identity)
+                return False
+            raise RuntimeError(f"{self.label}: cannot identify on a closed link")
+        self.link.identify(self.identity)
+        return True
+
+    def close(self, timeout=8):
+        if self.link.status != RNS.Link.CLOSED:
+            self.link.teardown()
+        if self._established.is_set():
+            self.wait_closed(timeout)
+
+def assert_state_for(dev, wanted, duration, label):
+    deadline=time.time()+duration; seen=[]
+    while time.time()<deadline:
+        state=dev.state(); seen.append(state)
+        if state != wanted:
+            raise AssertionError(
+                f"{label}: expected state {wanted} for {duration}s, "
+                f"observed {state}; history={seen}")
+        time.sleep(0.25)
+    return seen
+
+def cleanup_raw_callers(dev, *callers):
+    try:
+        if dev.state() != "IDLE": dev.cmd("T:CALL_HANGUP")
+    finally:
+        for caller in callers:
+            if caller is not None:
+                try: caller.close()
+                except Exception as exc:
+                    print(f"{caller.label} RAW_CLEANUP={exc!r}", flush=True)
+        ok,seen=dev.wait_state("IDLE",15)
+        if not ok:
+            raise AssertionError(f"raw-call cleanup did not reach IDLE; states={seen}")
+
 def val(resp,key):
     m=re.search(rf"\b{re.escape(key)}=([0-9]+)",resp or "")
     return int(m.group(1)) if m else -1
@@ -232,6 +389,119 @@ def main():
     phone.announce()
     results=[]
     try:
+        # Both directions need a current announce before the raw-link cases.
+        phone.announce(); dev.cmd("T:ANNLXST")
+        assert wait_path_pyxis(dev,side_dest,45),"Pyxis did not learn Sideband LXST path"
+        assert wait_path_rns(bytes.fromhex(py_dest),45),"Sideband did not learn Pyxis LXST path"
+
+        # Contention 1: B must be rejected without displacing unidentified A.
+        a=b=None
+        try:
+            print("TEST_IDENTIFY_CONTENTION raw A then raw B",flush=True)
+            a=RawCaller(bytes.fromhex(py_dest),"CONTENTION_A")
+            a.wait_established()
+            a.wait_signal(STATUS_AVAILABLE)
+            ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
+            print("TEST_IDENTIFY_CONTENTION states_to_identifying",seen,flush=True)
+            assert ok,"Pyxis did not reserve caller A while awaiting identity"
+            b=RawCaller(bytes.fromhex(py_dest),"CONTENTION_B")
+            b.wait_established()
+            b.wait_signal(STATUS_BUSY).wait_closed()
+            assert_state_for(dev,"INCOMING_IDENTIFYING",1.0,"caller B rejection")
+            assert a.is_open,"caller A was closed when caller B was rejected"
+            a.identify(); a.wait_signal(STATUS_RINGING)
+            ok,seen=dev.wait_state("INCOMING_RINGING",10)
+            assert ok,f"caller A did not ring after identification; states={seen}"
+            results.append(("unidentified_owner_rejects_second_link",True,
+                            {"a_signals":a.signals,"b_signals":b.signals,"states":seen}))
+        finally:
+            cleanup_raw_callers(dev,a,b)
+
+        # Contention 2: a local outgoing request cannot steal A's reservation.
+        a=None
+        try:
+            print("TEST_IDENTIFY_OUTGOING outgoing request while raw A owns",flush=True)
+            a=RawCaller(bytes.fromhex(py_dest),"OUTGOING_RACE_A")
+            a.wait_established()
+            a.wait_signal(STATUS_AVAILABLE)
+            ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
+            assert ok,f"Pyxis did not enter identifying before outgoing race; states={seen}"
+            response,_=dev.cmd("T:CALL "+side_dest)
+            assert response is not None,"T:CALL did not return during identification contention"
+            stable=assert_state_for(dev,"INCOMING_IDENTIFYING",1.0,"outgoing initiation")
+            assert a.is_open,"outgoing initiation displaced caller A"
+            assert not phone.is_in_call and not phone.telephone.active_call, \
+                "Sideband received an outgoing call while caller A owned Pyxis"
+            a.identify(); a.wait_signal(STATUS_RINGING)
+            ok,seen=dev.wait_state("INCOMING_RINGING",10)
+            assert ok,f"caller A did not ring after outgoing race; states={seen}"
+            results.append(("outgoing_cannot_displace_unidentified_owner",True,
+                            {"call_response":response,"stable":stable,"a_signals":a.signals}))
+        finally:
+            cleanup_raw_callers(dev,a)
+
+        # Stale A must not affect a later generation owned by identified B.
+        a=b=None
+        try:
+            print("TEST_STALE_LINK close A then identify B",flush=True)
+            a=RawCaller(bytes.fromhex(py_dest),"STALE_A")
+            a.wait_established()
+            a.wait_signal(STATUS_AVAILABLE)
+            ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
+            assert ok,f"Pyxis did not reserve stale caller A; states={seen}"
+            a.close(); ok,seen=dev.wait_state("IDLE",15)
+            assert ok,f"Pyxis did not release caller A; states={seen}"
+            b=RawCaller(bytes.fromhex(py_dest),"STALE_B")
+            b.wait_established()
+            b.wait_signal(STATUS_AVAILABLE); b.identify(); b.wait_signal(STATUS_RINGING)
+            ok,seen=dev.wait_state("INCOMING_RINGING",10)
+            assert ok,f"caller B did not ring; states={seen}"
+            late_sent=a.identify(allow_closed=True)
+            assert not late_sent,"closed caller A unexpectedly sent a late identification"
+            stable=assert_state_for(dev,"INCOMING_RINGING",1.0,"stale caller A drain")
+            assert b.is_open,"stale caller A action closed current caller B"
+            results.append(("stale_link_cannot_displace_new_owner",True,
+                            {"late_identify_sent":late_sent,"stable":stable,"b_signals":b.signals}))
+        finally:
+            cleanup_raw_callers(dev,a,b)
+
+        # Identification timeout must close A and leave the incoming destination
+        # reusable for a complete, audio-bearing Sideband call.
+        a=None
+        try:
+            print("TEST_IDENTIFY_TIMEOUT wait for raw A timeout",flush=True)
+            a=RawCaller(bytes.fromhex(py_dest),"TIMEOUT_A")
+            a.wait_established()
+            a.wait_signal(STATUS_AVAILABLE)
+            ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
+            assert ok,f"Pyxis did not enter identifying before timeout; states={seen}"
+            wait_seconds=IDENTIFY_TIMEOUT_SECONDS+IDENTIFY_TIMEOUT_MARGIN
+            print(f"TEST_IDENTIFY_TIMEOUT sleeping={wait_seconds:.1f}s",flush=True)
+            time.sleep(wait_seconds)
+            ok,seen=dev.wait_state("IDLE",5)
+            assert ok, \
+                f"Pyxis was not IDLE after {wait_seconds:.1f}s identification timeout; states={seen}"
+            a.wait_closed(5)
+        finally:
+            cleanup_raw_callers(dev,a)
+
+        dev.cmd("T:ANNLXST"); assert wait_path_rns(bytes.fromhex(py_dest),20)
+        print("TEST_IDENTIFY_TIMEOUT recovery Sideband -> Pyxis",flush=True)
+        recovery_dial=phone.dial(bytes.fromhex(py_id),profile=PROFILE)
+        assert recovery_dial!="no_path","timeout recovery call had no path"
+        ok,seen=dev.wait_state("INCOMING_RINGING",25)
+        assert ok,f"timeout recovery call did not ring; states={seen}"
+        print("TEST_IDENTIFY_TIMEOUT answer",dev.cmd("T:CALL_ANSWER")[0],flush=True)
+        ok,seen_active=dev.wait_state("ACTIVE",25)
+        assert ok,f"timeout recovery call did not become active; states={seen_active}"
+        deadline=time.time()+15
+        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        assert phone.is_in_call,"Sideband did not become active after identification timeout"
+        ok,data=run_audio(dev,"TEST_IDENTIFY_TIMEOUT")
+        results.append(("identification_timeout_recovery_bidirectional",ok,
+                        {"dial":recovery_dial,"ring_states":seen,"audio":data}))
+        phone.hangup(); dev.wait_state("IDLE",15); time.sleep(1)
+
         # Pyxis -> Sideband first. This proves Pyxis learned the fresh peer
         # announce before testing the reciprocal incoming route.
         phone.announce(); dev.cmd("T:ANNLXST")

--- a/tools/voice_test/sideband_e2e.py
+++ b/tools/voice_test/sideband_e2e.py
@@ -127,13 +127,17 @@ Sinks.Backend = FakeSinkBackend
 class Dev:
     def __init__(self):
         self.s = serial.Serial(PORT, 115200, timeout=0.12)
-        self.crash_trace = False
-        time.sleep(0.4)
-        self.s.reset_input_buffer()
+        try:
+            self.crash_trace = False
+            time.sleep(0.4)
+            self.s.reset_input_buffer()
+        except BaseException:
+            self.s.close()
+            raise
     def cmd(self, line, timeout=4):
         self.s.write((line+"\n").encode()); self.s.flush()
-        deadline = time.time()+timeout; lines=[]
-        while time.time()<deadline:
+        deadline = time.monotonic()+timeout; lines=[]
+        while time.monotonic()<deadline:
             raw=self.s.readline()
             if not raw: continue
             text=raw.decode("utf-8","replace").strip()
@@ -151,8 +155,8 @@ class Dev:
         r,_=self.cmd("T:CALL_STATE")
         return r.split("state=",1)[1] if r and "state=" in r else "?"
     def wait_state(self, wanted, timeout=30):
-        deadline=time.time()+timeout; seen=[]
-        while time.time()<deadline:
+        deadline=time.monotonic()+timeout; seen=[]
+        while time.monotonic()<deadline:
             st=self.state(); seen.append(st)
             if st==wanted: return True,seen
             time.sleep(0.35)
@@ -162,7 +166,7 @@ class Dev:
 class RawCaller:
     """A deliberately manual LXST caller backed by one fresh RNS identity.
 
-    This uses the RNS 1.3.8 Link API directly instead of Telephone, since
+    This uses the ordinary RNS Link API directly instead of Telephone, since
     Telephone automatically identifies as soon as STATUS_AVAILABLE arrives.
     """
     def __init__(self, destination_hash, label):
@@ -192,10 +196,18 @@ class RawCaller:
             self.destination,
             established_callback=self._on_established,
             closed_callback=self._on_closed)
+        # Ordinary Link packets are dropped when no packet callback is present.
+        # Register synchronously after construction so STATUS_AVAILABLE/BUSY
+        # cannot race the asynchronous established callback.
+        self.link.set_packet_callback(self._on_packet)
 
     def _on_established(self, link):
+        # Harmlessly repeat registration in case the Link implementation resets
+        # callbacks while transitioning to ACTIVE.
         link.set_packet_callback(self._on_packet)
-        self._established.set()
+        with self._condition:
+            self._established.set()
+            self._condition.notify_all()
         print(f"{self.label} RAW_LINK_ESTABLISHED id={link.link_id.hex()}", flush=True)
 
     def _on_closed(self, link):
@@ -234,17 +246,38 @@ class RawCaller:
         return self.link.status != RNS.Link.CLOSED
 
     def wait_established(self, timeout=20):
-        if not self._established.wait(timeout):
-            raise AssertionError(
-                f"{self.label}: raw link did not establish in {timeout}s "
-                f"(status={self.link.status}, closed={self._closed.is_set()})")
+        deadline = time.monotonic()+timeout
+        with self._condition:
+            while not self._established.is_set():
+                if self._packet_errors:
+                    raise AssertionError(
+                        f"{self.label}: failed to decode LXST packet(s) before establishment: "
+                        f"{self._packet_errors}")
+                if self._closed.is_set() or self.link.status == RNS.Link.CLOSED:
+                    raise AssertionError(
+                        f"{self.label}: raw link closed before establishment "
+                        f"(status={self.link.status}, signals={self._signals})")
+                remaining = deadline-time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError(
+                        f"{self.label}: raw link did not establish in {timeout}s "
+                        f"(status={self.link.status}, signals={self._signals}, "
+                        f"closed={self._closed.is_set()})")
+                self._condition.wait(max(0, remaining))
         return self
 
     def wait_signal(self, signal, timeout=8):
-        deadline = time.time()+timeout
+        deadline = time.monotonic()+timeout
         with self._condition:
-            while signal not in self._signals and time.time() < deadline:
-                self._condition.wait(deadline-time.time())
+            while signal not in self._signals:
+                if self._closed.is_set() or self.link.status == RNS.Link.CLOSED:
+                    raise AssertionError(
+                        f"{self.label}: link closed before signal 0x{signal:02x}; "
+                        f"received={self._signals}")
+                remaining = deadline-time.monotonic()
+                if remaining <= 0:
+                    break
+                self._condition.wait(max(0, remaining))
             if self._packet_errors:
                 raise AssertionError(
                     f"{self.label}: failed to decode LXST packet(s): {self._packet_errors}")
@@ -266,7 +299,7 @@ class RawCaller:
             raise RuntimeError(f"{self.label}: cannot identify before link establishment")
         if not self.is_open:
             if allow_closed:
-                # RNS 1.3.8 identify() intentionally becomes a no-op unless the
+                # RNS identify() intentionally becomes a no-op unless the
                 # initiator link is ACTIVE. Calling it exercises the feasible
                 # late-action path without fabricating a Reticulum callback.
                 self.link.identify(self.identity)
@@ -278,12 +311,12 @@ class RawCaller:
     def close(self, timeout=8):
         if self.link.status != RNS.Link.CLOSED:
             self.link.teardown()
-        if self._established.is_set():
+        if self.link.status != RNS.Link.CLOSED or self._closed.is_set():
             self.wait_closed(timeout)
 
 def assert_state_for(dev, wanted, duration, label):
-    deadline=time.time()+duration; seen=[]
-    while time.time()<deadline:
+    deadline=time.monotonic()+duration; seen=[]
+    while time.monotonic()<deadline:
         state=dev.state(); seen.append(state)
         if state != wanted:
             raise AssertionError(
@@ -293,33 +326,45 @@ def assert_state_for(dev, wanted, duration, label):
     return seen
 
 def cleanup_raw_callers(dev, *callers):
+    primary = sys.exc_info()[1]
+    errors = []
     try:
         if dev.state() != "IDLE": dev.cmd("T:CALL_HANGUP")
-    finally:
-        for caller in callers:
-            if caller is not None:
-                try: caller.close()
-                except Exception as exc:
-                    print(f"{caller.label} RAW_CLEANUP={exc!r}", flush=True)
+    except BaseException as exc:
+        errors.append(f"device hangup: {exc!r}")
+    for caller in callers:
+        if caller is not None:
+            try: caller.close()
+            except BaseException as exc:
+                errors.append(f"{caller.label}: {exc!r}")
+    try:
         ok,seen=dev.wait_state("IDLE",15)
         if not ok:
             raise AssertionError(f"raw-call cleanup did not reach IDLE; states={seen}")
+    except BaseException as exc:
+        errors.append(f"device idle: {exc!r}")
+    if errors:
+        detail = "; ".join(errors)
+        if primary is not None:
+            print(f"RAW_CLEANUP_AFTER_PRIMARY primary={primary!r} cleanup={detail}", flush=True)
+        else:
+            raise AssertionError(f"raw-call cleanup failed: {detail}")
 
 def val(resp,key):
     m=re.search(rf"\b{re.escape(key)}=([0-9]+)",resp or "")
     return int(m.group(1)) if m else -1
 
 def wait_path_rns(dest, timeout=30):
-    deadline=time.time()+timeout
-    while time.time()<deadline:
+    deadline=time.monotonic()+timeout
+    while time.monotonic()<deadline:
         if RNS.Transport.has_path(dest): return True
         RNS.Transport.request_path(dest)
         time.sleep(0.7)
     return False
 
 def wait_path_pyxis(dev,desthex,timeout=45):
-    deadline=time.time()+timeout
-    while time.time()<deadline:
+    deadline=time.monotonic()+timeout
+    while time.monotonic()<deadline:
         r,_=dev.cmd("T:HASPATH "+desthex)
         # Firmware includes diagnostic suffixes (`mem=... mem_count=...`).
         if r and r.startswith("T:OK 1"): return True
@@ -362,33 +407,37 @@ def run_audio(dev, label):
 
 def main():
     print(f"PORT={PORT}",flush=True)
-    dev=Dev()
-    owner=Owner()
-    # Use a fresh identity and isolated RNS storage on every run so cached paths
-    # cannot make wait_path_rns() pass before the current Pyxis announce arrives.
-    identity=RNS.Identity()
-    config_dir=f"/tmp/pyxis-sideband-rns-{os.getpid()}"
-    os.makedirs(config_dir,exist_ok=True)
-    rns_host=os.environ.get("PYXIS_RNS_HOST","127.0.0.1")
-    rns_port=int(os.environ.get("PYXIS_RNS_PORT","4242"))
-    with open(os.path.join(config_dir,"config"),"w") as f:
-        f.write(f"""[reticulum]\nenable_transport = No\nshare_instance = No\nshared_instance_port = 48428\ninstance_control_port = 48429\n\n[logging]\nloglevel = 5\n\n[interfaces]\n  [[Pyxis troubleshooting hub]]\n    type = TCPClientInterface\n    enabled = yes\n    target_host = {rns_host}\n    target_port = {rns_port}\n""")
-    print(f"RNS_TEST_HUB={rns_host}:{rns_port}",flush=True)
-    reticulum=RNS.Reticulum(configdir=config_dir,loglevel=5)
-    phone=ReticulumTelephone(identity, owner=owner)
-    phone.telephone.auto_answer=0.6
-    phone.announce()
-    side_id=identity.hash.hex(); side_dest=phone.telephone.destination.hash.hex()
-    py_id=(dev.cmd("T:ID")[0] or "").split()[-1]
-    py_dest=(dev.cmd("T:LXSTDEST")[0] or "").split()[-1]
-    print(f"SIDE_ID={side_id} SIDE_DEST={side_dest}",flush=True)
-    print(f"PYXIS_ID={py_id} PYXIS_DEST={py_dest}",flush=True)
-    dev.cmd("T:BLE off",timeout=5)
-    dev.cmd("T:CALL_PROFILE 0x10")
-    dev.cmd("T:ANNLXST")
-    phone.announce()
+    print(f"RNS_VERSION={RNS.__version__}",flush=True)
+    dev=None
+    phone=None
     results=[]
     try:
+        dev=Dev()
+        owner=Owner()
+        # Use a fresh identity and isolated RNS storage on every run so cached paths
+        # cannot make wait_path_rns() pass before the current Pyxis announce arrives.
+        identity=RNS.Identity()
+        config_dir=f"/tmp/pyxis-sideband-rns-{os.getpid()}"
+        os.makedirs(config_dir,exist_ok=True)
+        rns_host=os.environ.get("PYXIS_RNS_HOST","127.0.0.1")
+        rns_port=int(os.environ.get("PYXIS_RNS_PORT","4242"))
+        with open(os.path.join(config_dir,"config"),"w") as f:
+            f.write(f"""[reticulum]\nenable_transport = No\nshare_instance = No\nshared_instance_port = 48428\ninstance_control_port = 48429\n\n[logging]\nloglevel = 5\n\n[interfaces]\n  [[Pyxis troubleshooting hub]]\n    type = TCPClientInterface\n    enabled = yes\n    target_host = {rns_host}\n    target_port = {rns_port}\n""")
+        print(f"RNS_TEST_HUB={rns_host}:{rns_port}",flush=True)
+        reticulum=RNS.Reticulum(configdir=config_dir,loglevel=5)
+        phone=ReticulumTelephone(identity, owner=owner)
+        phone.telephone.auto_answer=0.6
+        phone.announce()
+        side_id=identity.hash.hex(); side_dest=phone.telephone.destination.hash.hex()
+        py_id=(dev.cmd("T:ID")[0] or "").split()[-1]
+        py_dest=(dev.cmd("T:LXSTDEST")[0] or "").split()[-1]
+        print(f"SIDE_ID={side_id} SIDE_DEST={side_dest}",flush=True)
+        print(f"PYXIS_ID={py_id} PYXIS_DEST={py_dest}",flush=True)
+        dev.cmd("T:BLE off",timeout=5)
+        dev.cmd("T:CALL_PROFILE 0x10")
+        dev.cmd("T:ANNLXST")
+        phone.announce()
+
         # Both directions need a current announce before the raw-link cases.
         phone.announce(); dev.cmd("T:ANNLXST")
         assert wait_path_pyxis(dev,side_dest,45),"Pyxis did not learn Sideband LXST path"
@@ -427,7 +476,8 @@ def main():
             ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
             assert ok,f"Pyxis did not enter identifying before outgoing race; states={seen}"
             response,_=dev.cmd("T:CALL "+side_dest)
-            assert response is not None,"T:CALL did not return during identification contention"
+            assert response == "T:ERR busy", \
+                f"T:CALL did not prove exact busy admission rejection: {response!r}"
             stable=assert_state_for(dev,"INCOMING_IDENTIFYING",1.0,"outgoing initiation")
             assert a.is_open,"outgoing initiation displaced caller A"
             assert not phone.is_in_call and not phone.telephone.active_call, \
@@ -440,27 +490,28 @@ def main():
         finally:
             cleanup_raw_callers(dev,a)
 
-        # Stale A must not affect a later generation owned by identified B.
+        # A closed link's late identify API is a no-op. Verify close + B redial
+        # stability while any already-queued callbacks from A drain.
         a=b=None
         try:
-            print("TEST_STALE_LINK close A then identify B",flush=True)
-            a=RawCaller(bytes.fromhex(py_dest),"STALE_A")
+            print("TEST_CLOSED_LINK_NOOP close A then identify B",flush=True)
+            a=RawCaller(bytes.fromhex(py_dest),"CLOSED_A")
             a.wait_established()
             a.wait_signal(STATUS_AVAILABLE)
             ok,seen=dev.wait_state("INCOMING_IDENTIFYING",10)
-            assert ok,f"Pyxis did not reserve stale caller A; states={seen}"
+            assert ok,f"Pyxis did not reserve caller A before close; states={seen}"
             a.close(); ok,seen=dev.wait_state("IDLE",15)
             assert ok,f"Pyxis did not release caller A; states={seen}"
-            b=RawCaller(bytes.fromhex(py_dest),"STALE_B")
+            b=RawCaller(bytes.fromhex(py_dest),"REDIAL_B")
             b.wait_established()
             b.wait_signal(STATUS_AVAILABLE); b.identify(); b.wait_signal(STATUS_RINGING)
             ok,seen=dev.wait_state("INCOMING_RINGING",10)
             assert ok,f"caller B did not ring; states={seen}"
             late_sent=a.identify(allow_closed=True)
             assert not late_sent,"closed caller A unexpectedly sent a late identification"
-            stable=assert_state_for(dev,"INCOMING_RINGING",1.0,"stale caller A drain")
-            assert b.is_open,"stale caller A action closed current caller B"
-            results.append(("stale_link_cannot_displace_new_owner",True,
+            stable=assert_state_for(dev,"INCOMING_RINGING",1.0,"closed caller A callback drain")
+            assert b.is_open,"closed caller A drain disturbed current caller B"
+            results.append(("closed_link_identify_noop_and_redial_stability",True,
                             {"late_identify_sent":late_sent,"stable":stable,"b_signals":b.signals}))
         finally:
             cleanup_raw_callers(dev,a,b)
@@ -494,16 +545,16 @@ def main():
         print("TEST_IDENTIFY_TIMEOUT answer",dev.cmd("T:CALL_ANSWER")[0],flush=True)
         ok,seen_active=dev.wait_state("ACTIVE",25)
         assert ok,f"timeout recovery call did not become active; states={seen_active}"
-        deadline=time.time()+15
-        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        deadline=time.monotonic()+15
+        while not phone.is_in_call and time.monotonic()<deadline: time.sleep(.2)
         assert phone.is_in_call,"Sideband did not become active after identification timeout"
         ok,data=run_audio(dev,"TEST_IDENTIFY_TIMEOUT")
         phone.hangup()
         idle_ok,hangup_states=dev.wait_state("IDLE",15)
         assert idle_ok, \
             f"timeout recovery hangup did not return Pyxis to IDLE; states={hangup_states}"
-        hangup_deadline=time.time()+15
-        while (phone.is_in_call or phone.telephone.active_call) and time.time()<hangup_deadline:
+        hangup_deadline=time.monotonic()+15
+        while (phone.is_in_call or phone.telephone.active_call) and time.monotonic()<hangup_deadline:
             time.sleep(.2)
         assert not phone.is_in_call and not phone.telephone.active_call, \
             "timeout recovery hangup did not close the Sideband call/link"
@@ -519,8 +570,8 @@ def main():
         print("TEST1 dialing Pyxis -> Sideband",flush=True)
         print("TEST1 call",dev.cmd("T:CALL "+side_dest)[0],flush=True)
         ok,seen=dev.wait_state("ACTIVE",35); print("TEST1 states_to_active",seen,flush=True); assert ok
-        deadline=time.time()+15
-        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        deadline=time.monotonic()+15
+        while not phone.is_in_call and time.monotonic()<deadline: time.sleep(.2)
         assert phone.is_in_call,"Sideband did not become active on incoming call"
         ok,data=run_audio(dev,"TEST1")
         results.append(("pyxis_to_sideband_bidirectional",ok,data))
@@ -534,8 +585,8 @@ def main():
         ok,seen=dev.wait_state("INCOMING_RINGING",25); print("TEST2 states_to_ring",seen,flush=True); assert ok
         print("TEST2 answer",dev.cmd("T:CALL_ANSWER")[0],flush=True)
         ok,seen=dev.wait_state("ACTIVE",25); print("TEST2 states_to_active",seen,flush=True); assert ok
-        deadline=time.time()+15
-        while not phone.is_in_call and time.time()<deadline: time.sleep(.2)
+        deadline=time.monotonic()+15
+        while not phone.is_in_call and time.monotonic()<deadline: time.sleep(.2)
         assert phone.is_in_call,"Sideband did not become active"
         ok,data=run_audio(dev,"TEST2")
         results.append(("sideband_to_pyxis_bidirectional",ok,data))
@@ -550,15 +601,29 @@ def main():
         if ok: dev.cmd("T:CALL_HANGUP")
         elif phone.telephone.active_call: phone.hangup()
     finally:
-        try: dev.cmd("T:CALL_INJECT off")
-        except Exception: pass
-        try:
-            if phone.telephone and phone.telephone.active_call: phone.hangup()
-            phone.stop()
-        except Exception as e: print("PHONE_CLEANUP",repr(e),flush=True)
-        try: dev.cmd("T:BLE on",timeout=5)
-        except Exception: pass
-        dev.close()
+        primary = sys.exc_info()[1]
+        cleanup_errors = []
+        if dev is not None:
+            try: dev.cmd("T:CALL_INJECT off")
+            except BaseException as exc: cleanup_errors.append(f"inject off: {exc!r}")
+        if phone is not None:
+            try:
+                if phone.telephone and phone.telephone.active_call: phone.hangup()
+            except BaseException as exc:
+                cleanup_errors.append(f"phone hangup: {exc!r}")
+            try: phone.stop()
+            except BaseException as exc: cleanup_errors.append(f"phone stop: {exc!r}")
+        if dev is not None:
+            try: dev.cmd("T:BLE on",timeout=5)
+            except BaseException as exc: cleanup_errors.append(f"BLE restore: {exc!r}")
+            try: dev.close()
+            except BaseException as exc: cleanup_errors.append(f"serial close: {exc!r}")
+        if cleanup_errors:
+            detail = "; ".join(cleanup_errors)
+            if primary is not None:
+                print(f"CLEANUP_AFTER_PRIMARY primary={primary!r} cleanup={detail}", flush=True)
+            else:
+                raise AssertionError(f"harness cleanup failed: {detail}")
     print("RESULTS",results,flush=True)
     return 0 if all(x[1] for x in results) else 1
 

--- a/tools/voice_test/voice_profile_contract.py
+++ b/tools/voice_test/voice_profile_contract.py
@@ -1,0 +1,22 @@
+"""Dependency-free production voice-profile checks for the physical harness."""
+
+import re
+
+ULBW_PROFILE_NAME = "ULBW"
+ULBW_PROFILE_ID = 0x10
+_ULBW_CONFIRMATION = re.compile(r"(?:^|\r?\n)T:OK profile=0x10(?:\r?\n|$)")
+
+
+def validate_requested_profiles(value):
+    profiles = [item.strip().upper() for item in value.split(",") if item.strip()]
+    if profiles != [ULBW_PROFILE_NAME]:
+        raise ValueError("Pyxis production voice testing supports only ULBW")
+    return profiles
+
+
+def require_ulbw_confirmation(response):
+    if not _ULBW_CONFIRMATION.search(response):
+        raise RuntimeError(
+            "firmware did not confirm the required ULBW profile (T:OK profile=0x10)"
+        )
+    return ULBW_PROFILE_ID


### PR DESCRIPTION
## Summary

- synchronize LXST telephony announcements with LXMF delivery announcements across boot and TCP lifecycle transitions
- harden call admission, exact-Link/generation ownership, callback serialization, terminal signaling, and 90-second valid-media liveness
- enforce the Pyxis production voice contract as LXST ULBW / Codec2-700C only
- reject VLBW/LBW negotiation and media before shared Codec2 state can mutate
- constrain the physical voice harness and wire regressions to the canonical 42-byte ULBW batch

## Production voice contract

```text
LXST profile:       ULBW / 0x10
Codec2:             700C / library mode 8 / mode header 0x00
Sample rate:        8 kHz
Samples/frame:      320
Frames/packet:      10
Samples/packet:     3,200
Packet duration:    400 ms
Codec2 payload:     41 bytes
LXST audio batch:   42 bytes
```

## Verification

- [x] Native/build-script/interoperability suite — 105 passed
- [x] `platformio run -e tdeck`
- [x] Exact firmware version `0.2.2-175-g6187248`
- [x] Application-slot-only flash and exact app0 read-back
- [x] Partition table, NVS, OTA metadata, alternate slot, LittleFS, and coredump preserved byte-for-byte
- [x] Two paced reboot checks; identity/storage/version/slot remained stable
- [x] Physical second-call ULBW negotiation and bidirectional 42-byte audio
- [x] Coordinated terminal signaling, Link teardown, and immediate call lifecycle completion
- [ ] Strict TCP-only acceptance with Columba BLE disabled
- [ ] Physical deliberate terminal/Link-close loss recovery
- [ ] Physical full 90-second no-valid-media timeout
- [ ] Production release build without diagnostic hooks

## Physical result

The valid second physical call established ULBW in both directions. Pyxis transmitted and received 42-byte Codec2-700C batches at approximately 400 ms cadence, and audio was intelligible both ways. The first call from that test sequence is intentionally excluded because it targeted the wrong phone.

Columba separately exhibited a two-second receiver prebuffer (`5 × 400 ms`); that is an LXST-kt playback-buffer issue, not a Pyxis transport or wire-geometry failure, and is being handled separately.

## Release boundary

The repository's current `tdeck` environment defines `PYXIS_TEST_HOOKS` on both the base and this branch. The physically tested image is therefore a diagnostic build, not production release firmware. This PR does not claim release qualification; release/test environment separation and strict TCP-only acceptance remain required before publishing firmware.

## Compatibility

Canonical Python LXST remains the protocol authority. The terminal `0x07` extension is transmitted three times with bounded spacing and retains ordinary Reticulum Link-close fallback. No VLBW/LBW wire geometry is enabled by this change.
