### PR TITLE
feat: add SF5 LoRa support

### DIFF
--- a/lib/sx1262_interface/SX1262Interface.h
+++ b/lib/sx1262_interface/SX1262Interface.h
@@ -38,7 +38,7 @@ namespace SX1262Pins {
 struct SX1262Config {
     float frequency = 927.25f;        // MHz
     float bandwidth = 62.5f;          // kHz (valid: 7.8, 10.4, 15.6, 20.8, 31.25, 41.7, 62.5, 125, 250, 500)
-    uint8_t spreading_factor = 7;     // SF7-SF12
+    uint8_t spreading_factor = 7;     // SF5-SF12
     uint8_t coding_rate = 5;          // 5=4/5, 6=4/6, 7=4/7, 8=4/8
     int8_t tx_power = 17;             // dBm (2-22)
     uint8_t sync_word = 0x12;         // Standard LoRa sync word

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp
@@ -612,7 +612,7 @@ void SettingsScreen::create_interfaces_section(lv_obj_t* parent) {
     lv_obj_set_style_text_font(sf_label, &lv_font_montserrat_14, 0);
 
     _dropdown_lora_sf = lv_dropdown_create(sfcr_row);
-    lv_dropdown_set_options(_dropdown_lora_sf, "7\n8\n9\n10\n11\n12");
+    lv_dropdown_set_options(_dropdown_lora_sf, "5\n6\n7\n8\n9\n10\n11\n12");
     lv_obj_set_size(_dropdown_lora_sf, 50, 28);
     lv_obj_align(_dropdown_lora_sf, LV_ALIGN_LEFT_MID, 30, 0);
     lv_obj_set_style_bg_color(_dropdown_lora_sf, Theme::surfaceInput(), 0);
@@ -1227,8 +1227,8 @@ void SettingsScreen::update_ui_from_settings() {
         lv_dropdown_set_selected(_dropdown_lora_bandwidth, idx);
     }
     if (_dropdown_lora_sf) {
-        // SF 7-12 maps to index 0-5
-        lv_dropdown_set_selected(_dropdown_lora_sf, _settings.lora_sf - 7);
+        // SF 5-12 maps to index 0-7
+        lv_dropdown_set_selected(_dropdown_lora_sf, _settings.lora_sf - 5);
     }
     if (_dropdown_lora_cr) {
         // CR 5-8 maps to index 0-3
@@ -1348,8 +1348,8 @@ void SettingsScreen::update_settings_from_ui() {
         }
     }
     if (_dropdown_lora_sf) {
-        // Index 0-5 maps to SF 7-12
-        _settings.lora_sf = lv_dropdown_get_selected(_dropdown_lora_sf) + 7;
+        // Index 0-7 maps to SF 5-12
+        _settings.lora_sf = lv_dropdown_get_selected(_dropdown_lora_sf) + 5;
     }
     if (_dropdown_lora_cr) {
         // Index 0-3 maps to CR 5-8

--- a/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/SettingsScreen.h
@@ -45,7 +45,7 @@ struct AppSettings {
     bool lora_enabled;
     float lora_frequency;     // MHz
     float lora_bandwidth;     // kHz
-    uint8_t lora_sf;          // Spreading factor (7-12)
+    uint8_t lora_sf;          // Spreading factor (5-12)
     uint8_t lora_cr;          // Coding rate (5-8)
     int8_t lora_power;        // TX power dBm (2-22)
     bool auto_enabled;        // Enable AutoInterface (WiFi peer discovery)

--- a/tests/build_scripts/test_lora_sf_contract.py
+++ b/tests/build_scripts/test_lora_sf_contract.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_CPP = (ROOT / "lib/tdeck_ui/UI/LXMF/SettingsScreen.cpp").read_text()
+SETTINGS_H = (ROOT / "lib/tdeck_ui/UI/LXMF/SettingsScreen.h").read_text()
+SX1262_H = (ROOT / "lib/sx1262_interface/SX1262Interface.h").read_text()
+
+
+def test_lora_settings_expose_the_full_sx1262_sf5_through_sf12_range():
+    assert 'lv_dropdown_set_options(_dropdown_lora_sf, "5\\n6\\n7\\n8\\n9\\n10\\n11\\n12");' in SETTINGS_CPP
+    assert "lv_dropdown_set_selected(_dropdown_lora_sf, _settings.lora_sf - 5);" in SETTINGS_CPP
+    assert "_settings.lora_sf = lv_dropdown_get_selected(_dropdown_lora_sf) + 5;" in SETTINGS_CPP
+
+
+def test_lora_spreading_factor_documentation_matches_the_supported_range():
+    assert "Spreading factor (5-12)" in SETTINGS_H
+    assert "SF5-SF12" in SX1262_H


### PR DESCRIPTION
## Summary

- expose the full SX1262-supported spreading-factor range, SF5 through SF12, in the LoRa settings dropdown
- update value/index mappings so SF5 and SF6 persist and apply correctly while existing SF7-SF12 settings retain their values
- align SX1262 and application-setting documentation with the supported range
- add focused source contracts for the dropdown and round-trip mappings

Closes #43

## Verification

- `pytest -q tests/build_scripts/test_lora_sf_contract.py`: **2 passed**
- `pytest -q tests/build_scripts tests/native`: **98 passed**
- `pio run -e tdeck`: **success**
- `pio run -e tdeck-release`: **success**
- independent review: **PASS**
- resolved RadioLib 6.6.0 confirms `SX126x::setSpreadingFactor()` accepts values `5..12`
- release ELF audit: serial test-hook commands absent

Artifacts built from commit `c869842088be0f571fc800474c32a2cc95a02fc2`:

- `tdeck` SHA-256: `9fc83c46a828283414c34b592111528a2f3ecb231b73424e245a00c6f82337ce`
- `tdeck-release` SHA-256: `1a21bf91aada67be62d8224b6ddf8fa4adcecfb7ac93d8e16149f0097e397e2b`

## Hardware status

Compilation and host contracts are complete. Physical SF5 radio initialization, runtime stop/reconfigure/restart, and over-the-air SF5 interoperability remain pending; no device was flashed for this change.
