### PR TITLE
fix: correct LoRa interface bitrate units

### DIFF
--- a/lib/sx1262_interface/SX1262Bitrate.h
+++ b/lib/sx1262_interface/SX1262Bitrate.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+// Match Python RNS RNodeInterface's bitrate formula while accepting the
+// bandwidth unit used by SX1262Config and RadioLib (kHz, not Hz).
+inline uint32_t calculate_lora_bitrate_bps(float bandwidth_khz, uint8_t spreading_factor, uint8_t coding_rate) {
+    if (bandwidth_khz <= 0.0f || spreading_factor == 0 || coding_rate == 0) {
+        return 0;
+    }
+
+    const double bandwidth_hz = static_cast<double>(bandwidth_khz) * 1000.0;
+    const double symbol_rate = bandwidth_hz / std::pow(2.0, spreading_factor);
+    const double coding_efficiency = 4.0 / static_cast<double>(coding_rate);
+    return static_cast<uint32_t>(spreading_factor * coding_efficiency * symbol_rate);
+}

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "SX1262Interface.h"
+#include "SX1262Bitrate.h"
 #include <microReticulum/Log.h>
 #include <microReticulum/Utilities/OS.h>
 
@@ -31,11 +32,11 @@ SX1262Interface::SX1262Interface(const char* name) : InterfaceImpl(name) {
     _HW_MTU = HW_MTU;
     _AUTOCONFIGURE_MTU = true;
 
-    // Calculate bitrate from modulation parameters (matching Python RNS formula)
-    // bitrate = sf * ((4.0/cr) / (2^sf / (bw/1000))) * 1000
-    _bitrate = (double)_config.spreading_factor *
-               ((4.0 / _config.coding_rate) /
-                (pow(2, _config.spreading_factor) / (_config.bandwidth / 1000.0))) * 1000.0;
+    _bitrate = calculate_lora_bitrate_bps(
+        _config.bandwidth,
+        _config.spreading_factor,
+        _config.coding_rate
+    );
 }
 
 SX1262Interface::~SX1262Interface() {
@@ -45,10 +46,11 @@ SX1262Interface::~SX1262Interface() {
 void SX1262Interface::set_config(const SX1262Config& config) {
     _config = config;
 
-    // Recalculate bitrate
-    _bitrate = (double)_config.spreading_factor *
-               ((4.0 / _config.coding_rate) /
-                (pow(2, _config.spreading_factor) / (_config.bandwidth / 1000.0))) * 1000.0;
+    _bitrate = calculate_lora_bitrate_bps(
+        _config.bandwidth,
+        _config.spreading_factor,
+        _config.coding_rate
+    );
 }
 
 std::string SX1262Interface::toString() const {

--- a/tests/native/test_sx1262_bitrate.cpp
+++ b/tests/native/test_sx1262_bitrate.cpp
@@ -1,0 +1,28 @@
+#include <cstdint>
+#include <iostream>
+
+#include "SX1262Bitrate.h"
+
+int main() {
+    int passed = 0;
+    int failed = 0;
+
+    auto check = [&](const char* name, uint32_t actual, uint32_t expected) {
+        if (actual == expected) {
+            ++passed;
+        } else {
+            ++failed;
+            std::cerr << name << ": expected " << expected << ", got " << actual << "\n";
+        }
+    };
+
+    check("k3s RNode settings", calculate_lora_bitrate_bps(500.0f, 7, 5), 21875);
+    check("Pyxis default settings", calculate_lora_bitrate_bps(62.5f, 7, 5), 2734);
+    check("SF5 settings", calculate_lora_bitrate_bps(500.0f, 5, 5), 62500);
+    check("zero bandwidth", calculate_lora_bitrate_bps(0.0f, 7, 5), 0);
+    check("zero spreading factor", calculate_lora_bitrate_bps(500.0f, 0, 5), 0);
+    check("zero coding rate", calculate_lora_bitrate_bps(500.0f, 7, 0), 0);
+
+    std::cout << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/native/test_sx1262_bitrate.py
+++ b/tests/native/test_sx1262_bitrate.py
@@ -1,0 +1,44 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_sx1262_bitrate.cpp"
+INTERFACE_SOURCE = PYXIS_ROOT / "lib" / "sx1262_interface" / "SX1262Interface.cpp"
+
+
+def _find_cxx():
+    for command in ("clang++", "g++"):
+        if shutil.which(command):
+            return command
+    pytest.skip("no C++ compiler found")
+
+
+def test_sx1262_bitrate_matches_python_rns_units(tmp_path):
+    binary = tmp_path / "test_sx1262_bitrate"
+    command = [
+        _find_cxx(),
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        f"-I{PYXIS_ROOT / 'lib' / 'sx1262_interface'}",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(command, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+
+    result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "6 passed, 0 failed"
+
+
+def test_sx1262_interface_uses_the_unit_safe_bitrate_helper():
+    source = INTERFACE_SOURCE.read_text()
+    assert source.count("calculate_lora_bitrate_bps(") == 2
+    assert "_config.bandwidth / 1000.0" not in source


### PR DESCRIPTION
## Summary

- correct the SX1262 interface bitrate calculation by converting RadioLib's kHz bandwidth input to Hz exactly once
- use one unit-safe helper from both construction and runtime configuration paths
- add native coverage for the current 500 kHz/SF7/CR4/5 configuration, Pyxis defaults, SF5, and invalid zero inputs

## Behavior

This changes Reticulum interface timing metadata from 21 bps to 21,875 bps for 500 kHz/SF7/CR4/5. It does not change frequency, bandwidth, spreading factor, coding rate, transmit power, framing, or RadioLib transmission configuration.

The corrected value is used for first-hop/proof timeout estimates and non-local announce/path-request pacing. Locally originated Pyxis announces continue to bypass announce bandwidth caps.

## Verification

- `pytest -q tests/build_scripts tests/native`
- `pio run -e tdeck`
- `pio run -e tdeck-release`
- physical T-Deck boot reported `22.000000 kbps`
- exact application flash read-back passed
- clean firmware persisted across two boots with the same identity, delivery destination, six conversations, and mounted SD card
- real-peer LoRa acceptance passed: Pyxis announce was heard through a phone-paired RNode and bidirectional LXMF messages were exchanged

## Risk and rollback

Risk is limited to Reticulum timing and pacing derived from interface bitrate. Reverting commit `9832131` restores the prior calculation; no storage migration or radio-setting change is involved.
