### PR TITLE
build: add release-qualified T-Deck firmware pipeline

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [tdeck]
+        environment: [tdeck, tdeck-release]
 
     steps:
       - name: Checkout repository
@@ -29,11 +29,11 @@ jobs:
         run: pio run -e ${{ matrix.environment }}
 
       - name: Upload firmware artifact
-        if: matrix.environment == 'tdeck'
+        if: matrix.environment == 'tdeck-release'
         uses: actions/upload-artifact@v4
         with:
-          name: firmware-${{ github.event.pull_request.head.sha }}
+          name: release-firmware-${{ github.event.pull_request.head.sha }}
           path: |
-            .pio/build/tdeck/firmware.bin
-            .pio/build/tdeck/bootloader.bin
-            .pio/build/tdeck/partitions.bin
+            .pio/build/tdeck-release/firmware.bin
+            .pio/build/tdeck-release/bootloader.bin
+            .pio/build/tdeck-release/partitions.bin

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Build ${{ matrix.environment }}
         run: pio run -e ${{ matrix.environment }}
 
+      - name: Audit release artifact
+        if: matrix.environment == 'tdeck-release'
+        run: python tools/audit_release_build.py
+
       - name: Upload firmware artifact
         if: matrix.environment == 'tdeck-release'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build release-qualified T-Deck firmware
         run: pio run -e tdeck-release
 
+      - name: Audit release artifact
+        run: python tools/audit_release_build.py
+
       - name: Determine version string
         id: version
         run: |

--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Install PlatformIO
         run: pip install platformio
 
-      - name: Build T-Deck firmware (NimBLE)
-        run: pio run -e tdeck
+      - name: Build release-qualified T-Deck firmware
+        run: pio run -e tdeck-release
 
       - name: Determine version string
         id: version
@@ -45,9 +45,9 @@ jobs:
       - name: Copy firmware binaries
         run: |
           mkdir -p docs/flasher/firmware
-          cp .pio/build/tdeck/bootloader.bin docs/flasher/firmware/
-          cp .pio/build/tdeck/partitions.bin docs/flasher/firmware/
-          cp .pio/build/tdeck/firmware.bin docs/flasher/firmware/
+          cp .pio/build/tdeck-release/bootloader.bin docs/flasher/firmware/
+          cp .pio/build/tdeck-release/partitions.bin docs/flasher/firmware/
+          cp .pio/build/tdeck-release/firmware.bin docs/flasher/firmware/
           BOOT_APP0=$(find ~/.platformio -name "boot_app0.bin" | head -1)
           cp "$BOOT_APP0" docs/flasher/firmware/
 
@@ -56,9 +56,9 @@ jobs:
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             mkdir -p "docs/flasher/firmware/releases/${TAG}"
-            cp .pio/build/tdeck/bootloader.bin "docs/flasher/firmware/releases/${TAG}/"
-            cp .pio/build/tdeck/partitions.bin "docs/flasher/firmware/releases/${TAG}/"
-            cp .pio/build/tdeck/firmware.bin "docs/flasher/firmware/releases/${TAG}/"
+            cp .pio/build/tdeck-release/bootloader.bin "docs/flasher/firmware/releases/${TAG}/"
+            cp .pio/build/tdeck-release/partitions.bin "docs/flasher/firmware/releases/${TAG}/"
+            cp .pio/build/tdeck-release/firmware.bin "docs/flasher/firmware/releases/${TAG}/"
             cp "$BOOT_APP0" "docs/flasher/firmware/releases/${TAG}/"
           fi
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -230,6 +230,19 @@ build_flags =
     ; CORE_DEBUG_LEVEL=2 (WARNING) reduces INFO-level log output
     -DBOOT_REDUCED_LOGGING
 
