### PR TITLE
Make Reticulum transport mode opt-in

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -33,6 +33,7 @@ static const char* KEY_TIMEOUT = "timeout";
 static const char* KEY_ANNOUNCE_INT = "announce";
 static const char* KEY_SYNC_INT = "sync_int";
 static const char* KEY_GPS_SYNC = "gps_sync";
+static const char* KEY_TRANSPORT_ENABLED = "transport";
 // Notification settings
 static const char* KEY_NOTIF_SND = "notif_snd";
 static const char* KEY_NOTIF_VOL = "notif_vol";
@@ -68,6 +69,7 @@ SettingsScreen::SettingsScreen(lv_obj_t* parent)
       _slider_lora_power(nullptr), _label_lora_power_value(nullptr),
       _lora_params_container(nullptr), _switch_auto_enabled(nullptr), _switch_ble_enabled(nullptr),
       _ta_announce_interval(nullptr), _ta_sync_interval(nullptr), _switch_gps_sync(nullptr),
+      _switch_transport_enabled(nullptr), _transport_warning_modal(nullptr), _transport_enable_confirmed(false),
       _btn_propagation_nodes(nullptr), _switch_prop_fallback(nullptr), _switch_prop_only(nullptr),
       _gps(nullptr) {
     LVGL_LOCK();
@@ -178,6 +180,8 @@ void SettingsScreen::create_content() {
     create_gps_section(_content);
     create_system_section(_content);
     create_advanced_section(_content);
+    // This dangerous opt-in must remain the final Settings section.
+    create_transport_mode_section(_content);
 }
 
 lv_obj_t* SettingsScreen::create_section_header(lv_obj_t* parent, const char* title) {
@@ -864,6 +868,127 @@ void SettingsScreen::create_advanced_section(lv_obj_t* parent) {
     lv_obj_set_style_bg_color(_switch_gps_sync, Theme::primary(), LV_PART_INDICATOR | LV_STATE_CHECKED);
 }
 
+void SettingsScreen::create_transport_mode_section(lv_obj_t* parent) {
+    create_section_header(parent, "== DANGER: Transport Mode ==");
+
+    lv_obj_t* warning = lv_label_create(parent);
+    lv_obj_set_width(warning, LV_PCT(100));
+    lv_label_set_long_mode(warning, LV_LABEL_LONG_WRAP);
+    lv_label_set_text(
+        warning,
+        "NOT RECOMMENDED. Transport mode routes other nodes' Reticulum traffic "
+        "across every enabled interface. It can saturate LoRa airtime, drain the battery, "
+        "and turn this handheld into network infrastructure. Enable only if you understand "
+        "Reticulum routing and intend this device to be a transport node. Takes effect after reboot.");
+    lv_obj_set_style_text_color(warning, Theme::error(), 0);
+    lv_obj_set_style_text_font(warning, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_pad_bottom(warning, 4, 0);
+
+    // Keep this row as the final object in Settings so the opt-in cannot be
+    // mistaken for an ordinary interface switch higher in the screen.
+    lv_obj_t* transport_row = lv_obj_create(parent);
+    lv_obj_set_width(transport_row, LV_PCT(100));
+    lv_obj_set_height(transport_row, 32);
+    lv_obj_set_style_bg_opa(transport_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(transport_row, 0, 0);
+    lv_obj_set_style_pad_all(transport_row, 0, 0);
+    lv_obj_clear_flag(transport_row, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* label = lv_label_create(transport_row);
+    lv_label_set_text(label, "Enable Transport Node:");
+    lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_set_style_text_color(label, Theme::error(), 0);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_14, 0);
+
+    _switch_transport_enabled = lv_switch_create(transport_row);
+    lv_obj_set_size(_switch_transport_enabled, 40, 20);
+    lv_obj_align(_switch_transport_enabled, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_obj_set_style_bg_color(_switch_transport_enabled, Theme::border(), LV_PART_MAIN);
+    lv_obj_set_style_bg_color(_switch_transport_enabled, Theme::error(), LV_PART_INDICATOR | LV_STATE_CHECKED);
+    lv_obj_add_event_cb(_switch_transport_enabled, on_transport_enabled_changed, LV_EVENT_VALUE_CHANGED, this);
+
+    lv_group_t* group = LVGL::LVGLInit::get_default_group();
+    if (group) {
+        lv_group_add_obj(group, _switch_transport_enabled);
+    }
+}
+
+void SettingsScreen::show_transport_warning() {
+    if (_transport_warning_modal) return;
+
+    _transport_warning_modal = lv_obj_create(_screen);
+    lv_obj_set_size(_transport_warning_modal, LV_PCT(100), LV_PCT(100));
+    lv_obj_center(_transport_warning_modal);
+    lv_obj_set_style_bg_color(_transport_warning_modal, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(_transport_warning_modal, LV_OPA_80, 0);
+    lv_obj_set_style_border_width(_transport_warning_modal, 0, 0);
+    lv_obj_set_style_radius(_transport_warning_modal, 0, 0);
+    lv_obj_set_style_pad_all(_transport_warning_modal, 8, 0);
+    lv_obj_clear_flag(_transport_warning_modal, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(_transport_warning_modal, LV_OBJ_FLAG_CLICKABLE);
+
+    lv_obj_t* panel = lv_obj_create(_transport_warning_modal);
+    lv_obj_set_size(panel, LV_PCT(100), LV_PCT(100));
+    lv_obj_center(panel);
+    lv_obj_set_style_bg_color(panel, Theme::surface(), 0);
+    lv_obj_set_style_border_color(panel, Theme::error(), 0);
+    lv_obj_set_style_border_width(panel, 2, 0);
+    lv_obj_set_style_radius(panel, 6, 0);
+    lv_obj_set_style_pad_all(panel, 8, 0);
+    lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
+
+    lv_obj_t* title = lv_label_create(panel);
+    lv_label_set_text(title, "DANGER: Transport Mode");
+    lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_text_color(title, Theme::error(), 0);
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_16, 0);
+
+    lv_obj_t* text = lv_label_create(panel);
+    lv_obj_set_width(text, LV_PCT(100));
+    lv_label_set_long_mode(text, LV_LABEL_LONG_WRAP);
+    lv_label_set_text(
+        text,
+        "This is NOT RECOMMENDED. The device will relay other nodes' traffic and may "
+        "saturate LoRa airtime, drain the battery, and disrupt nearby Reticulum users.\n\n"
+        "Enable only if you understand the consequences and deliberately want this T-Deck "
+        "to operate as network infrastructure. Takes effect after reboot.");
+    lv_obj_align(text, LV_ALIGN_TOP_LEFT, 0, 28);
+    lv_obj_set_style_text_color(text, Theme::textPrimary(), 0);
+    lv_obj_set_style_text_font(text, &lv_font_montserrat_12, 0);
+
+    lv_obj_t* cancel = lv_btn_create(panel);
+    lv_obj_set_size(cancel, 100, 32);
+    lv_obj_align(cancel, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+    lv_obj_set_style_bg_color(cancel, Theme::btnSecondary(), 0);
+    lv_obj_add_event_cb(cancel, on_transport_cancel_enable, LV_EVENT_CLICKED, this);
+    lv_obj_t* cancel_label = lv_label_create(cancel);
+    lv_label_set_text(cancel_label, "Cancel");
+    lv_obj_center(cancel_label);
+
+    lv_obj_t* confirm = lv_btn_create(panel);
+    lv_obj_set_size(confirm, 145, 32);
+    lv_obj_align(confirm, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+    lv_obj_set_style_bg_color(confirm, Theme::error(), 0);
+    lv_obj_add_event_cb(confirm, on_transport_confirm_enable, LV_EVENT_CLICKED, this);
+    lv_obj_t* confirm_label = lv_label_create(confirm);
+    lv_label_set_text(confirm_label, "ENABLE ANYWAY");
+    lv_obj_center(confirm_label);
+
+    lv_group_t* group = LVGL::LVGLInit::get_default_group();
+    if (group) {
+        lv_group_add_obj(group, cancel);
+        lv_group_add_obj(group, confirm);
+        lv_group_focus_obj(cancel);
+    }
+}
+
+void SettingsScreen::close_transport_warning() {
+    if (!_transport_warning_modal) return;
+    lv_obj_t* modal = _transport_warning_modal;
+    _transport_warning_modal = nullptr;
+    lv_obj_del_async(modal);
+}
+
 void SettingsScreen::load_settings() {
     Preferences prefs;
     prefs.begin(NVS_NAMESPACE, true);  // read-only
@@ -876,9 +1001,10 @@ void SettingsScreen::load_settings() {
     _settings.brightness = prefs.getUChar(KEY_BRIGHTNESS, 180);
     _settings.keyboard_light = prefs.getBool(KEY_KB_LIGHT, false);
     _settings.screen_timeout = prefs.getUShort(KEY_TIMEOUT, 60);
-    _settings.announce_interval = prefs.getUInt(KEY_ANNOUNCE_INT, 3600);   // Default 3600s = 1 hour
+    _settings.announce_interval = prefs.getUInt(KEY_ANNOUNCE_INT, 14400);  // Default 14400s = 4 hours
     _settings.sync_interval = prefs.getUInt(KEY_SYNC_INT, 14400);  // Default 14400s = 4 hours
     _settings.gps_time_sync = prefs.getBool(KEY_GPS_SYNC, true);
+    _settings.transport_enabled = prefs.getBool(KEY_TRANSPORT_ENABLED, false);
 
     // Notification settings
     _settings.notification_sound = prefs.getBool(KEY_NOTIF_SND, true);
@@ -928,6 +1054,7 @@ void SettingsScreen::save_settings() {
     prefs.putUInt(KEY_ANNOUNCE_INT, _settings.announce_interval);
     prefs.putUInt(KEY_SYNC_INT, _settings.sync_interval);
     prefs.putBool(KEY_GPS_SYNC, _settings.gps_time_sync);
+    prefs.putBool(KEY_TRANSPORT_ENABLED, _settings.transport_enabled);
 
     // Notification settings
     prefs.putBool(KEY_NOTIF_SND, _settings.notification_sound);
@@ -1027,6 +1154,16 @@ void SettingsScreen::update_ui_from_settings() {
         } else {
             lv_obj_clear_state(_switch_gps_sync, LV_STATE_CHECKED);
         }
+    }
+    if (_switch_transport_enabled) {
+        // Bypass the user-confirmation handler while reflecting persisted state.
+        _transport_enable_confirmed = true;
+        if (_settings.transport_enabled) {
+            lv_obj_add_state(_switch_transport_enabled, LV_STATE_CHECKED);
+        } else {
+            lv_obj_clear_state(_switch_transport_enabled, LV_STATE_CHECKED);
+        }
+        _transport_enable_confirmed = false;
     }
 
     // Interface settings
@@ -1162,6 +1299,9 @@ void SettingsScreen::update_settings_from_ui() {
     }
     if (_switch_gps_sync) {
         _settings.gps_time_sync = lv_obj_has_state(_switch_gps_sync, LV_STATE_CHECKED);
+    }
+    if (_switch_transport_enabled) {
+        _settings.transport_enabled = lv_obj_has_state(_switch_transport_enabled, LV_STATE_CHECKED);
     }
 
     // Interface settings
@@ -1384,6 +1524,7 @@ void SettingsScreen::show() {
 
 void SettingsScreen::hide() {
     LVGL_LOCK();
+    close_transport_warning();
     // Remove from focus group when hiding
     lv_group_t* group = LVGL::LVGLInit::get_default_group();
     if (group) {
@@ -1464,6 +1605,41 @@ void SettingsScreen::on_notification_volume_changed(lv_event_t* event) {
 
     // Update label
     lv_label_set_text(screen->_label_notification_volume_value, String(volume).c_str());
+}
+
+void SettingsScreen::on_transport_enabled_changed(lv_event_t* event) {
+    SettingsScreen* screen = (SettingsScreen*)lv_event_get_user_data(event);
+    bool enabled = lv_obj_has_state(screen->_switch_transport_enabled, LV_STATE_CHECKED);
+
+    if (!enabled) {
+        screen->_transport_enable_confirmed = false;
+        return;
+    }
+
+    if (screen->_transport_enable_confirmed) {
+        return;
+    }
+
+    // Never leave the switch enabled merely because it was toggled. The user
+    // must complete the explicit second confirmation in the danger dialog.
+    lv_obj_clear_state(screen->_switch_transport_enabled, LV_STATE_CHECKED);
+    screen->show_transport_warning();
+}
+
+void SettingsScreen::on_transport_confirm_enable(lv_event_t* event) {
+    SettingsScreen* screen = (SettingsScreen*)lv_event_get_user_data(event);
+    screen->_transport_enable_confirmed = true;
+    lv_obj_add_state(screen->_switch_transport_enabled, LV_STATE_CHECKED);
+    screen->_transport_enable_confirmed = false;
+    screen->close_transport_warning();
+    INFO("Transport mode opt-in confirmed; save settings and reboot to activate");
+}
+
+void SettingsScreen::on_transport_cancel_enable(lv_event_t* event) {
+    SettingsScreen* screen = (SettingsScreen*)lv_event_get_user_data(event);
+    screen->_transport_enable_confirmed = false;
+    lv_obj_clear_state(screen->_switch_transport_enabled, LV_STATE_CHECKED);
+    screen->close_transport_warning();
 }
 
 void SettingsScreen::on_propagation_nodes_clicked(lv_event_t* event) {

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -69,7 +69,8 @@ SettingsScreen::SettingsScreen(lv_obj_t* parent)
       _slider_lora_power(nullptr), _label_lora_power_value(nullptr),
       _lora_params_container(nullptr), _switch_auto_enabled(nullptr), _switch_ble_enabled(nullptr),
       _ta_announce_interval(nullptr), _ta_sync_interval(nullptr), _switch_gps_sync(nullptr),
-      _switch_transport_enabled(nullptr), _transport_warning_modal(nullptr), _transport_enable_confirmed(false),
+      _switch_transport_enabled(nullptr), _transport_warning_modal(nullptr),
+      _transport_modal_group(nullptr), _transport_enable_confirmed(false),
       _btn_propagation_nodes(nullptr), _switch_prop_fallback(nullptr), _switch_prop_only(nullptr),
       _gps(nullptr) {
     LVGL_LOCK();
@@ -974,19 +975,43 @@ void SettingsScreen::show_transport_warning() {
     lv_label_set_text(confirm_label, "ENABLE ANYWAY");
     lv_obj_center(confirm_label);
 
-    lv_group_t* group = LVGL::LVGLInit::get_default_group();
-    if (group) {
-        lv_group_add_obj(group, cancel);
-        lv_group_add_obj(group, confirm);
+    _transport_modal_group = lv_group_create();
+    if (_transport_modal_group) {
+        lv_group_add_obj(_transport_modal_group, cancel);
+        lv_group_add_obj(_transport_modal_group, confirm);
         lv_group_focus_obj(cancel);
+
+        // Isolate keyboard and trackball focus inside the warning. Otherwise
+        // users can navigate into and activate Settings controls behind the
+        // still-visible modal.
+        lv_indev_t* keyboard = LVGL::LVGLInit::get_keyboard();
+        lv_indev_t* trackball = LVGL::LVGLInit::get_trackball();
+        if (keyboard) lv_indev_set_group(keyboard, _transport_modal_group);
+        if (trackball) lv_indev_set_group(trackball, _transport_modal_group);
     }
 }
 
 void SettingsScreen::close_transport_warning() {
     if (!_transport_warning_modal) return;
+
+    lv_group_t* default_group = LVGL::LVGLInit::get_default_group();
+    lv_indev_t* keyboard = LVGL::LVGLInit::get_keyboard();
+    lv_indev_t* trackball = LVGL::LVGLInit::get_trackball();
+    if (keyboard) lv_indev_set_group(keyboard, default_group);
+    if (trackball) lv_indev_set_group(trackball, default_group);
+
+    if (_transport_modal_group) {
+        lv_group_del(_transport_modal_group);
+        _transport_modal_group = nullptr;
+    }
+
     lv_obj_t* modal = _transport_warning_modal;
     _transport_warning_modal = nullptr;
     lv_obj_del_async(modal);
+
+    if (default_group && _switch_transport_enabled) {
+        lv_group_focus_obj(_switch_transport_enabled);
+    }
 }
 
 void SettingsScreen::load_settings() {

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
@@ -52,9 +52,10 @@ struct AppSettings {
     bool ble_enabled;         // Enable BLE mesh interface
 
     // Advanced
-    uint32_t announce_interval;  // seconds (UI shows minutes; default 3600 = 1h)
+    uint32_t announce_interval;  // seconds (UI shows minutes; default 14400 = 4h)
     uint32_t sync_interval;      // seconds (0 = disabled; UI shows hours; default 14400 = 4h)
     bool gps_time_sync;
+    bool transport_enabled;     // Route traffic for other nodes; default off, requires reboot
 
     // Propagation
     bool prop_auto_select;          // Auto-select best propagation node
@@ -80,9 +81,10 @@ struct AppSettings {
         lora_power(17),
         auto_enabled(false),
         ble_enabled(false),
-        announce_interval(3600),
+        announce_interval(14400),
         sync_interval(14400),
         gps_time_sync(true),
+        transport_enabled(false),
         prop_auto_select(true),
         prop_selected_node(""),
         prop_fallback_enabled(true),
@@ -292,6 +294,11 @@ private:
     lv_obj_t* _ta_sync_interval;
     lv_obj_t* _switch_gps_sync;
 
+    // Dangerous transport-mode section (must remain last in Settings)
+    lv_obj_t* _switch_transport_enabled;
+    lv_obj_t* _transport_warning_modal;
+    bool _transport_enable_confirmed;
+
     // Delivery/Propagation section
     lv_obj_t* _btn_propagation_nodes;
     lv_obj_t* _switch_prop_fallback;
@@ -321,6 +328,7 @@ private:
     void create_gps_section(lv_obj_t* parent);
     void create_system_section(lv_obj_t* parent);
     void create_advanced_section(lv_obj_t* parent);
+    void create_transport_mode_section(lv_obj_t* parent);
     void create_delivery_section(lv_obj_t* parent);
 
     // Helpers
@@ -344,6 +352,11 @@ private:
     static void on_lora_power_changed(lv_event_t* event);
     static void on_propagation_nodes_clicked(lv_event_t* event);
     static void on_notification_volume_changed(lv_event_t* event);
+    static void on_transport_enabled_changed(lv_event_t* event);
+    static void on_transport_confirm_enable(lv_event_t* event);
+    static void on_transport_cancel_enable(lv_event_t* event);
+    void show_transport_warning();
+    void close_transport_warning();
 };
 
 } // namespace LXMF

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
@@ -297,6 +297,7 @@ private:
     // Dangerous transport-mode section (must remain last in Settings)
     lv_obj_t* _switch_transport_enabled;
     lv_obj_t* _transport_warning_modal;
+    lv_group_t* _transport_modal_group;
     bool _transport_enable_confirmed;
 
     // Delivery/Propagation section

--- a/platformio.ini
+++ b/platformio.ini
@@ -97,7 +97,9 @@ lib_deps =
     ; (_path_table) unpopulated. When bumping past upstream finishing that migration
     ; (_path_table removed / a for_each API added), DELETE the mirror — see the long
     ; comment at the _path_table mirror in Transport::inbound for details.
-    https://github.com/torlando-tech/microReticulum.git#6054f6ba82367628a85cd07fcb668b95e947f046
+    ; 1bbd422: initializes persistent path storage for endpoint-only clients too.
+    ; Path discovery therefore remains usable without enabling transport forwarding.
+    https://github.com/torlando-tech/microReticulum.git#1bbd422a3b25b4a710642fc5cd01039e5774a4a7
     ; microLXMF: chore/microreticulum-0.4.1-layout — includes namespaced to
     ; <microReticulum/...> for the 0.4.x src/microReticulum/ layout.
     ; 3cdde79: faster load_message_metadata — single LittleFS open (read_file

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,6 +4,10 @@ extra_scripts =
     pre:generate_splash.py
     pre:patch_nimble.py
     pre:patch_msgpack.py
+    ; Mirror an explicit local microReticulum override before patch scripts run.
+    ; PIO does not reliably refresh file dependencies, and a newly fetched stale
+    ; dependency can have a newer mtime than the local corrected checkout.
+    pre:sync_file_libdeps.py
     ; patch_filestore.py silences upstream microStore's spammy
     ; "[ustore] get: key not found in index" print (fires on every
     ; path-store miss; saturated USB CDC during LXST calls). Set
@@ -14,12 +18,6 @@ extra_scripts =
     ; a leading "/" — ESP32 Arduino LittleFS rejects "./"-prefixed paths, which
     ; broke the path store (no peer paths learned). See the script header.
     pre:patch_littlefs_paths.py
-    ; sync_file_libdeps.py mirrors file:// lib_deps source trees into
-    ; .pio/libdeps before each build. PIO doesn't re-sync file:// deps
-    ; after first install — without this, edits to ~/repos/
-    ; microReticulum (or any other file:// dep) silently never reach
-    ; the device. That bit us on a microReticulum security fix.
-    pre:sync_file_libdeps.py
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -685,9 +685,10 @@ void load_app_settings() {
     app_settings.ble_enabled = prefs.getBool("ble_en", false);
 
     // Advanced
-    app_settings.announce_interval = prefs.getULong("announce", 3600);
+    app_settings.announce_interval = prefs.getULong("announce", 14400);
     app_settings.sync_interval = prefs.getULong("sync_int", 14400);  // Default 14400s = 4 hours
     app_settings.gps_time_sync = prefs.getBool("gps_sync", true);
+    app_settings.transport_enabled = prefs.getBool("transport", false);
 
     // Propagation
     app_settings.prop_auto_select = prefs.getBool("prop_auto", true);
@@ -1068,18 +1069,15 @@ void setup_reticulum() {
     // Create Reticulum instance (no auto-init)
     reticulum = new Reticulum();
 
-    // Enable transport mode so Transport::start() initializes the path
-    // store. Without this, the entire `_path_store.init()` block at
-    // Transport.cpp:244 is gated out, _new_path_table.put() always
-    // returns false at TypedStore::isValid(), and every announce
-    // surfaces as "Failed to add destination to path table". The UI's
-    // announce list reads from the path table, so on a busy network
-    // (TLAN) nothing ever appears.
-    //
-    // Transport mode also enables relaying packets for other nodes —
-    // typically a desktop-class node behavior, but acceptable on a
-    // T-Deck Plus with PSRAM and LittleFS-backed path persistence.
-    Reticulum::transport_enabled(true);
+    // Transport mode makes this handheld route traffic for other nodes across
+    // every enabled interface. Keep it off unless the user explicitly accepts
+    // the warning in Settings. Endpoint path persistence does not require it.
+    Reticulum::transport_enabled(app_settings.transport_enabled);
+    if (app_settings.transport_enabled) {
+        WARNING("Reticulum transport mode ENABLED: this device will relay traffic for other nodes");
+    } else {
+        INFO("Reticulum transport mode disabled (endpoint-only)");
+    }
 
     // Reduce transport log verbosity — LOG_TRACE floods serial with
     // token/link/announce details that drown out audio diagnostics.
@@ -1388,8 +1386,13 @@ void setup_ui_manager() {
                                         (new_settings.lora_power != app_settings.lora_power);
             bool auto_settings_changed = (new_settings.auto_enabled != app_settings.auto_enabled);
             bool ble_settings_changed = (new_settings.ble_enabled != app_settings.ble_enabled);
+            bool transport_settings_changed = (new_settings.transport_enabled != app_settings.transport_enabled);
 
             app_settings = new_settings;
+
+            if (transport_settings_changed) {
+                WARNING("Transport mode setting changed; reboot required before it takes effect");
+            }
 
             // Handle WiFi credential changes - auto reconnect
             if (wifi_settings_changed && new_settings.wifi_ssid.length() > 0) {

--- a/sync_file_libdeps.py
+++ b/sync_file_libdeps.py
@@ -17,6 +17,7 @@ Import("env")
 import os
 import sys
 import shutil
+import filecmp
 from pathlib import Path
 sys.path.insert(0, env.get("PROJECT_DIR", "."))
 from _build_helpers import env_libdeps_dir  # per-env libdeps path; never hardcode the env
@@ -57,9 +58,15 @@ def mirror(src: Path, dst: Path):
             sp = Path(root) / fn
             dp = dst / rel / fn
             src_files += 1
-            if not dp.exists() or sp.stat().st_mtime > dp.stat().st_mtime:
+            # A freshly fetched dependency can have a newer mtime than an older
+            # local checkout even when the local bytes contain the intended fix.
+            # Compare content so the explicit local override always wins.
+            if not dp.exists() or not filecmp.cmp(sp, dp, shallow=False):
                 dp.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(sp, dp)
+                # copy2 preserves the source mtime. Touch the mirrored file so
+                # incremental PlatformIO builds recompile changed dependency code.
+                dp.touch()
                 copied += 1
     if copied > 0:
         print(f"SYNC: {dst.name}: refreshed {copied}/{src_files} files from {src}")

--- a/sync_file_libdeps.py
+++ b/sync_file_libdeps.py
@@ -48,6 +48,8 @@ def mirror(src: Path, dst: Path):
         return False
     src_files = 0
     copied = 0
+    removed = 0
+    mirrored_paths = set()
     for root, dirs, files in os.walk(src):
         # Skip git, build artifacts.
         dirs[:] = [d for d in dirs if d not in (".git", ".pio", "__pycache__", "build")]
@@ -57,6 +59,7 @@ def mirror(src: Path, dst: Path):
                 continue
             sp = Path(root) / fn
             dp = dst / rel / fn
+            mirrored_paths.add((rel / fn).as_posix())
             src_files += 1
             # A freshly fetched dependency can have a newer mtime than an older
             # local checkout even when the local bytes contain the intended fix.
@@ -68,8 +71,26 @@ def mirror(src: Path, dst: Path):
                 # incremental PlatformIO builds recompile changed dependency code.
                 dp.touch()
                 copied += 1
-    if copied > 0:
-        print(f"SYNC: {dst.name}: refreshed {copied}/{src_files} files from {src}")
+
+    # A mirror must also remove source files deleted from the explicit local
+    # checkout. Otherwise PlatformIO can continue compiling stale translation
+    # units that no longer exist in the dependency being tested.
+    for root, dirs, files in os.walk(dst):
+        dirs[:] = [d for d in dirs if d not in (".git", ".pio", "__pycache__", "build")]
+        rel = Path(root).relative_to(dst)
+        for fn in files:
+            if fn == ".piopm" or fn.endswith((".pyc", ".o", ".a", ".elf", ".bin")):
+                continue
+            relative_path = (rel / fn).as_posix()
+            if relative_path not in mirrored_paths:
+                (Path(root) / fn).unlink()
+                removed += 1
+
+    if copied > 0 or removed > 0:
+        print(
+            f"SYNC: {dst.name}: refreshed {copied}/{src_files} files, "
+            f"removed {removed} stale files from {src}"
+        )
     return True
 
 

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 MICROSTORE_PIN = "https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2"
-MICRORETICULUM_PIN = "https://github.com/torlando-tech/microReticulum.git#6054f6ba82367628a85cd07fcb668b95e947f046"
+MICRORETICULUM_PIN = "https://github.com/torlando-tech/microReticulum.git#1bbd422a3b25b4a710642fc5cd01039e5774a4a7"
 
 
 def test_microstore_pin_resolves_before_transitive_registry_requirement():

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -14,6 +14,13 @@ def test_microstore_pin_resolves_before_transitive_registry_requirement():
     assert dependencies.index(MICROSTORE_PIN) < dependencies.index(MICRORETICULUM_PIN)
 
 
+def test_release_auditor_expects_the_configured_microreticulum_pin():
+    audit = (ROOT / "tools/audit_release_build.py").read_text()
+    expected_revision = MICRORETICULUM_PIN.rsplit("#", 1)[1]
+
+    assert f'"microReticulum": "{expected_revision}"' in audit
+
+
 def test_tdeck_release_removes_diagnostic_flags():
     config = (ROOT / "platformio.ini").read_text()
     release = config.split("[env:tdeck-release]", 1)[1].split("[env:", 1)[0]

--- a/tests/build_scripts/test_sync_file_libdeps.py
+++ b/tests/build_scripts/test_sync_file_libdeps.py
@@ -1,0 +1,51 @@
+import os
+import runpy
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "sync_file_libdeps.py"
+
+
+class FakeEnv(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+
+def test_local_override_uses_content_not_mtime(tmp_path, monkeypatch):
+    source = tmp_path / "source"
+    destination = tmp_path / "libdeps" / "microReticulum"
+    source.mkdir()
+    destination.mkdir(parents=True)
+
+    source_file = source / "Transport.cpp"
+    destination_file = destination / "Transport.cpp"
+    source_file.write_text("patched source\n")
+    destination_file.write_text("stale fetched source\n")
+
+    # A just-fetched dependency can have a newer mtime than the local checkout.
+    # The override must still win based on bytes, not timestamps.
+    os.utime(source_file, (1, 1))
+    os.utime(destination_file, (2, 2))
+
+    helpers = types.ModuleType("_build_helpers")
+    setattr(helpers, "env_libdeps_dir", lambda env: str(tmp_path / "libdeps"))
+    monkeypatch.setitem(sys.modules, "_build_helpers", helpers)
+    monkeypatch.setenv("PYXIS_MICRORETICULUM_DIR", str(source))
+
+    env = FakeEnv(PROJECT_DIR=str(ROOT))
+    runpy.run_path(
+        str(SCRIPT),
+        init_globals={"Import": lambda _: None, "env": env},
+    )
+
+    assert destination_file.read_text() == "patched source\n"
+    assert destination_file.stat().st_mtime > 2
+
+
+def test_local_override_runs_before_dependency_patch_scripts():
+    config = (ROOT / "platformio.ini").read_text()
+    scripts = config.split("extra_scripts =", 1)[1].split("platform =", 1)[0]
+    assert scripts.index("pre:sync_file_libdeps.py") < scripts.index("pre:patch_littlefs_paths.py")

--- a/tests/build_scripts/test_sync_file_libdeps.py
+++ b/tests/build_scripts/test_sync_file_libdeps.py
@@ -22,8 +22,10 @@ def test_local_override_uses_content_not_mtime(tmp_path, monkeypatch):
 
     source_file = source / "Transport.cpp"
     destination_file = destination / "Transport.cpp"
+    orphan_file = destination / "Removed.cpp"
     source_file.write_text("patched source\n")
     destination_file.write_text("stale fetched source\n")
+    orphan_file.write_text("removed local source\n")
 
     # A just-fetched dependency can have a newer mtime than the local checkout.
     # The override must still win based on bytes, not timestamps.
@@ -43,6 +45,7 @@ def test_local_override_uses_content_not_mtime(tmp_path, monkeypatch):
 
     assert destination_file.read_text() == "patched source\n"
     assert destination_file.stat().st_mtime > 2
+    assert not orphan_file.exists()
 
 
 def test_local_override_runs_before_dependency_patch_scripts():

--- a/tests/build_scripts/test_transport_mode_safety_contract.py
+++ b/tests/build_scripts/test_transport_mode_safety_contract.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MAIN = (ROOT / "src/main.cpp").read_text()
+SETTINGS_H = (ROOT / "lib/tdeck_ui/UI/LXMF/SettingsScreen.h").read_text()
+SETTINGS_CPP = (ROOT / "lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp").read_text()
+
+
+def test_transport_mode_defaults_off_and_controls_reticulum_startup():
+    assert "bool transport_enabled;" in SETTINGS_H
+    assert "transport_enabled(false)" in SETTINGS_H
+    assert 'prefs.getBool("transport", false)' in MAIN
+    assert MAIN.index("load_app_settings();") < MAIN.index("setup_reticulum();")
+    assert "Reticulum::transport_enabled(app_settings.transport_enabled);" in MAIN
+    assert "Reticulum::transport_enabled(true);" not in MAIN
+
+
+def test_transport_mode_setting_is_persisted():
+    assert 'KEY_TRANSPORT_ENABLED = "transport"' in SETTINGS_CPP
+    assert "prefs.getBool(KEY_TRANSPORT_ENABLED, false)" in SETTINGS_CPP
+    assert "prefs.putBool(KEY_TRANSPORT_ENABLED, _settings.transport_enabled)" in SETTINGS_CPP
+
+
+def test_transport_toggle_is_last_and_requires_explicit_warning_confirmation():
+    advanced = SETTINGS_CPP.index("create_advanced_section(_content);")
+    transport = SETTINGS_CPP.index("create_transport_mode_section(_content);")
+    assert advanced < transport
+
+    assert "DANGER: Transport Mode" in SETTINGS_CPP
+    assert "NOT RECOMMENDED" in SETTINGS_CPP
+    assert "saturate LoRa airtime" in SETTINGS_CPP
+    assert "drain the battery" in SETTINGS_CPP
+    assert "ENABLE ANYWAY" in SETTINGS_CPP
+    assert "Takes effect after reboot" in SETTINGS_CPP
+    assert "on_transport_enabled_changed" in SETTINGS_CPP
+    assert "on_transport_confirm_enable" in SETTINGS_CPP

--- a/tests/build_scripts/test_transport_mode_safety_contract.py
+++ b/tests/build_scripts/test_transport_mode_safety_contract.py
@@ -34,3 +34,6 @@ def test_transport_toggle_is_last_and_requires_explicit_warning_confirmation():
     assert "Takes effect after reboot" in SETTINGS_CPP
     assert "on_transport_enabled_changed" in SETTINGS_CPP
     assert "on_transport_confirm_enable" in SETTINGS_CPP
+    assert "lv_group_create()" in SETTINGS_CPP
+    assert "lv_indev_set_group(keyboard, _transport_modal_group)" in SETTINGS_CPP
+    assert "lv_indev_set_group(trackball, _transport_modal_group)" in SETTINGS_CPP

--- a/tools/audit_release_build.py
+++ b/tools/audit_release_build.py
@@ -40,7 +40,7 @@ EXCLUDED_SYMBOLS = (
     "BootProfiler::",
 )
 PINNED_DEPENDENCIES = {
-    "microReticulum": "6054f6ba82367628a85cd07fcb668b95e947f046",
+    "microReticulum": "1bbd422a3b25b4a710642fc5cd01039e5774a4a7",
     "microLXMF": "d9bbc04cf69bfa9b555c3f293b89b440b4820518",
     "microStore": "c5fb69d68229e684c7fbd17692a67ae8193b84e2",
 }


### PR DESCRIPTION
## Summary

- default Reticulum transport mode to disabled for fresh installs and upgrades without a stored preference
- add an opt-in toggle at the bottom of Settings with an explicit danger confirmation
- isolate modal keyboard and trackball focus from underlying Settings controls
- retain endpoint path learning through the corrected microReticulum dependency
- set the default periodic announce interval to four hours
- make local dependency overrides content-based and remove stale mirrored source files

## Safety behavior

Enabling transport requires `ENABLE ANYWAY` confirmation. The warning explains that transport mode relays other nodes' traffic and can consume LoRa airtime, battery, and nearby network capacity. The saved setting is loaded before Reticulum starts and takes effect after reboot.

## Verification

- 87 build-script and native tests passed
- clean `tdeck-release` build fetched microReticulum commit `1bbd422a3b25b4a710642fc5cd01039e5774a4a7` from GitHub
- release ELF contains the endpoint-only status, danger title, and confirmation label
- application-only flash verified by esptool hash
- two physical boots loaded the existing identity, Wi-Fi settings, display name, and four conversations
- serial output confirmed transport remained disabled and firmware ran from `app0`
- post-flash RNode sample: 1,273 TX bytes over 30 seconds, 0 RX bytes, 2.38% short-term airtime, zero queued/outgoing announces
- measured traffic was 91.14% lower than the prior Pyxis-on heavy sample

## Dependency order

The microReticulum endpoint path-store PR should merge before this PR so the immutable dependency pin remains resolvable.