+; Production release environment. Keep the exact hardware/dependency contract
+; from tdeck while removing test commands, private test-endpoint macros, and
+; runtime instrumentation. The instrumentation headers compile their call
+; sites to no-ops when these flags are absent.
+[env:tdeck-release]
+extends = env:tdeck
+build_unflags =
+    -DPYXIS_TEST_HOOKS
+    -DPYXIS_TEST_TCP_HOST=*
+    -DPYXIS_TEST_TCP_PORT=*
+    -DMEMORY_INSTRUMENTATION_ENABLED
+    -DBOOT_PROFILING_ENABLED
+
 ; OTA flashing environment (wireless upload via ArduinoOTA)
 ; Usage: pio run -e tdeck-ota -t upload
 ;   The old upload_command pointed at tools/espota.py (which does not exist in the

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,12 @@ lib_ldf_mode = chain+
 ; Build type
 build_type = release
 lib_deps =
+    ; Install the immutable microStore pin before microReticulum. Its upstream
+    ; metadata declares an unconstrained registry microStore dependency; if
+    ; microReticulum resolves first, PlatformIO can populate the shared library
+    ; name with a newer registry package while misleadingly labeling the graph
+    ; as this VCS pin.
+    https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2
     ; Explicit git dep so PIO links exactly ONE microReticulum (the
     ; live source). lib_extra_dirs was creating duplicate compilations
     ; — PIO compiled deps/microReticulum/ as one library AND auto-
@@ -125,13 +131,7 @@ lib_deps =
     lxst_audio
     sh123/esp32_codec2@^1.0.7  ; carries modern codec2 since PR #4 (Jan 2026); -D__EMBEDDED__ + -DMEMORY_CRITICAL set in build_flags below put codebooks in flash
     libbz2
-    ; Pinned to attermann/microStore@ceea8f5 (2026-04-14 "Added SD
-    ; filesystem and enhanced Flash filesystem"). Pre-0.1.6 — newer
-    ; commits introduced a dynamic segment-size refactor that hasn't
-    ; been validated against pyxis's MessageStore / path-store usage
-    ; patterns. Bump the SHA when ready to re-validate. Matches the
-    ; same pin used in conformance bridge builds.
-    https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2
+
 
 ; Build configuration
 build_flags =
@@ -238,8 +238,8 @@ build_flags =
 extends = env:tdeck
 build_unflags =
     -DPYXIS_TEST_HOOKS
-    -DPYXIS_TEST_TCP_HOST=*
-    -DPYXIS_TEST_TCP_PORT=*
+    -DPYXIS_TEST_TCP_HOST
+    -DPYXIS_TEST_TCP_PORT
     -DMEMORY_INSTRUMENTATION_ENABLED
     -DBOOT_PROFILING_ENABLED
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,15 +93,9 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 
-// Memory instrumentation
-#ifdef MEMORY_INSTRUMENTATION_ENABLED
+// These headers provide no-op macros when their release flags are disabled.
 #include <Instrumentation/MemoryMonitor.h>
-#endif
-
-// Boot profiling
-#ifdef BOOT_PROFILING_ENABLED
 #include <Instrumentation/BootProfiler.h>
-#endif
 
 // Firmware version for web flasher detection
 #ifndef FIRMWARE_VERSION

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -47,8 +47,10 @@ def test_ci_and_deployment_build_the_release_environment():
     assert "environment: [tdeck, tdeck-release]" in build_check
     assert "matrix.environment == 'tdeck-release'" in build_check
     assert ".pio/build/tdeck-release/firmware.bin" in build_check
+    assert "python tools/audit_release_build.py" in build_check
 
     assert "pio run -e tdeck-release" in release
+    assert "python tools/audit_release_build.py" in release
     assert ".pio/build/tdeck-release/bootloader.bin" in release
     assert ".pio/build/tdeck-release/partitions.bin" in release
     assert ".pio/build/tdeck-release/firmware.bin" in release

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -38,3 +38,18 @@ def test_disabled_instrumentation_macros_remain_defined():
     assert "#include <Instrumentation/BootProfiler.h>" in main
     assert "#define MEMORY_MONITOR_POLL() ((void)0)" in memory
     assert "#define BOOT_PROFILE_COMPLETE() ((void)0)" in boot
+
+
+def test_ci_and_deployment_build_the_release_environment():
+    build_check = (ROOT / ".github/workflows/build-check.yml").read_text()
+    release = (ROOT / ".github/workflows/release-firmware.yml").read_text()
+
+    assert "environment: [tdeck, tdeck-release]" in build_check
+    assert "matrix.environment == 'tdeck-release'" in build_check
+    assert ".pio/build/tdeck-release/firmware.bin" in build_check
+
+    assert "pio run -e tdeck-release" in release
+    assert ".pio/build/tdeck-release/bootloader.bin" in release
+    assert ".pio/build/tdeck-release/partitions.bin" in release
+    assert ".pio/build/tdeck-release/firmware.bin" in release
+    assert ".pio/build/tdeck/firmware.bin" not in release

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_tdeck_release_removes_diagnostic_flags():
+    config = (ROOT / "platformio.ini").read_text()
+    release = config.split("[env:tdeck-release]", 1)[1].split("[env:", 1)[0]
+
+    assert "extends = env:tdeck" in release
+    for flag in (
+        "-DPYXIS_TEST_HOOKS",
+        "-DPYXIS_TEST_TCP_HOST=*",
+        "-DPYXIS_TEST_TCP_PORT=*",
+        "-DMEMORY_INSTRUMENTATION_ENABLED",
+        "-DBOOT_PROFILING_ENABLED",
+    ):
+        assert flag in release
+
+
+def test_disabled_instrumentation_macros_remain_defined():
+    main = (ROOT / "src/main.cpp").read_text()
+    memory = (ROOT / "lib/microreticulum-shim/Instrumentation/MemoryMonitor.h").read_text()
+    boot = (ROOT / "lib/microreticulum-shim/Instrumentation/BootProfiler.h").read_text()
+
+    assert "#include <Instrumentation/MemoryMonitor.h>" in main
+    assert "#include <Instrumentation/BootProfiler.h>" in main
+    assert "#define MEMORY_MONITOR_POLL() ((void)0)" in memory
+    assert "#define BOOT_PROFILE_COMPLETE() ((void)0)" in boot

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -2,6 +2,16 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
+MICROSTORE_PIN = "https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2"
+MICRORETICULUM_PIN = "https://github.com/torlando-tech/microReticulum.git#6054f6ba82367628a85cd07fcb668b95e947f046"
+
+
+def test_microstore_pin_resolves_before_transitive_registry_requirement():
+    config = (ROOT / "platformio.ini").read_text()
+    dependencies = config.split("lib_deps =", 1)[1].split("; Build configuration", 1)[0]
+
+    assert dependencies.count(MICROSTORE_PIN) == 1
+    assert dependencies.index(MICROSTORE_PIN) < dependencies.index(MICRORETICULUM_PIN)
 
 
 def test_tdeck_release_removes_diagnostic_flags():
@@ -11,8 +21,8 @@ def test_tdeck_release_removes_diagnostic_flags():
     assert "extends = env:tdeck" in release
     for flag in (
         "-DPYXIS_TEST_HOOKS",
-        "-DPYXIS_TEST_TCP_HOST=*",
-        "-DPYXIS_TEST_TCP_PORT=*",
+        "-DPYXIS_TEST_TCP_HOST",
+        "-DPYXIS_TEST_TCP_PORT",
         "-DMEMORY_INSTRUMENTATION_ENABLED",
         "-DBOOT_PROFILING_ENABLED",
     ):

--- a/tools/audit_release_build.py
+++ b/tools/audit_release_build.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Fail closed when a tdeck-release build is not release-qualified."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENVIRONMENT = "tdeck-release"
+BUILD = ROOT / ".pio" / "build" / ENVIRONMENT
+EXCLUDED_DEFINITIONS = (
+    "PYXIS_TEST_HOOKS",
+    "PYXIS_TEST_TCP_HOST",
+    "PYXIS_TEST_TCP_PORT",
+    "MEMORY_INSTRUMENTATION_ENABLED",
+    "BOOT_PROFILING_ENABLED",
+)
+EXCLUDED_STRINGS = (
+    b"T:CALL_PROFILE",
+    b"T:CALL_INJECT",
+    b"T:DEST",
+    b"PYXIS_TEST_HOOKS",
+    b"Boot Profile Summary",
+    b"Memory monitor started",
+)
+EXCLUDED_SYMBOLS = (
+    "test_call_",
+    "process_test_serial_command",
+    "MemoryMonitor::",
+    "BootProfiler::",
+)
+PINNED_DEPENDENCIES = {
+    "microReticulum": "6054f6ba82367628a85cd07fcb668b95e947f046",
+    "microLXMF": "d9bbc04cf69bfa9b555c3f293b89b440b4820518",
+    "microStore": "c5fb69d68229e684c7fbd17692a67ae8193b84e2",
+}
+
+
+def run(*args: str, cwd: Path = ROOT) -> str:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"release audit failed: {message}")
+
+
+def package_commit(name: str) -> str:
+    package = ROOT / ".pio" / "libdeps" / ENVIRONMENT / name
+    require(package.is_dir(), f"missing dependency package {name}")
+    top = Path(run("git", "rev-parse", "--show-toplevel", cwd=package)).resolve()
+    require(top == package.resolve(), f"{name} is not an independently verifiable VCS package")
+    return run("git", "rev-parse", "HEAD", cwd=package)
+
+
+def locate_nm() -> str:
+    direct = shutil.which("xtensa-esp32s3-elf-nm")
+    if direct:
+        return direct
+    candidate = (
+        Path.home()
+        / ".platformio/packages/toolchain-xtensa-esp32s3/bin/xtensa-esp32s3-elf-nm"
+    )
+    require(candidate.is_file(), "xtensa-esp32s3-elf-nm not found")
+    return str(candidate)
+
+
+def main() -> None:
+    run("pio", "run", "-e", ENVIRONMENT, "-t", "compiledb")
+
+    compile_commands = ROOT / "compile_commands.json"
+    commands = json.loads(compile_commands.read_text())
+    main_compile = next(
+        entry for entry in commands if Path(entry["file"]).as_posix().endswith("src/main.cpp")
+    )
+    command = main_compile.get("command") or " ".join(main_compile["arguments"])
+    present = [flag for flag in EXCLUDED_DEFINITIONS if flag in command]
+    require(not present, f"excluded compiler definitions present: {', '.join(present)}")
+
+    firmware = BUILD / "firmware.bin"
+    elf = BUILD / "firmware.elf"
+    require(firmware.is_file(), "firmware.bin missing")
+    require(elf.is_file(), "firmware.elf missing")
+
+    firmware_bytes = firmware.read_bytes()
+    strings_present = [value.decode() for value in EXCLUDED_STRINGS if value in firmware_bytes]
+    require(not strings_present, f"excluded firmware strings present: {', '.join(strings_present)}")
+
+    symbols = run(locate_nm(), "-C", str(elf))
+    symbols_present = [value for value in EXCLUDED_SYMBOLS if value in symbols]
+    require(not symbols_present, f"excluded ELF symbols present: {', '.join(symbols_present)}")
+
+    for name, expected in PINNED_DEPENDENCIES.items():
+        actual = package_commit(name)
+        require(actual == expected, f"{name} resolved to {actual}, expected {expected}")
+
+    compile_commands.unlink()
+    print("release audit passed")
+    print(f"firmware_size={len(firmware_bytes)}")
+    for name, expected in PINNED_DEPENDENCIES.items():
+        print(f"{name}={expected}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a reproducible `tdeck-release` PlatformIO environment that inherits the T-Deck hardware/dependency contract while removing serial test hooks, test endpoint definitions, memory instrumentation, and boot profiling
- include instrumentation macro headers unconditionally so their documented disabled/no-op mode compiles
- resolve the immutable microStore pin before microReticulum's unconstrained transitive registry requirement, preventing PlatformIO from compiling a newer registry package under a misleading pinned graph label
- add host-side contracts for release flags, disabled instrumentation macros, and dependency ordering
- make PR CI build both diagnostic and release environments, upload only the release artifact, and make dev/tag deployment publish `tdeck-release`

## Why

The merged `tdeck` environment was diagnostic: it enabled `PYXIS_TEST_HOOKS` plus memory and boot instrumentation. Removing those flags initially exposed that `main.cpp` depended on macros whose headers were conditionally omitted.

A clean dependency fetch also showed that PlatformIO could populate the shared `microStore` package name with registry `0.1.7` before processing the explicit `c5fb69d` (`0.1.6`) VCS pin. Ordering the immutable pin first makes clean builds compile the intended source.

## Verification

Exact head: `e5f00a8b39fec7c417782132be0f745f40953f7e`

- [x] 109 build-script, native, and Python-LXST interoperability tests passed
- [x] both `pio run -e tdeck` and `pio run -e tdeck-release` passed
- [x] clean `pio run -e tdeck-release` passed
- [x] resolved `src/main.cpp` compiler command omitted all five release-excluded definitions
- [x] firmware/ELF audit found no test-hook or instrumentation strings/symbols
- [x] PR and deployment workflows run the fail-closed release audit before uploading or publishing artifacts
- [x] the automated audit verifies resolved definitions, firmware strings, ELF symbols, and exact VCS dependency SHAs
- [x] ESP32-S3 image checksum and appended validation hash were valid
- [x] clean dependency tree resolved:
  - microReticulum `6054f6ba82367628a85cd07fcb668b95e947f046`
  - microLXMF `d9bbc04cf69bfa9b555c3f293b89b440b4820518`
  - microStore `c5fb69d68229e684c7fbd17692a67ae8193b84e2`
- [x] resolved microStore tree matched the immutable pin except for the existing deterministic LittleFS path patch

Exact-head release artifact audited locally:

```text
version:  0.2.2-181-ge5f00a8
size:     2,452,752 bytes
SHA-256:  b3ffd42db3c4110c62abbbe7f2db205eaff6b78119a6a3372893a2106c672846
```

Physically flashed code-equivalent predecessor (later commits change only workflows, tests, and the build-audit tool):

```text
commit:   3f98f43f1f90221b79e0235f04cb6160ba4822c8
version:  0.2.2-179-g3f98f43
SHA-256:  8103ca8aebcf5beb48ed9e41a65be7798c1e4579e8b31964da80fc7ae0793f70
slot:     app0 at 0x10000
```

Physical validation:

- [x] application-slot-only write
- [x] exact pre-boot application read-back
- [x] partition table, NVS, OTA metadata, alternate app slot, LittleFS, and coredump byte-identical before/after
- [x] two clean 120-second boots ran the exact version from `app0`
- [x] filesystem, SD card, identity/destination restoration, persisted interface settings, and three conversations restored
- [x] Wi-Fi and TCP connectivity restored on both clean boots
- [x] no panic, assertion, watchdog trigger, brownout, abort, or backtrace on either clean boot

## Adjacent observation

An early USB verifier accidentally produced back-to-back reset transitions. One such stress cycle hit an Arduino-ESP32 SD mount-failure cleanup panic in `SPIClass::endTransaction()`. After correcting the harness to set DTR/RTS before opening and emit exactly one reset, the fault did not reproduce in two clean cycles. This PR does not change SD runtime behavior.

## Scope

No bootloader, partition table, updater, OTA selector, persistence format, voice protocol, or runtime feature behavior is changed. The physical flash was application-slot-only; no persistent partition was written.
