### PR TITLE
feat: add current-channel Radio Activity view

### DIFF
--- a/lib/lv_conf.h
+++ b/lib/lv_conf.h
@@ -68,7 +68,7 @@
 /*====================
    FONT SETTINGS
  *====================*/
-#define LV_FONT_MONTSERRAT_8 0
+#define LV_FONT_MONTSERRAT_8 1
 #define LV_FONT_MONTSERRAT_10 0
 #define LV_FONT_MONTSERRAT_12 1
 #define LV_FONT_MONTSERRAT_14 1

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -20,6 +20,7 @@ constexpr uint8_t event_bit(Event event) {
 struct Sample {
     int16_t rssi_dbm = -135;
     uint8_t events = 0;
+    bool rssi_valid = true;
     uint32_t sequence = 0;
 };
 
@@ -57,13 +58,23 @@ public:
 
     void mark_event(Event event) {
         if (event == Event::Noise) return;
-        _pending_events |= event_bit(event);
+        const std::size_t index = event_index(event);
+        if (_pending_event_buckets[index] == 0) {
+            _pending_event_buckets[index] = 1;
+        }
+    }
+
+    void mark_event(Event event, std::size_t buckets) {
+        if (event == Event::Noise || buckets == 0) return;
+        const std::size_t index = event_index(event);
+        const std::size_t total = _pending_event_buckets[index] + buckets;
+        _pending_event_buckets[index] = static_cast<uint8_t>(
+            total > CAPACITY ? CAPACITY : total);
     }
 
     void record(int16_t rssi_dbm) {
         const int16_t rssi = clamp_rssi(rssi_dbm);
-        uint8_t events = _pending_events;
-        _pending_events = 0;
+        uint8_t events = take_pending_events();
         if (events == 0 && _noise_count >= MIN_BASELINE_SAMPLES &&
             rssi > static_cast<int16_t>(noise_floor() + ACTIVITY_THRESHOLD_DB)) {
             events |= event_bit(Event::Interference);
@@ -73,15 +84,20 @@ public:
             accept_noise(rssi);
         }
 
-        Sample sample;
-        sample.rssi_dbm = rssi;
-        sample.events = events;
-        sample.sequence = _next_sequence++;
-        _samples[_write_index] = sample;
-        _write_index = (_write_index + 1) % CAPACITY;
-        if (_count < CAPACITY) {
-            ++_count;
+        append_sample(rssi, true, events);
+    }
+
+    void record_gap(bool consume_events = true) {
+        append_sample(MIN_RSSI_DBM, false,
+                      consume_events ? take_pending_events() : 0);
+    }
+
+    std::size_t pending_bucket_span() const {
+        std::size_t span = 0;
+        for (const uint8_t count : _pending_event_buckets) {
+            if (count > span) span = count;
         }
+        return span;
     }
 
     Snapshot snapshot() const {
@@ -91,12 +107,14 @@ public:
         std::size_t active = 0;
         for (std::size_t i = 0; i < _count; ++i) {
             result.samples[i] = _samples[(oldest + i) % CAPACITY];
+            if (result.samples[i].rssi_valid) {
+                result.current_rssi = result.samples[i].rssi_dbm;
+            }
             if (result.samples[i].events != 0) {
                 ++active;
             }
         }
         if (_count > 0) {
-            result.current_rssi = result.samples[_count - 1].rssi_dbm;
             result.channel_load_percent = static_cast<uint8_t>((active * 100U) / _count);
         }
         result.noise_floor_ready = _noise_count >= MIN_BASELINE_SAMPLES;
@@ -105,6 +123,40 @@ public:
     }
 
 private:
+    static std::size_t event_index(Event event) {
+        switch (event) {
+            case Event::Rx: return 0;
+            case Event::Tx: return 1;
+            case Event::Interference: return 2;
+            case Event::Noise: return 0;
+        }
+        return 0;
+    }
+
+    uint8_t take_pending_events() {
+        uint8_t events = 0;
+        for (std::size_t i = 0; i < _pending_event_buckets.size(); ++i) {
+            if (_pending_event_buckets[i] > 0) {
+                events |= static_cast<uint8_t>(1U << i);
+                --_pending_event_buckets[i];
+            }
+        }
+        return events;
+    }
+
+    void append_sample(int16_t rssi, bool rssi_valid, uint8_t events) {
+        Sample sample;
+        sample.rssi_dbm = rssi;
+        sample.events = events;
+        sample.rssi_valid = rssi_valid;
+        sample.sequence = _next_sequence++;
+        _samples[_write_index] = sample;
+        _write_index = (_write_index + 1) % CAPACITY;
+        if (_count < CAPACITY) {
+            ++_count;
+        }
+    }
+
     static int16_t clamp_rssi(int16_t value) {
         if (value < MIN_RSSI_DBM) return MIN_RSSI_DBM;
         if (value > MAX_RSSI_DBM) return MAX_RSSI_DBM;
@@ -138,7 +190,7 @@ private:
     std::size_t _noise_count = 0;
     int32_t _noise_sum = 0;
     uint32_t _next_sequence = 0;
-    uint8_t _pending_events = 0;
+    std::array<uint8_t, 3> _pending_event_buckets{};
 };
 
 } // namespace RadioActivity

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -57,6 +57,14 @@ public:
     static constexpr int16_t MIN_RSSI_DBM = -135;
     static constexpr int16_t MAX_RSSI_DBM = -20;
 
+    uint32_t generation() const { return _generation; }
+
+    void reset() {
+        const uint32_t next_generation = _generation + 1;
+        *this = History{};
+        _generation = next_generation;
+    }
+
     void mark_event(Event event) {
         if (event == Event::Noise) return;
         const std::size_t index = event_index(event);
@@ -124,6 +132,8 @@ public:
     }
 
 private:
+    uint32_t _generation = 0;
+
     static std::size_t event_index(Event event) {
         switch (event) {
             case Event::Rx: return 0;

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -48,18 +48,15 @@ public:
     static constexpr int16_t MAX_RSSI_DBM = -20;
 
     void mark_event(Event event) {
-        if (event != Event::Noise) {
-            _pending_event = event;
-        }
+        if (event == Event::Noise) return;
+        const int16_t marker_rssi = _count > 0
+            ? _samples[(_write_index + CAPACITY - 1) % CAPACITY].rssi_dbm
+            : MIN_RSSI_DBM;
+        record(marker_rssi, event);
     }
 
     void record(int16_t rssi_dbm, Event event = Event::Noise) {
         const int16_t rssi = clamp_rssi(rssi_dbm);
-        if (event == Event::Noise && _pending_event != Event::Noise) {
-            event = _pending_event;
-        }
-        _pending_event = Event::Noise;
-
         if (event == Event::Noise && _noise_count >= MIN_BASELINE_SAMPLES &&
             rssi > static_cast<int16_t>(noise_floor() + ACTIVITY_THRESHOLD_DB)) {
             event = Event::Interference;
@@ -134,7 +131,6 @@ private:
     std::size_t _noise_count = 0;
     int32_t _noise_sum = 0;
     uint32_t _next_sequence = 0;
-    Event _pending_event = Event::Noise;
 };
 
 } // namespace RadioActivity

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -34,6 +34,7 @@ struct Snapshot {
     std::array<Sample, CAPACITY> samples{};
     std::size_t count = 0;
     int16_t current_rssi = -135;
+    bool current_rssi_valid = false;
     int16_t noise_floor = -135;
     bool noise_floor_ready = false;
     uint8_t channel_load_percent = 0;
@@ -107,14 +108,14 @@ public:
         std::size_t active = 0;
         for (std::size_t i = 0; i < _count; ++i) {
             result.samples[i] = _samples[(oldest + i) % CAPACITY];
-            if (result.samples[i].rssi_valid) {
-                result.current_rssi = result.samples[i].rssi_dbm;
-            }
             if (result.samples[i].events != 0) {
                 ++active;
             }
         }
         if (_count > 0) {
+            const Sample& newest = result.samples[_count - 1];
+            result.current_rssi_valid = newest.rssi_valid;
+            result.current_rssi = newest.rssi_valid ? newest.rssi_dbm : MIN_RSSI_DBM;
             result.channel_load_percent = static_cast<uint8_t>((active * 100U) / _count);
         }
         result.noise_floor_ready = _noise_count >= MIN_BASELINE_SAMPLES;

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -8,16 +8,24 @@ namespace RadioActivity {
 
 enum class Event : uint8_t {
     Noise = 0,
-    Rx,
-    Tx,
-    Interference,
+    Rx = 1U << 0,
+    Tx = 1U << 1,
+    Interference = 1U << 2,
 };
+
+constexpr uint8_t event_bit(Event event) {
+    return static_cast<uint8_t>(event);
+}
 
 struct Sample {
     int16_t rssi_dbm = -135;
-    Event event = Event::Noise;
+    uint8_t events = 0;
     uint32_t sequence = 0;
 };
+
+constexpr bool has_event(const Sample& sample, Event event) {
+    return (sample.events & event_bit(event)) != 0;
+}
 
 struct Snapshot {
     static constexpr std::size_t CAPACITY = 96;
@@ -49,26 +57,25 @@ public:
 
     void mark_event(Event event) {
         if (event == Event::Noise) return;
-        const int16_t marker_rssi = _count > 0
-            ? _samples[(_write_index + CAPACITY - 1) % CAPACITY].rssi_dbm
-            : MIN_RSSI_DBM;
-        record(marker_rssi, event);
+        _pending_events |= event_bit(event);
     }
 
-    void record(int16_t rssi_dbm, Event event = Event::Noise) {
+    void record(int16_t rssi_dbm) {
         const int16_t rssi = clamp_rssi(rssi_dbm);
-        if (event == Event::Noise && _noise_count >= MIN_BASELINE_SAMPLES &&
+        uint8_t events = _pending_events;
+        _pending_events = 0;
+        if (events == 0 && _noise_count >= MIN_BASELINE_SAMPLES &&
             rssi > static_cast<int16_t>(noise_floor() + ACTIVITY_THRESHOLD_DB)) {
-            event = Event::Interference;
+            events |= event_bit(Event::Interference);
         }
 
-        if (event == Event::Noise) {
+        if (events == 0) {
             accept_noise(rssi);
         }
 
         Sample sample;
         sample.rssi_dbm = rssi;
-        sample.event = event;
+        sample.events = events;
         sample.sequence = _next_sequence++;
         _samples[_write_index] = sample;
         _write_index = (_write_index + 1) % CAPACITY;
@@ -84,7 +91,7 @@ public:
         std::size_t active = 0;
         for (std::size_t i = 0; i < _count; ++i) {
             result.samples[i] = _samples[(oldest + i) % CAPACITY];
-            if (result.samples[i].event != Event::Noise) {
+            if (result.samples[i].events != 0) {
                 ++active;
             }
         }
@@ -131,6 +138,7 @@ private:
     std::size_t _noise_count = 0;
     int32_t _noise_sum = 0;
     uint32_t _next_sequence = 0;
+    uint8_t _pending_events = 0;
 };
 
 } // namespace RadioActivity

--- a/lib/radio_activity/RadioActivityHistory.h
+++ b/lib/radio_activity/RadioActivityHistory.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace RadioActivity {
+
+enum class Event : uint8_t {
+    Noise = 0,
+    Rx,
+    Tx,
+    Interference,
+};
+
+struct Sample {
+    int16_t rssi_dbm = -135;
+    Event event = Event::Noise;
+    uint32_t sequence = 0;
+};
+
+struct Snapshot {
+    static constexpr std::size_t CAPACITY = 96;
+
+    std::array<Sample, CAPACITY> samples{};
+    std::size_t count = 0;
+    int16_t current_rssi = -135;
+    int16_t noise_floor = -135;
+    bool noise_floor_ready = false;
+    uint8_t channel_load_percent = 0;
+};
+
+/**
+ * Hardware-independent, fixed-capacity current-channel RSSI history.
+ *
+ * Samples within 11 dB of the learned floor are admitted to a bounded rolling
+ * baseline. Decoded RX, local TX, and stronger undecodable activity are kept as
+ * metadata but excluded from that baseline. This model is observational only;
+ * it does not influence radio admission or modulation.
+ */
+class History {
+public:
+    static constexpr std::size_t CAPACITY = Snapshot::CAPACITY;
+    static constexpr std::size_t NOISE_WINDOW_CAPACITY = 24;
+    static constexpr std::size_t MIN_BASELINE_SAMPLES = 4;
+    static constexpr int16_t ACTIVITY_THRESHOLD_DB = 11;
+    static constexpr int16_t MIN_RSSI_DBM = -135;
+    static constexpr int16_t MAX_RSSI_DBM = -20;
+
+    void mark_event(Event event) {
+        if (event != Event::Noise) {
+            _pending_event = event;
+        }
+    }
+
+    void record(int16_t rssi_dbm, Event event = Event::Noise) {
+        const int16_t rssi = clamp_rssi(rssi_dbm);
+        if (event == Event::Noise && _pending_event != Event::Noise) {
+            event = _pending_event;
+        }
+        _pending_event = Event::Noise;
+
+        if (event == Event::Noise && _noise_count >= MIN_BASELINE_SAMPLES &&
+            rssi > static_cast<int16_t>(noise_floor() + ACTIVITY_THRESHOLD_DB)) {
+            event = Event::Interference;
+        }
+
+        if (event == Event::Noise) {
+            accept_noise(rssi);
+        }
+
+        Sample sample;
+        sample.rssi_dbm = rssi;
+        sample.event = event;
+        sample.sequence = _next_sequence++;
+        _samples[_write_index] = sample;
+        _write_index = (_write_index + 1) % CAPACITY;
+        if (_count < CAPACITY) {
+            ++_count;
+        }
+    }
+
+    Snapshot snapshot() const {
+        Snapshot result;
+        result.count = _count;
+        const std::size_t oldest = (_count == CAPACITY) ? _write_index : 0;
+        std::size_t active = 0;
+        for (std::size_t i = 0; i < _count; ++i) {
+            result.samples[i] = _samples[(oldest + i) % CAPACITY];
+            if (result.samples[i].event != Event::Noise) {
+                ++active;
+            }
+        }
+        if (_count > 0) {
+            result.current_rssi = result.samples[_count - 1].rssi_dbm;
+            result.channel_load_percent = static_cast<uint8_t>((active * 100U) / _count);
+        }
+        result.noise_floor_ready = _noise_count >= MIN_BASELINE_SAMPLES;
+        result.noise_floor = result.noise_floor_ready ? noise_floor() : MIN_RSSI_DBM;
+        return result;
+    }
+
+private:
+    static int16_t clamp_rssi(int16_t value) {
+        if (value < MIN_RSSI_DBM) return MIN_RSSI_DBM;
+        if (value > MAX_RSSI_DBM) return MAX_RSSI_DBM;
+        return value;
+    }
+
+    int16_t noise_floor() const {
+        if (_noise_count == 0) return MIN_RSSI_DBM;
+        // Integer division intentionally gives a stable whole-dBm display value.
+        return static_cast<int16_t>(_noise_sum / static_cast<int32_t>(_noise_count));
+    }
+
+    void accept_noise(int16_t rssi) {
+        if (_noise_count < NOISE_WINDOW_CAPACITY) {
+            _noise_samples[_noise_write] = rssi;
+            _noise_sum += rssi;
+            ++_noise_count;
+        } else {
+            _noise_sum -= _noise_samples[_noise_write];
+            _noise_samples[_noise_write] = rssi;
+            _noise_sum += rssi;
+        }
+        _noise_write = (_noise_write + 1) % NOISE_WINDOW_CAPACITY;
+    }
+
+    std::array<Sample, CAPACITY> _samples{};
+    std::array<int16_t, NOISE_WINDOW_CAPACITY> _noise_samples{};
+    std::size_t _write_index = 0;
+    std::size_t _count = 0;
+    std::size_t _noise_write = 0;
+    std::size_t _noise_count = 0;
+    int32_t _noise_sum = 0;
+    uint32_t _next_sequence = 0;
+    Event _pending_event = Event::Noise;
+};
+
+} // namespace RadioActivity

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -65,6 +65,17 @@ SX1262Interface::~SX1262Interface() {
 }
 
 void SX1262Interface::set_config(const SX1262Config& config) {
+#ifdef ARDUINO
+    if (lock_activity(portMAX_DELAY)) {
+        _activity_history.reset();
+        _last_activity_sample_ms = millis();
+        unlock_activity();
+    }
+#else
+    _activity_history.reset();
+    _last_activity_sample_ms = 0;
+#endif
+
     _config = config;
 
     _bitrate = calculate_lora_bitrate_bps(
@@ -207,7 +218,16 @@ void SX1262Interface::start_receive() {
 void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
 #ifdef ARDUINO
     if (!_online || _radio == nullptr || _spi_mutex == nullptr) return;
-    const uint32_t elapsed = now_ms - _last_activity_sample_ms;
+
+    uint32_t activity_generation = 0;
+    uint32_t last_activity_sample_ms = 0;
+    if (!lock_activity(pdMS_TO_TICKS(2))) return;
+    activity_generation = _activity_history.generation();
+    last_activity_sample_ms = _last_activity_sample_ms;
+    now_ms = millis();
+    unlock_activity();
+
+    const uint32_t elapsed = now_ms - last_activity_sample_ms;
     if (elapsed < ACTIVITY_SAMPLE_INTERVAL_MS) return;
     const uint32_t raw_due = elapsed / ACTIVITY_SAMPLE_INTERVAL_MS;
     const std::size_t due = raw_due > RadioActivity::History::CAPACITY
@@ -218,19 +238,24 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
         if (raw_due > RadioActivity::History::CAPACITY) {
             _last_activity_sample_ms = now_ms;
         } else {
-            _last_activity_sample_ms += raw_due * ACTIVITY_SAMPLE_INTERVAL_MS;
+            _last_activity_sample_ms = last_activity_sample_ms +
+                raw_due * ACTIVITY_SAMPLE_INTERVAL_MS;
         }
     };
     auto record_gaps = [&](std::size_t count) {
         if (!lock_activity(pdMS_TO_TICKS(2))) return;
+        if (_activity_history.generation() != activity_generation) {
+            unlock_activity();
+            return;
+        }
         const std::size_t pending_span = _activity_history.pending_bucket_span();
         const std::size_t active_span = pending_span > count ? count : pending_span;
         const std::size_t inactive_count = count - active_span;
         for (std::size_t i = 0; i < count; ++i) {
             _activity_history.record_gap(i >= inactive_count);
         }
-        unlock_activity();
         advance_clock();
+        unlock_activity();
     };
 
     if (_transmitting) {
@@ -252,6 +277,10 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
     xSemaphoreGive(_spi_mutex);
 
     if (!lock_activity(pdMS_TO_TICKS(2))) return;
+    if (_activity_history.generation() != activity_generation) {
+        unlock_activity();
+        return;
+    }
     const std::size_t pending_span = _activity_history.pending_bucket_span();
     const std::size_t active_span = pending_span > due ? due : pending_span;
     const std::size_t inactive_count = due - active_span;
@@ -259,8 +288,8 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
         _activity_history.record_gap(i >= inactive_count);
     }
     _activity_history.record(static_cast<int16_t>(instantaneous_rssi));
-    unlock_activity();
     advance_clock();
+    unlock_activity();
 #else
     (void)now_ms;
 #endif
@@ -282,6 +311,14 @@ void SX1262Interface::loop() {
 
 #ifdef ARDUINO
     if (_radio == nullptr) return;
+
+    uint32_t activity_generation = 0;
+    bool activity_generation_valid = false;
+    if (lock_activity(portMAX_DELAY)) {
+        activity_generation = _activity_history.generation();
+        activity_generation_valid = true;
+        unlock_activity();
+    }
 
     // Try to acquire SPI mutex (non-blocking to avoid stalling display)
     if (xSemaphoreTake(_spi_mutex, pdMS_TO_TICKS(5)) != pdTRUE) {
@@ -325,9 +362,13 @@ void SX1262Interface::loop() {
 
             // SPI is already released. Wait for the bounded history mutex so a
             // real receive marker cannot be dropped behind a snapshot/catch-up.
-            if (lock_activity(portMAX_DELAY)) {
-                _activity_history.mark_event(RadioActivity::Event::Rx);
-                unlock_activity();
+            if (activity_generation_valid && lock_activity(portMAX_DELAY)) {
+                if (_activity_history.generation() != activity_generation) {
+                    unlock_activity();
+                } else {
+                    _activity_history.mark_event(RadioActivity::Event::Rx);
+                    unlock_activity();
+                }
             }
 
             on_incoming(payload);
@@ -347,6 +388,14 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
 
 #ifdef ARDUINO
     if (_radio == nullptr) return false;
+
+    uint32_t activity_generation = 0;
+    bool activity_generation_valid = false;
+    if (lock_activity(portMAX_DELAY)) {
+        activity_generation = _activity_history.generation();
+        activity_generation_valid = true;
+        unlock_activity();
+    }
 
     DEBUG(toString() + ": Sending " + std::to_string(data.size()) + " bytes");
 
@@ -398,9 +447,13 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
         if (tx_buckets == 0) tx_buckets = 1;
         // SPI is already released. Wait for the bounded history mutex so a
         // completed transmission duration cannot disappear from the timeline.
-        if (lock_activity(portMAX_DELAY)) {
-            _activity_history.mark_event(RadioActivity::Event::Tx, tx_buckets);
-            unlock_activity();
+        if (activity_generation_valid && lock_activity(portMAX_DELAY)) {
+            if (_activity_history.generation() != activity_generation) {
+                unlock_activity();
+            } else {
+                _activity_history.mark_event(RadioActivity::Event::Tx, tx_buckets);
+                unlock_activity();
+            }
         }
         // Perform post-send housekeeping
         InterfaceImpl::handle_outgoing(data);

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -265,7 +265,7 @@ void SX1262Interface::loop() {
                   "SNR=" + std::to_string((int)_last_snr) + " dB");
 
             portENTER_CRITICAL(&_activity_mux);
-            _activity_history.record(static_cast<int16_t>(_last_rssi), RadioActivity::Event::Rx);
+            _activity_history.mark_event(RadioActivity::Event::Rx);
             portEXIT_CRITICAL(&_activity_mux);
 
             on_incoming(payload);

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -186,22 +186,60 @@ void SX1262Interface::start_receive() {
 void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
 #ifdef ARDUINO
     if (!_online || _radio == nullptr || _spi_mutex == nullptr) return;
-    if (_transmitting) return;
-    if (now_ms - _last_activity_sample_ms < ACTIVITY_SAMPLE_INTERVAL_MS) return;
+    const uint32_t elapsed = now_ms - _last_activity_sample_ms;
+    if (elapsed < ACTIVITY_SAMPLE_INTERVAL_MS) return;
+    const uint32_t raw_due = elapsed / ACTIVITY_SAMPLE_INTERVAL_MS;
+    const std::size_t due = raw_due > RadioActivity::History::CAPACITY
+        ? RadioActivity::History::CAPACITY
+        : static_cast<std::size_t>(raw_due);
+
+    auto advance_clock = [&]() {
+        if (raw_due > RadioActivity::History::CAPACITY) {
+            _last_activity_sample_ms = now_ms;
+        } else {
+            _last_activity_sample_ms += raw_due * ACTIVITY_SAMPLE_INTERVAL_MS;
+        }
+    };
+    auto record_gaps = [&](std::size_t count) {
+        portENTER_CRITICAL(&_activity_mux);
+        const std::size_t pending_span = _activity_history.pending_bucket_span();
+        const std::size_t active_span = pending_span > count ? count : pending_span;
+        const std::size_t inactive_count = count - active_span;
+        for (std::size_t i = 0; i < count; ++i) {
+            _activity_history.record_gap(i >= inactive_count);
+        }
+        portEXIT_CRITICAL(&_activity_mux);
+        advance_clock();
+    };
+
+    if (_transmitting) {
+        record_gaps(due);
+        return;
+    }
 
     // Sampling is deliberately best-effort: display/SD/radio work always wins.
-    if (xSemaphoreTake(_spi_mutex, 0) != pdTRUE) return;
+    if (xSemaphoreTake(_spi_mutex, 0) != pdTRUE) {
+        record_gaps(due);
+        return;
+    }
     if (_transmitting) {
         xSemaphoreGive(_spi_mutex);
+        record_gaps(due);
         return;
     }
     const float instantaneous_rssi = _radio->getRSSI(false);
     xSemaphoreGive(_spi_mutex);
 
-    _last_activity_sample_ms = now_ms;
     portENTER_CRITICAL(&_activity_mux);
+    const std::size_t pending_span = _activity_history.pending_bucket_span();
+    const std::size_t active_span = pending_span > due ? due : pending_span;
+    const std::size_t inactive_count = due - active_span;
+    for (std::size_t i = 0; i + 1 < due; ++i) {
+        _activity_history.record_gap(i >= inactive_count);
+    }
     _activity_history.record(static_cast<int16_t>(instantaneous_rssi));
     portEXIT_CRITICAL(&_activity_mux);
+    advance_clock();
 #else
     (void)now_ms;
 #endif
@@ -310,9 +348,11 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
     }
 
     _transmitting = true;
+    const uint32_t tx_started_ms = millis();
 
     // Transmit (blocking)
     int16_t state = _radio->transmit(buf, len);
+    const uint32_t tx_duration_ms = millis() - tx_started_ms;
 
     _transmitting = false;
 
@@ -328,8 +368,12 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
 
     if (state == RADIOLIB_ERR_NONE) {
         DEBUG("SX1262Interface: Sent " + std::to_string(len) + " bytes");
+        std::size_t tx_buckets = static_cast<std::size_t>(
+            (tx_duration_ms + ACTIVITY_SAMPLE_INTERVAL_MS - 1) /
+            ACTIVITY_SAMPLE_INTERVAL_MS);
+        if (tx_buckets == 0) tx_buckets = 1;
         portENTER_CRITICAL(&_activity_mux);
-        _activity_history.mark_event(RadioActivity::Event::Tx);
+        _activity_history.mark_event(RadioActivity::Event::Tx, tx_buckets);
         portEXIT_CRITICAL(&_activity_mux);
         // Perform post-send housekeeping
         InterfaceImpl::handle_outgoing(data);

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -24,6 +24,15 @@ void SX1262Interface::set_spi_mutex(SemaphoreHandle_t mutex) {
         DEBUG("SX1262Interface: Using external SPI mutex");
     }
 }
+
+bool SX1262Interface::lock_activity(TickType_t timeout_ticks) const {
+    return _activity_mutex != nullptr &&
+           xSemaphoreTake(_activity_mutex, timeout_ticks) == pdTRUE;
+}
+
+void SX1262Interface::unlock_activity() const {
+    xSemaphoreGive(_activity_mutex);
+}
 #endif
 
 SX1262Interface::SX1262Interface(const char* name) : InterfaceImpl(name) {
@@ -37,10 +46,22 @@ SX1262Interface::SX1262Interface(const char* name) : InterfaceImpl(name) {
         _config.spreading_factor,
         _config.coding_rate
     );
+#ifdef ARDUINO
+    _activity_mutex = xSemaphoreCreateMutex();
+    if (_activity_mutex == nullptr) {
+        ERROR("SX1262Interface: Failed to create activity mutex");
+    }
+#endif
 }
 
 SX1262Interface::~SX1262Interface() {
     stop();
+#ifdef ARDUINO
+    if (_activity_mutex != nullptr) {
+        vSemaphoreDelete(_activity_mutex);
+        _activity_mutex = nullptr;
+    }
+#endif
 }
 
 void SX1262Interface::set_config(const SX1262Config& config) {
@@ -201,14 +222,14 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
         }
     };
     auto record_gaps = [&](std::size_t count) {
-        portENTER_CRITICAL(&_activity_mux);
+        if (!lock_activity(pdMS_TO_TICKS(2))) return;
         const std::size_t pending_span = _activity_history.pending_bucket_span();
         const std::size_t active_span = pending_span > count ? count : pending_span;
         const std::size_t inactive_count = count - active_span;
         for (std::size_t i = 0; i < count; ++i) {
             _activity_history.record_gap(i >= inactive_count);
         }
-        portEXIT_CRITICAL(&_activity_mux);
+        unlock_activity();
         advance_clock();
     };
 
@@ -230,7 +251,7 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
     const float instantaneous_rssi = _radio->getRSSI(false);
     xSemaphoreGive(_spi_mutex);
 
-    portENTER_CRITICAL(&_activity_mux);
+    if (!lock_activity(pdMS_TO_TICKS(2))) return;
     const std::size_t pending_span = _activity_history.pending_bucket_span();
     const std::size_t active_span = pending_span > due ? due : pending_span;
     const std::size_t inactive_count = due - active_span;
@@ -238,7 +259,7 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
         _activity_history.record_gap(i >= inactive_count);
     }
     _activity_history.record(static_cast<int16_t>(instantaneous_rssi));
-    portEXIT_CRITICAL(&_activity_mux);
+    unlock_activity();
     advance_clock();
 #else
     (void)now_ms;
@@ -247,9 +268,9 @@ void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
 
 RadioActivity::Snapshot SX1262Interface::radio_activity_snapshot() const {
 #ifdef ARDUINO
-    portENTER_CRITICAL(&_activity_mux);
+    if (!lock_activity(pdMS_TO_TICKS(2))) return {};
     RadioActivity::Snapshot result = _activity_history.snapshot();
-    portEXIT_CRITICAL(&_activity_mux);
+    unlock_activity();
     return result;
 #else
     return _activity_history.snapshot();
@@ -302,9 +323,12 @@ void SX1262Interface::loop() {
                   "RSSI=" + std::to_string((int)_last_rssi) + " dBm, " +
                   "SNR=" + std::to_string((int)_last_snr) + " dB");
 
-            portENTER_CRITICAL(&_activity_mux);
-            _activity_history.mark_event(RadioActivity::Event::Rx);
-            portEXIT_CRITICAL(&_activity_mux);
+            // SPI is already released. Wait for the bounded history mutex so a
+            // real receive marker cannot be dropped behind a snapshot/catch-up.
+            if (lock_activity(portMAX_DELAY)) {
+                _activity_history.mark_event(RadioActivity::Event::Rx);
+                unlock_activity();
+            }
 
             on_incoming(payload);
             return;
@@ -372,9 +396,12 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
             (tx_duration_ms + ACTIVITY_SAMPLE_INTERVAL_MS - 1) /
             ACTIVITY_SAMPLE_INTERVAL_MS);
         if (tx_buckets == 0) tx_buckets = 1;
-        portENTER_CRITICAL(&_activity_mux);
-        _activity_history.mark_event(RadioActivity::Event::Tx, tx_buckets);
-        portEXIT_CRITICAL(&_activity_mux);
+        // SPI is already released. Wait for the bounded history mutex so a
+        // completed transmission duration cannot disappear from the timeline.
+        if (lock_activity(portMAX_DELAY)) {
+            _activity_history.mark_event(RadioActivity::Event::Tx, tx_buckets);
+            unlock_activity();
+        }
         // Perform post-send housekeeping
         InterfaceImpl::handle_outgoing(data);
         return true;

--- a/lib/sx1262_interface/SX1262Interface.cpp
+++ b/lib/sx1262_interface/SX1262Interface.cpp
@@ -183,6 +183,41 @@ void SX1262Interface::start_receive() {
 #endif
 }
 
+void SX1262Interface::sample_radio_activity(uint32_t now_ms) {
+#ifdef ARDUINO
+    if (!_online || _radio == nullptr || _spi_mutex == nullptr) return;
+    if (_transmitting) return;
+    if (now_ms - _last_activity_sample_ms < ACTIVITY_SAMPLE_INTERVAL_MS) return;
+
+    // Sampling is deliberately best-effort: display/SD/radio work always wins.
+    if (xSemaphoreTake(_spi_mutex, 0) != pdTRUE) return;
+    if (_transmitting) {
+        xSemaphoreGive(_spi_mutex);
+        return;
+    }
+    const float instantaneous_rssi = _radio->getRSSI(false);
+    xSemaphoreGive(_spi_mutex);
+
+    _last_activity_sample_ms = now_ms;
+    portENTER_CRITICAL(&_activity_mux);
+    _activity_history.record(static_cast<int16_t>(instantaneous_rssi));
+    portEXIT_CRITICAL(&_activity_mux);
+#else
+    (void)now_ms;
+#endif
+}
+
+RadioActivity::Snapshot SX1262Interface::radio_activity_snapshot() const {
+#ifdef ARDUINO
+    portENTER_CRITICAL(&_activity_mux);
+    RadioActivity::Snapshot result = _activity_history.snapshot();
+    portEXIT_CRITICAL(&_activity_mux);
+    return result;
+#else
+    return _activity_history.snapshot();
+#endif
+}
+
 void SX1262Interface::loop() {
     if (!_online) return;
 
@@ -228,6 +263,10 @@ void SX1262Interface::loop() {
             DEBUG("SX1262Interface: Received " + std::to_string(len) + " bytes, " +
                   "RSSI=" + std::to_string((int)_last_rssi) + " dBm, " +
                   "SNR=" + std::to_string((int)_last_snr) + " dB");
+
+            portENTER_CRITICAL(&_activity_mux);
+            _activity_history.record(static_cast<int16_t>(_last_rssi), RadioActivity::Event::Rx);
+            portEXIT_CRITICAL(&_activity_mux);
 
             on_incoming(payload);
             return;
@@ -289,6 +328,9 @@ bool SX1262Interface::send_outgoing(const Bytes& data) {
 
     if (state == RADIOLIB_ERR_NONE) {
         DEBUG("SX1262Interface: Sent " + std::to_string(len) + " bytes");
+        portENTER_CRITICAL(&_activity_mux);
+        _activity_history.mark_event(RadioActivity::Event::Tx);
+        portEXIT_CRITICAL(&_activity_mux);
         // Perform post-send housekeeping
         InterfaceImpl::handle_outgoing(data);
         return true;

--- a/lib/sx1262_interface/SX1262Interface.h
+++ b/lib/sx1262_interface/SX1262Interface.h
@@ -97,6 +97,10 @@ protected:
 private:
     void on_incoming(const RNS::Bytes& data);
     void start_receive();
+#ifdef ARDUINO
+    bool lock_activity(TickType_t timeout_ticks) const;
+    void unlock_activity() const;
+#endif
 
 #ifdef ARDUINO
     // RadioLib objects
@@ -109,7 +113,7 @@ private:
     // SPI mutex for shared bus with display
     static SemaphoreHandle_t _spi_mutex;
     static bool _mutex_initialized;
-    mutable portMUX_TYPE _activity_mux = portMUX_INITIALIZER_UNLOCKED;
+    mutable SemaphoreHandle_t _activity_mutex = nullptr;
 #endif
 
     // Configuration

--- a/lib/sx1262_interface/SX1262Interface.h
+++ b/lib/sx1262_interface/SX1262Interface.h
@@ -7,6 +7,7 @@
 #include <microReticulum/Bytes.h>
 #include <microReticulum/Type.h>
 #include <microReticulum/Cryptography/Random.h>
+#include "radio_activity/RadioActivityHistory.h"
 
 #ifdef ARDUINO
 #include <RadioLib.h>
@@ -78,6 +79,16 @@ public:
     float get_snr() const { return _last_snr; }
     bool is_transmitting() const { return _transmitting; }
 
+    /**
+     * Take one instantaneous current-channel RSSI sample. This is called by the
+     * application main loop only while the Radio Activity screen is visible.
+     * It never retunes and skips TX, cadence misses, and SPI contention.
+     */
+    void sample_radio_activity(uint32_t now_ms);
+
+    /** Copy the bounded history without touching the radio or SPI bus. */
+    RadioActivity::Snapshot radio_activity_snapshot() const;
+
     virtual std::string toString() const override;
 
 protected:
@@ -98,6 +109,7 @@ private:
     // SPI mutex for shared bus with display
     static SemaphoreHandle_t _spi_mutex;
     static bool _mutex_initialized;
+    mutable portMUX_TYPE _activity_mux = portMUX_INITIALIZER_UNLOCKED;
 #endif
 
     // Configuration
@@ -107,6 +119,9 @@ private:
     bool _transmitting = false;
     float _last_rssi = 0.0f;
     float _last_snr = 0.0f;
+    RadioActivity::History _activity_history;
+    uint32_t _last_activity_sample_ms = 0;
+    static constexpr uint32_t ACTIVITY_SAMPLE_INTERVAL_MS = 100;
 
     // Receive buffer
     RNS::Bytes _rx_buffer;

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
@@ -286,6 +286,9 @@ void RadioActivityScreen::on_chart_draw(lv_event_t* event) {
         trace_dsc.width = 2;
         trace_dsc.opa = LV_OPA_COVER;
         for (std::size_t i = 1; i < snapshot.count; ++i) {
+            if (!snapshot.samples[i - 1].rssi_valid || !snapshot.samples[i].rssi_valid) {
+                continue;
+            }
             lv_point_t p1 = {x_for(i - 1), y_for(snapshot.samples[i - 1].rssi_dbm)};
             lv_point_t p2 = {x_for(i), y_for(snapshot.samples[i].rssi_dbm)};
             lv_draw_line(draw_ctx, &trace_dsc, &p1, &p2);
@@ -301,7 +304,9 @@ void RadioActivityScreen::on_chart_draw(lv_event_t* event) {
             int32_t marker_x = static_cast<int32_t>(x_for(i)) + x_offset;
             if (marker_x < area.x1) marker_x = area.x1;
             if (marker_x > area.x2) marker_x = area.x2;
-            const lv_coord_t y1 = start_at_rssi ? y_for(sample.rssi_dbm) : area.y1;
+            const lv_coord_t y1 = start_at_rssi && sample.rssi_valid
+                ? y_for(sample.rssi_dbm)
+                : area.y1;
 
             lv_draw_line_dsc_t dsc;
             lv_draw_line_dsc_init(&dsc);

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
@@ -1,0 +1,325 @@
+#include "RadioActivityScreen.h"
+
+#ifdef ARDUINO
+
+#include "Theme.h"
+#include "../LVGL/LVGLInit.h"
+#include "../LVGL/LVGLLock.h"
+
+namespace UI {
+namespace LXMF {
+namespace {
+
+constexpr uint32_t RENDER_INTERVAL_MS = 143; // Seven frames per second.
+constexpr int16_t GRAPH_MIN_DBM = -135;
+constexpr int16_t GRAPH_MAX_DBM = -60;
+
+void style_panel(lv_obj_t* panel) {
+    lv_obj_set_style_bg_color(panel, Theme::surfaceInput(), 0);
+    lv_obj_set_style_bg_opa(panel, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_color(panel, Theme::border(), 0);
+    lv_obj_set_style_border_width(panel, 1, 0);
+    lv_obj_set_style_radius(panel, 4, 0);
+    lv_obj_set_style_pad_all(panel, 3, 0);
+}
+
+lv_obj_t* metric_panel(lv_obj_t* parent, int x, int width,
+                       const char* title, lv_obj_t** value) {
+    lv_obj_t* panel = lv_obj_create(parent);
+    lv_obj_set_pos(panel, x, 40);
+    lv_obj_set_size(panel, width, 34);
+    lv_obj_clear_flag(panel, LV_OBJ_FLAG_SCROLLABLE);
+    style_panel(panel);
+
+    lv_obj_t* heading = lv_label_create(panel);
+    lv_label_set_text(heading, title);
+    lv_obj_align(heading, LV_ALIGN_TOP_LEFT, 0, -1);
+    lv_obj_set_style_text_font(heading, &lv_font_montserrat_8, 0);
+    lv_obj_set_style_text_color(heading, Theme::textMuted(), 0);
+
+    *value = lv_label_create(panel);
+    lv_label_set_text(*value, "--");
+    lv_obj_align(*value, LV_ALIGN_BOTTOM_LEFT, 0, 1);
+    lv_obj_set_style_text_font(*value, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(*value, Theme::textPrimary(), 0);
+    return panel;
+}
+
+} // namespace
+
+RadioActivityScreen::RadioActivityScreen(lv_obj_t* parent) {
+    _screen = lv_obj_create(parent ? parent : lv_scr_act());
+    lv_obj_set_size(_screen, LV_PCT(100), LV_PCT(100));
+    lv_obj_clear_flag(_screen, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_color(_screen, Theme::surface(), 0);
+    lv_obj_set_style_bg_opa(_screen, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(_screen, 0, 0);
+    lv_obj_set_style_radius(_screen, 0, 0);
+    lv_obj_set_style_pad_all(_screen, 0, 0);
+
+    create_header();
+    create_metrics();
+    create_graph();
+    create_footer();
+    hide();
+}
+
+RadioActivityScreen::~RadioActivityScreen() {
+    LVGL_LOCK();
+    if (_screen) lv_obj_del(_screen);
+}
+
+void RadioActivityScreen::create_header() {
+    lv_obj_t* header = lv_obj_create(_screen);
+    lv_obj_set_pos(header, 0, 0);
+    lv_obj_set_size(header, 320, 36);
+    lv_obj_clear_flag(header, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_color(header, Theme::surfaceHeader(), 0);
+    lv_obj_set_style_border_width(header, 0, 0);
+    lv_obj_set_style_radius(header, 0, 0);
+    lv_obj_set_style_pad_all(header, 0, 0);
+
+    _btn_back = lv_btn_create(header);
+    lv_obj_set_size(_btn_back, 44, 28);
+    lv_obj_align(_btn_back, LV_ALIGN_LEFT_MID, 7, 0);
+    lv_obj_set_style_bg_color(_btn_back, Theme::btnSecondary(), 0);
+    lv_obj_set_style_border_color(_btn_back, Theme::border(), 0);
+    lv_obj_set_style_border_width(_btn_back, 1, 0);
+    lv_obj_add_event_cb(_btn_back, on_back_clicked, LV_EVENT_CLICKED, this);
+    lv_obj_t* back = lv_label_create(_btn_back);
+    lv_label_set_text(back, LV_SYMBOL_LEFT);
+    lv_obj_center(back);
+
+    lv_obj_t* title = lv_label_create(header);
+    lv_label_set_text(title, "Radio Activity");
+    lv_obj_align(title, LV_ALIGN_LEFT_MID, 60, 0);
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(title, Theme::textPrimary(), 0);
+
+    lv_obj_t* live = lv_label_create(header);
+    lv_label_set_text(live, LV_SYMBOL_BULLET " LIVE · 7 FPS");
+    lv_obj_align(live, LV_ALIGN_RIGHT_MID, -7, 0);
+    lv_obj_set_style_text_font(live, &lv_font_montserrat_8, 0);
+    lv_obj_set_style_text_color(live, Theme::success(), 0);
+}
+
+void RadioActivityScreen::create_metrics() {
+    metric_panel(_screen, 7, 100, "CURRENT", &_label_current);
+    metric_panel(_screen, 111, 100, "NOISE FLOOR", &_label_noise);
+    metric_panel(_screen, 215, 98, "CHANNEL LOAD", &_label_load);
+    lv_obj_set_style_text_color(_label_load, Theme::success(), 0);
+}
+
+void RadioActivityScreen::create_graph() {
+    lv_obj_t* graph_panel = lv_obj_create(_screen);
+    lv_obj_set_pos(graph_panel, 7, 78);
+    lv_obj_set_size(graph_panel, 306, 116);
+    lv_obj_clear_flag(graph_panel, LV_OBJ_FLAG_SCROLLABLE);
+    style_panel(graph_panel);
+    lv_obj_set_style_pad_all(graph_panel, 0, 0);
+
+    const char* scales[] = {"-60", "-100", "-135"};
+    const int ys[] = {3, 49, 98};
+    for (int i = 0; i < 3; ++i) {
+        lv_obj_t* label = lv_label_create(graph_panel);
+        lv_label_set_text(label, scales[i]);
+        lv_obj_set_pos(label, 3, ys[i]);
+        lv_obj_set_style_text_font(label, &lv_font_montserrat_8, 0);
+        lv_obj_set_style_text_color(label, Theme::textMuted(), 0);
+    }
+
+    // A plain draw object avoids both a full-screen canvas and LVGL's disabled
+    // chart widget. The callback emits only bounded line primitives.
+    _chart = lv_obj_create(graph_panel);
+    lv_obj_set_pos(_chart, 27, 3);
+    lv_obj_set_size(_chart, 276, 108);
+    lv_obj_clear_flag(_chart, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_bg_color(_chart, Theme::surface(), 0);
+    lv_obj_set_style_bg_opa(_chart, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(_chart, 0, 0);
+    lv_obj_set_style_radius(_chart, 0, 0);
+    lv_obj_set_style_pad_all(_chart, 0, 0);
+    lv_obj_add_event_cb(_chart, on_chart_draw, LV_EVENT_DRAW_POST_END, this);
+}
+
+void RadioActivityScreen::create_footer() {
+    lv_obj_t* legend = lv_label_create(_screen);
+    lv_label_set_text(legend, "■ Noise    ■ LoRa RX    ■ Other RF    ■ TX");
+    lv_obj_set_pos(legend, 9, 198);
+    lv_obj_set_style_text_font(legend, &lv_font_montserrat_8, 0);
+    lv_obj_set_style_text_color(legend, Theme::textTertiary(), 0);
+
+    _label_footer = lv_label_create(_screen);
+    lv_label_set_text(_label_footer, "Radio unavailable");
+    lv_obj_set_pos(_label_footer, 0, 220);
+    lv_obj_set_width(_label_footer, 320);
+    lv_obj_set_style_text_align(_label_footer, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_style_text_font(_label_footer, &lv_font_montserrat_8, 0);
+    lv_obj_set_style_text_color(_label_footer, Theme::textTertiary(), 0);
+}
+
+void RadioActivityScreen::render(const RadioActivity::Snapshot& snapshot,
+                                 const RadioConfig& config,
+                                 uint32_t now_ms) {
+    if (!_visible || now_ms - _last_render_ms < RENDER_INTERVAL_MS) return;
+    _last_render_ms = now_ms;
+
+    LVGL_LOCK();
+    _draw_snapshot = snapshot;
+
+    char text[64];
+    if (snapshot.count > 0) {
+        snprintf(text, sizeof(text), "%d dBm", snapshot.current_rssi);
+    } else {
+        snprintf(text, sizeof(text), "Warming up");
+    }
+    lv_label_set_text(_label_current, text);
+
+    if (snapshot.noise_floor_ready) {
+        snprintf(text, sizeof(text), "%d dBm", snapshot.noise_floor);
+    } else {
+        snprintf(text, sizeof(text), "Learning...");
+    }
+    lv_label_set_text(_label_noise, text);
+    snprintf(text, sizeof(text), "%u%%", snapshot.channel_load_percent);
+    lv_label_set_text(_label_load, text);
+
+    if (config.available) {
+        snprintf(text, sizeof(text), "%.3f MHz · BW %.1f kHz · SF%u · CR4/%u · %d dBm",
+                 config.frequency_mhz, config.bandwidth_khz,
+                 config.spreading_factor, config.coding_rate, config.tx_power_dbm);
+    } else {
+        snprintf(text, sizeof(text), "Radio unavailable");
+    }
+    lv_label_set_text(_label_footer, text);
+    lv_obj_invalidate(_chart);
+}
+
+void RadioActivityScreen::show() {
+    LVGL_LOCK();
+    _visible = true;
+    _last_render_ms = millis() - RENDER_INTERVAL_MS;
+    lv_obj_clear_flag(_screen, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(_screen);
+    lv_group_t* group = LVGL::LVGLInit::get_default_group();
+    if (group && _btn_back) {
+        lv_group_add_obj(group, _btn_back);
+        lv_group_focus_obj(_btn_back);
+    }
+}
+
+void RadioActivityScreen::hide() {
+    LVGL_LOCK();
+    _visible = false;
+    lv_group_t* group = LVGL::LVGLInit::get_default_group();
+    if (group && _btn_back) lv_group_remove_obj(_btn_back);
+    lv_obj_add_flag(_screen, LV_OBJ_FLAG_HIDDEN);
+}
+
+void RadioActivityScreen::set_back_callback(BackCallback callback) {
+    _back_callback = callback;
+}
+
+void RadioActivityScreen::on_back_clicked(lv_event_t* event) {
+    auto* screen = static_cast<RadioActivityScreen*>(lv_event_get_user_data(event));
+    if (screen && screen->_back_callback) screen->_back_callback();
+}
+
+void RadioActivityScreen::on_chart_draw(lv_event_t* event) {
+    auto* screen = static_cast<RadioActivityScreen*>(lv_event_get_user_data(event));
+    if (!screen || screen->_draw_snapshot.count == 0) return;
+
+    lv_draw_ctx_t* draw_ctx = lv_event_get_draw_ctx(event);
+    lv_area_t area;
+    lv_obj_get_content_coords(screen->_chart, &area);
+    const int32_t width = lv_area_get_width(&area) - 1;
+    const int32_t height = lv_area_get_height(&area) - 1;
+    const auto& snapshot = screen->_draw_snapshot;
+
+    auto x_for = [&](std::size_t index) -> lv_coord_t {
+        const std::size_t right_aligned = RadioActivity::History::CAPACITY - snapshot.count + index;
+        return static_cast<lv_coord_t>(area.x1 + static_cast<int32_t>(
+            right_aligned * width / (RadioActivity::History::CAPACITY - 1)));
+    };
+    auto y_for = [&](int16_t rssi) -> lv_coord_t {
+        if (rssi < GRAPH_MIN_DBM) rssi = GRAPH_MIN_DBM;
+        if (rssi > GRAPH_MAX_DBM) rssi = GRAPH_MAX_DBM;
+        return static_cast<lv_coord_t>(area.y1 + static_cast<int32_t>(
+            (GRAPH_MAX_DBM - rssi) * height / (GRAPH_MAX_DBM - GRAPH_MIN_DBM)));
+    };
+
+    lv_draw_line_dsc_t grid_dsc;
+    lv_draw_line_dsc_init(&grid_dsc);
+    grid_dsc.color = Theme::border();
+    grid_dsc.width = 1;
+    grid_dsc.opa = LV_OPA_30;
+    for (const int16_t dbm : {static_cast<int16_t>(-60), static_cast<int16_t>(-100),
+                              static_cast<int16_t>(-135)}) {
+        lv_point_t p1 = {area.x1, y_for(dbm)};
+        lv_point_t p2 = {area.x2, y_for(dbm)};
+        lv_draw_line(draw_ctx, &grid_dsc, &p1, &p2);
+    }
+    for (int division = 1; division < 4; ++division) {
+        const lv_coord_t x = static_cast<lv_coord_t>(area.x1 + width * division / 4);
+        lv_point_t p1 = {x, area.y1};
+        lv_point_t p2 = {x, area.y2};
+        lv_draw_line(draw_ctx, &grid_dsc, &p1, &p2);
+    }
+
+    if (snapshot.noise_floor_ready) {
+        lv_draw_line_dsc_t noise_dsc;
+        lv_draw_line_dsc_init(&noise_dsc);
+        noise_dsc.color = lv_color_hex(0xA98BAE);
+        noise_dsc.width = 1;
+        noise_dsc.opa = LV_OPA_60;
+        const lv_coord_t y = y_for(snapshot.noise_floor);
+        lv_point_t p1 = {area.x1, y};
+        lv_point_t p2 = {area.x2, y};
+        lv_draw_line(draw_ctx, &noise_dsc, &p1, &p2);
+    }
+
+    if (snapshot.count > 1) {
+        lv_draw_line_dsc_t trace_dsc;
+        lv_draw_line_dsc_init(&trace_dsc);
+        trace_dsc.color = lv_color_hex(0x675A70);
+        trace_dsc.width = 2;
+        trace_dsc.opa = LV_OPA_COVER;
+        for (std::size_t i = 1; i < snapshot.count; ++i) {
+            lv_point_t p1 = {x_for(i - 1), y_for(snapshot.samples[i - 1].rssi_dbm)};
+            lv_point_t p2 = {x_for(i), y_for(snapshot.samples[i].rssi_dbm)};
+            lv_draw_line(draw_ctx, &trace_dsc, &p1, &p2);
+        }
+    }
+
+    for (std::size_t i = 0; i < snapshot.count; ++i) {
+        const auto event_type = snapshot.samples[i].event;
+        if (event_type == RadioActivity::Event::Noise) continue;
+        const lv_coord_t x = x_for(i);
+        int32_t y1 = area.y1;
+        lv_color_t color = Theme::primaryLight();
+        uint8_t line_width = 2;
+        if (event_type == RadioActivity::Event::Rx) {
+            color = lv_color_hex(0x55966B);
+            y1 = y_for(snapshot.samples[i].rssi_dbm);
+        } else if (event_type == RadioActivity::Event::Interference) {
+            color = lv_color_hex(0xA98BAE);
+            y1 = y_for(snapshot.samples[i].rssi_dbm);
+        } else {
+            line_width = 3;
+        }
+
+        lv_draw_line_dsc_t dsc;
+        lv_draw_line_dsc_init(&dsc);
+        dsc.color = color;
+        dsc.width = line_width;
+        dsc.opa = LV_OPA_80;
+        lv_point_t points[2] = {{static_cast<lv_coord_t>(x), static_cast<lv_coord_t>(y1)},
+                                {static_cast<lv_coord_t>(x), area.y2}};
+        lv_draw_line(draw_ctx, &dsc, &points[0], &points[1]);
+    }
+}
+
+} // namespace LXMF
+} // namespace UI
+
+#endif // ARDUINO

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
@@ -97,7 +97,7 @@ void RadioActivityScreen::create_header() {
     lv_obj_set_style_text_color(title, Theme::textPrimary(), 0);
 
     lv_obj_t* live = lv_label_create(header);
-    lv_label_set_text(live, LV_SYMBOL_BULLET " LIVE · 7 FPS");
+    lv_label_set_text(live, LV_SYMBOL_BULLET " LIVE | 7 FPS");
     lv_obj_align(live, LV_ALIGN_RIGHT_MID, -7, 0);
     lv_obj_set_style_text_font(live, &lv_font_montserrat_8, 0);
     lv_obj_set_style_text_color(live, Theme::success(), 0);
@@ -144,7 +144,8 @@ void RadioActivityScreen::create_graph() {
 
 void RadioActivityScreen::create_footer() {
     lv_obj_t* legend = lv_label_create(_screen);
-    lv_label_set_text(legend, "■ Noise    ■ LoRa RX    ■ Other RF    ■ TX");
+    lv_label_set_text(legend, LV_SYMBOL_BULLET " Noise   " LV_SYMBOL_BULLET
+                      " LoRa RX   " LV_SYMBOL_BULLET " Other RF   " LV_SYMBOL_BULLET " TX");
     lv_obj_set_pos(legend, 9, 198);
     lv_obj_set_style_text_font(legend, &lv_font_montserrat_8, 0);
     lv_obj_set_style_text_color(legend, Theme::textTertiary(), 0);
@@ -185,7 +186,7 @@ void RadioActivityScreen::render(const RadioActivity::Snapshot& snapshot,
     lv_label_set_text(_label_load, text);
 
     if (config.available) {
-        snprintf(text, sizeof(text), "%.3f MHz · BW %.1f kHz · SF%u · CR4/%u · %d dBm",
+        snprintf(text, sizeof(text), "%.3f MHz | BW %.1f kHz | SF%u | CR4/%u | %d dBm",
                  config.frequency_mhz, config.bandwidth_khz,
                  config.spreading_factor, config.coding_rate, config.tx_power_dbm);
     } else {

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
@@ -293,30 +293,31 @@ void RadioActivityScreen::on_chart_draw(lv_event_t* event) {
     }
 
     for (std::size_t i = 0; i < snapshot.count; ++i) {
-        const auto event_type = snapshot.samples[i].event;
-        if (event_type == RadioActivity::Event::Noise) continue;
-        const lv_coord_t x = x_for(i);
-        int32_t y1 = area.y1;
-        lv_color_t color = Theme::primaryLight();
-        uint8_t line_width = 2;
-        if (event_type == RadioActivity::Event::Rx) {
-            color = lv_color_hex(0x55966B);
-            y1 = y_for(snapshot.samples[i].rssi_dbm);
-        } else if (event_type == RadioActivity::Event::Interference) {
-            color = lv_color_hex(0xA98BAE);
-            y1 = y_for(snapshot.samples[i].rssi_dbm);
-        } else {
-            line_width = 3;
-        }
+        const auto& sample = snapshot.samples[i];
+        auto draw_marker = [&](RadioActivity::Event event_type, int32_t x_offset,
+                               lv_color_t color, uint8_t line_width,
+                               bool start_at_rssi) {
+            if (!RadioActivity::has_event(sample, event_type)) return;
+            int32_t marker_x = static_cast<int32_t>(x_for(i)) + x_offset;
+            if (marker_x < area.x1) marker_x = area.x1;
+            if (marker_x > area.x2) marker_x = area.x2;
+            const lv_coord_t y1 = start_at_rssi ? y_for(sample.rssi_dbm) : area.y1;
 
-        lv_draw_line_dsc_t dsc;
-        lv_draw_line_dsc_init(&dsc);
-        dsc.color = color;
-        dsc.width = line_width;
-        dsc.opa = LV_OPA_80;
-        lv_point_t points[2] = {{static_cast<lv_coord_t>(x), static_cast<lv_coord_t>(y1)},
-                                {static_cast<lv_coord_t>(x), area.y2}};
-        lv_draw_line(draw_ctx, &dsc, &points[0], &points[1]);
+            lv_draw_line_dsc_t dsc;
+            lv_draw_line_dsc_init(&dsc);
+            dsc.color = color;
+            dsc.width = line_width;
+            dsc.opa = LV_OPA_80;
+            lv_point_t points[2] = {
+                {static_cast<lv_coord_t>(marker_x), y1},
+                {static_cast<lv_coord_t>(marker_x), area.y2},
+            };
+            lv_draw_line(draw_ctx, &dsc, &points[0], &points[1]);
+        };
+
+        draw_marker(RadioActivity::Event::Rx, -1, lv_color_hex(0x55966B), 2, true);
+        draw_marker(RadioActivity::Event::Interference, 0, lv_color_hex(0xA98BAE), 2, true);
+        draw_marker(RadioActivity::Event::Tx, 1, Theme::primaryLight(), 3, false);
     }
 }
 

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.cpp
@@ -143,12 +143,27 @@ void RadioActivityScreen::create_graph() {
 }
 
 void RadioActivityScreen::create_footer() {
-    lv_obj_t* legend = lv_label_create(_screen);
-    lv_label_set_text(legend, LV_SYMBOL_BULLET " Noise   " LV_SYMBOL_BULLET
-                      " LoRa RX   " LV_SYMBOL_BULLET " Other RF   " LV_SYMBOL_BULLET " TX");
-    lv_obj_set_pos(legend, 9, 198);
-    lv_obj_set_style_text_font(legend, &lv_font_montserrat_8, 0);
-    lv_obj_set_style_text_color(legend, Theme::textTertiary(), 0);
+    auto style_legend = [](lv_obj_t* label, int x, lv_color_t color) {
+        lv_obj_set_pos(label, x, 198);
+        lv_obj_set_style_text_font(label, &lv_font_montserrat_8, 0);
+        lv_obj_set_style_text_color(label, color, 0);
+    };
+
+    lv_obj_t* legend_noise = lv_label_create(_screen);
+    lv_label_set_text(legend_noise, LV_SYMBOL_BULLET " Noise");
+    style_legend(legend_noise, 9, lv_color_hex(0x675A70));
+
+    lv_obj_t* legend_rx = lv_label_create(_screen);
+    lv_label_set_text(legend_rx, LV_SYMBOL_BULLET " LoRa RX");
+    style_legend(legend_rx, 72, lv_color_hex(0x55966B));
+
+    lv_obj_t* legend_other = lv_label_create(_screen);
+    lv_label_set_text(legend_other, LV_SYMBOL_BULLET " Other RF");
+    style_legend(legend_other, 155, lv_color_hex(0xA98BAE));
+
+    lv_obj_t* legend_tx = lv_label_create(_screen);
+    lv_label_set_text(legend_tx, LV_SYMBOL_BULLET " TX");
+    style_legend(legend_tx, 264, Theme::primaryLight());
 
     _label_footer = lv_label_create(_screen);
     lv_label_set_text(_label_footer, "Radio unavailable");
@@ -162,17 +177,17 @@ void RadioActivityScreen::create_footer() {
 void RadioActivityScreen::render(const RadioActivity::Snapshot& snapshot,
                                  const RadioConfig& config,
                                  uint32_t now_ms) {
-    if (!_visible || now_ms - _last_render_ms < RENDER_INTERVAL_MS) return;
+    if (!render_due(now_ms)) return;
     _last_render_ms = now_ms;
 
     LVGL_LOCK();
     _draw_snapshot = snapshot;
 
     char text[64];
-    if (snapshot.count > 0) {
+    if (snapshot.current_rssi_valid) {
         snprintf(text, sizeof(text), "%d dBm", snapshot.current_rssi);
     } else {
-        snprintf(text, sizeof(text), "Warming up");
+        snprintf(text, sizeof(text), "-- dBm");
     }
     lv_label_set_text(_label_current, text);
 
@@ -194,6 +209,10 @@ void RadioActivityScreen::render(const RadioActivity::Snapshot& snapshot,
     }
     lv_label_set_text(_label_footer, text);
     lv_obj_invalidate(_chart);
+}
+
+bool RadioActivityScreen::render_due(uint32_t now_ms) const {
+    return _visible && now_ms - _last_render_ms >= RENDER_INTERVAL_MS;
 }
 
 void RadioActivityScreen::show() {

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.h
@@ -33,6 +33,7 @@ public:
     void show();
     void hide();
     bool visible() const { return _visible; }
+    bool render_due(uint32_t now_ms) const;
 
 private:
     lv_obj_t* _screen = nullptr;

--- a/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/RadioActivityScreen.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#ifdef ARDUINO
+
+#include <Arduino.h>
+#include <functional>
+#include <lvgl.h>
+#include "radio_activity/RadioActivityHistory.h"
+
+namespace UI {
+namespace LXMF {
+
+class RadioActivityScreen {
+public:
+    struct RadioConfig {
+        float frequency_mhz = 0.0f;
+        float bandwidth_khz = 0.0f;
+        uint8_t spreading_factor = 0;
+        uint8_t coding_rate = 0;
+        int8_t tx_power_dbm = 0;
+        bool available = false;
+    };
+
+    using BackCallback = std::function<void()>;
+
+    explicit RadioActivityScreen(lv_obj_t* parent = nullptr);
+    ~RadioActivityScreen();
+
+    void set_back_callback(BackCallback callback);
+    void render(const RadioActivity::Snapshot& snapshot,
+                const RadioConfig& config,
+                uint32_t now_ms);
+    void show();
+    void hide();
+    bool visible() const { return _visible; }
+
+private:
+    lv_obj_t* _screen = nullptr;
+    lv_obj_t* _btn_back = nullptr;
+    lv_obj_t* _chart = nullptr;
+    lv_obj_t* _label_current = nullptr;
+    lv_obj_t* _label_noise = nullptr;
+    lv_obj_t* _label_load = nullptr;
+    lv_obj_t* _label_footer = nullptr;
+    RadioActivity::Snapshot _draw_snapshot{};
+    BackCallback _back_callback;
+    uint32_t _last_render_ms = 0;
+    bool _visible = false;
+
+    void create_header();
+    void create_metrics();
+    void create_graph();
+    void create_footer();
+    static void on_back_clicked(lv_event_t* event);
+    static void on_chart_draw(lv_event_t* event);
+};
+
+} // namespace LXMF
+} // namespace UI
+
+#endif // ARDUINO

--- a/lib/tdeck_ui/UI/LXMF/StatusScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/StatusScreen.cpp
@@ -18,7 +18,7 @@ namespace LXMF {
 
 StatusScreen::StatusScreen(lv_obj_t* parent)
     : _screen(nullptr), _header(nullptr), _content(nullptr), _btn_back(nullptr),
-      _btn_share(nullptr), _label_uptime(nullptr),
+      _btn_share(nullptr), _btn_radio_activity(nullptr), _label_uptime(nullptr),
       _label_identity_value(nullptr), _label_lxmf_value(nullptr),
       _label_wifi_status(nullptr), _label_wifi_ip(nullptr), _label_wifi_rssi(nullptr),
       _label_rns_status(nullptr), _label_prop_node(nullptr), _label_ble_header(nullptr),
@@ -117,6 +117,17 @@ void StatusScreen::create_content() {
     lv_obj_set_flex_align(_content, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     lv_obj_set_scroll_dir(_content, LV_DIR_VER);
     lv_obj_set_scrollbar_mode(_content, LV_SCROLLBAR_MODE_AUTO);
+
+    // Radio telemetry is a child of Status, not a persistent fifth nav tab.
+    _btn_radio_activity = lv_btn_create(_content);
+    lv_obj_set_size(_btn_radio_activity, LV_PCT(100), 34);
+    lv_obj_set_style_bg_color(_btn_radio_activity, Theme::surfaceInput(), 0);
+    lv_obj_set_style_bg_color(_btn_radio_activity, Theme::surfaceElevated(), LV_STATE_PRESSED);
+    lv_obj_add_event_cb(_btn_radio_activity, on_radio_activity_clicked, LV_EVENT_CLICKED, this);
+    lv_obj_t* radio_label = lv_label_create(_btn_radio_activity);
+    lv_label_set_text(radio_label, "Radio Activity  " LV_SYMBOL_RIGHT);
+    lv_obj_align(radio_label, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_set_style_text_color(radio_label, Theme::textPrimary(), 0);
 
     // Uptime section
     _label_uptime = lv_label_create(_content);
@@ -356,6 +367,10 @@ void StatusScreen::set_share_callback(ShareCallback callback) {
     _share_callback = callback;
 }
 
+void StatusScreen::set_radio_activity_callback(RadioActivityCallback callback) {
+    _radio_activity_callback = callback;
+}
+
 void StatusScreen::show() {
     LVGL_LOCK();
     refresh();  // Update status when shown
@@ -371,6 +386,9 @@ void StatusScreen::show() {
         if (_btn_share) {
             lv_group_add_obj(group, _btn_share);
         }
+        if (_btn_radio_activity) {
+            lv_group_add_obj(group, _btn_radio_activity);
+        }
         lv_group_focus_obj(_btn_back);
     }
 }
@@ -385,6 +403,9 @@ void StatusScreen::hide() {
         }
         if (_btn_share) {
             lv_group_remove_obj(_btn_share);
+        }
+        if (_btn_radio_activity) {
+            lv_group_remove_obj(_btn_radio_activity);
         }
     }
 
@@ -408,6 +429,13 @@ void StatusScreen::on_share_clicked(lv_event_t* event) {
 
     if (screen->_share_callback) {
         screen->_share_callback();
+    }
+}
+
+void StatusScreen::on_radio_activity_clicked(lv_event_t* event) {
+    StatusScreen* screen = static_cast<StatusScreen*>(lv_event_get_user_data(event));
+    if (screen && screen->_radio_activity_callback) {
+        screen->_radio_activity_callback();
     }
 }
 

--- a/lib/tdeck_ui/UI/LXMF/StatusScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/StatusScreen.h
@@ -45,6 +45,7 @@ class StatusScreen {
 public:
     using BackCallback = std::function<void()>;
     using ShareCallback = std::function<void()>;
+    using RadioActivityCallback = std::function<void()>;
 
     /**
      * Create status screen
@@ -116,6 +117,9 @@ public:
      */
     void set_share_callback(ShareCallback callback);
 
+    /** Open the dedicated current-channel Radio Activity screen. */
+    void set_radio_activity_callback(RadioActivityCallback callback);
+
     /**
      * Show the screen
      */
@@ -137,6 +141,7 @@ private:
     lv_obj_t* _content;
     lv_obj_t* _btn_back;
     lv_obj_t* _btn_share;
+    lv_obj_t* _btn_radio_activity;
 
     // Labels for dynamic content
     lv_obj_t* _label_uptime;
@@ -164,6 +169,7 @@ private:
 
     BackCallback _back_callback;
     ShareCallback _share_callback;
+    RadioActivityCallback _radio_activity_callback;
 
     void create_header();
     void create_content();
@@ -171,6 +177,7 @@ private:
 
     static void on_back_clicked(lv_event_t* event);
     static void on_share_clicked(lv_event_t* event);
+    static void on_radio_activity_clicked(lv_event_t* event);
 };
 
 } // namespace LXMF

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -96,6 +96,7 @@ UIManager::UIManager(Reticulum& reticulum, ::LXMF::LXMRouter& router, ::LXMF::Me
       _compose_screen(nullptr),
       _announce_list_screen(nullptr),
       _status_screen(nullptr),
+      _radio_activity_screen(nullptr),
       _qr_screen(nullptr),
       _settings_screen(nullptr),
       _propagation_nodes_screen(nullptr),
@@ -136,6 +137,7 @@ UIManager::~UIManager() {
     if (_compose_screen) delete _compose_screen;
     if (_announce_list_screen) delete _announce_list_screen;
     if (_status_screen) delete _status_screen;
+    if (_radio_activity_screen) delete _radio_activity_screen;
     if (_qr_screen) delete _qr_screen;
     if (_settings_screen) delete _settings_screen;
     if (_propagation_nodes_screen) delete _propagation_nodes_screen;
@@ -156,6 +158,7 @@ bool UIManager::init() {
     _compose_screen = new ComposeScreen();
     _announce_list_screen = new AnnounceListScreen();
     _status_screen = new StatusScreen();
+    _radio_activity_screen = new RadioActivityScreen();
     _qr_screen = new QRScreen();
     _settings_screen = new SettingsScreen();
     _propagation_nodes_screen = new PropagationNodesScreen();
@@ -235,6 +238,14 @@ bool UIManager::init() {
 
     _status_screen->set_share_callback(
         [this]() { on_share_from_status(); }
+    );
+
+    _status_screen->set_radio_activity_callback(
+        [this]() { show_radio_activity(); }
+    );
+
+    _radio_activity_screen->set_back_callback(
+        [this]() { on_back_from_radio_activity(); }
     );
 
     // Set up callbacks for QR screen
@@ -379,6 +390,13 @@ void UIManager::update() {
     if (_current_screen == SCREEN_SETTINGS && _settings_screen) {
         _settings_screen->tick();  // keep the live clock / GPS / system readouts ticking
     }
+    // Snapshot acquisition is deliberately before LVGL_LOCK. The provider only
+    // copies the bounded history; RadioActivityScreen::render owns LVGL work.
+    if (_current_screen == SCREEN_RADIO_ACTIVITY &&
+        _radio_activity_screen && _radio_activity_snapshot_provider) {
+        const RadioActivity::Snapshot snapshot = _radio_activity_snapshot_provider();
+        _radio_activity_screen->render(snapshot, _radio_activity_config, millis());
+    }
     LVGL_LOCK();
 
     // Outgoing starts are initiated here while the recursive LVGL mutex is
@@ -464,6 +482,7 @@ void UIManager::show_conversation_list() {
     _compose_screen->hide();
     _announce_list_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _settings_screen->hide();
     _propagation_nodes_screen->hide();
     if (_call_screen) _call_screen->hide();
@@ -485,6 +504,7 @@ void UIManager::show_chat(const Bytes& peer_hash) {
     _compose_screen->hide();
     _announce_list_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _settings_screen->hide();
     _propagation_nodes_screen->hide();
     if (_call_screen) _call_screen->hide();
@@ -502,6 +522,7 @@ void UIManager::show_compose() {
     _chat_screen->hide();
     _announce_list_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _settings_screen->hide();
     _propagation_nodes_screen->hide();
 
@@ -518,6 +539,7 @@ void UIManager::show_announces() {
     _chat_screen->hide();
     _compose_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _settings_screen->hide();
     _propagation_nodes_screen->hide();
 
@@ -580,8 +602,32 @@ void UIManager::show_status() {
     _announce_list_screen->hide();
     _settings_screen->hide();
     _propagation_nodes_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
 
     _current_screen = SCREEN_STATUS;
+}
+
+void UIManager::show_radio_activity() {
+    LVGL_LOCK();
+    INFO("Showing Radio Activity screen");
+
+    _conversation_list_screen->hide();
+    _chat_screen->hide();
+    _compose_screen->hide();
+    _announce_list_screen->hide();
+    _status_screen->hide();
+    _settings_screen->hide();
+    _propagation_nodes_screen->hide();
+    if (_call_screen) _call_screen->hide();
+    _radio_activity_screen->show();
+    _current_screen = SCREEN_RADIO_ACTIVITY;
+}
+
+void UIManager::set_radio_activity_source(
+    std::function<RadioActivity::Snapshot()> snapshot_provider,
+    const RadioActivityScreen::RadioConfig& config) {
+    _radio_activity_snapshot_provider = std::move(snapshot_provider);
+    _radio_activity_config = config;
 }
 
 void UIManager::on_conversation_selected(const Bytes& peer_hash) {
@@ -603,6 +649,7 @@ void UIManager::show_settings() {
     _compose_screen->hide();
     _announce_list_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _propagation_nodes_screen->hide();
 
     _current_screen = SCREEN_SETTINGS;
@@ -641,6 +688,7 @@ void UIManager::show_propagation_nodes() {
     _compose_screen->hide();
     _announce_list_screen->hide();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _settings_screen->hide();
 
     _current_screen = SCREEN_PROPAGATION_NODES;
@@ -722,9 +770,14 @@ void UIManager::on_back_from_status() {
     show_conversation_list();
 }
 
+void UIManager::on_back_from_radio_activity() {
+    show_status();
+}
+
 void UIManager::on_share_from_status() {
     LVGL_LOCK();
     _status_screen->hide();
+    if (_radio_activity_screen) _radio_activity_screen->hide();
     _qr_screen->show();
     _current_screen = SCREEN_QR;
 }

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -390,12 +390,14 @@ void UIManager::update() {
     if (_current_screen == SCREEN_SETTINGS && _settings_screen) {
         _settings_screen->tick();  // keep the live clock / GPS / system readouts ticking
     }
-    // Snapshot acquisition is deliberately before LVGL_LOCK. The provider only
-    // copies the bounded history; RadioActivityScreen::render owns LVGL work.
+    const uint32_t now = millis();
+    // Snapshot acquisition is deliberately before LVGL_LOCK and is coalesced
+    // to the screen's render cadence. The provider never touches radio or SPI.
     if (_current_screen == SCREEN_RADIO_ACTIVITY &&
-        _radio_activity_screen && _radio_activity_snapshot_provider) {
+        _radio_activity_screen && _radio_activity_snapshot_provider &&
+        _radio_activity_screen->render_due(now)) {
         const RadioActivity::Snapshot snapshot = _radio_activity_snapshot_provider();
-        _radio_activity_screen->render(snapshot, _radio_activity_config, millis());
+        _radio_activity_screen->render(snapshot, _radio_activity_config, now);
     }
     LVGL_LOCK();
 
@@ -440,7 +442,6 @@ void UIManager::update() {
 
     // Update status indicators (WiFi/battery) on conversation list
     static uint32_t last_status_update = 0;
-    uint32_t now = millis();
     if (now - last_status_update > 3000) {  // Update every 3 seconds
         last_status_update = now;
         if (_conversation_list_screen) {

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -14,6 +14,7 @@
 #include "ComposeScreen.h"
 #include "AnnounceListScreen.h"
 #include "StatusScreen.h"
+#include "RadioActivityScreen.h"
 #include "QRScreen.h"
 #include "SettingsScreen.h"
 #include "PropagationNodesScreen.h"
@@ -120,6 +121,17 @@ public:
      * Show status screen
      */
     void show_status();
+
+    /** Show current-channel activity history from the Status screen. */
+    void show_radio_activity();
+
+    /** True only while sampling/rendering the dedicated activity screen. */
+    bool radio_activity_visible() const { return _current_screen == SCREEN_RADIO_ACTIVITY; }
+
+    /** Install a copied snapshot provider and immutable active RF settings. */
+    void set_radio_activity_source(
+        std::function<RadioActivity::Snapshot()> snapshot_provider,
+        const RadioActivityScreen::RadioConfig& config);
 
     /**
      * Show settings screen
@@ -288,6 +300,7 @@ private:
         SCREEN_COMPOSE,
         SCREEN_ANNOUNCES,
         SCREEN_STATUS,
+        SCREEN_RADIO_ACTIVITY,
         SCREEN_QR,
         SCREEN_SETTINGS,
         SCREEN_PROPAGATION_NODES,
@@ -317,10 +330,13 @@ private:
     ComposeScreen* _compose_screen;
     AnnounceListScreen* _announce_list_screen;
     StatusScreen* _status_screen;
+    RadioActivityScreen* _radio_activity_screen;
     QRScreen* _qr_screen;
     SettingsScreen* _settings_screen;
     PropagationNodesScreen* _propagation_nodes_screen;
     CallScreen* _call_screen;
+    std::function<RadioActivity::Snapshot()> _radio_activity_snapshot_provider;
+    RadioActivityScreen::RadioConfig _radio_activity_config;
 
     ::LXMF::PropagationNodeManager* _propagation_manager;
     RNS::Interface* _ble_interface;
@@ -339,6 +355,7 @@ private:
     void on_back_from_announces();
     void on_back_from_status();
     void on_share_from_status();
+    void on_back_from_radio_activity();
     void on_back_from_qr();
     void on_back_from_settings();
     void on_back_from_propagation_nodes();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1298,6 +1298,28 @@ void setup_lxmf() {
     INFO(msg.c_str());
 }
 
+void update_radio_activity_source() {
+    if (!ui_manager) return;
+
+    UI::LXMF::RadioActivityScreen::RadioConfig display_config;
+    if (lora_interface_impl) {
+        const SX1262Config& config = lora_interface_impl->get_config();
+        display_config.frequency_mhz = config.frequency;
+        display_config.bandwidth_khz = config.bandwidth;
+        display_config.spreading_factor = config.spreading_factor;
+        display_config.coding_rate = config.coding_rate;
+        display_config.tx_power_dbm = config.tx_power;
+        display_config.available = lora_interface && lora_interface->online();
+    }
+    ui_manager->set_radio_activity_source(
+        []() {
+            return lora_interface_impl
+                ? lora_interface_impl->radio_activity_snapshot()
+                : RadioActivity::Snapshot{};
+        },
+        display_config);
+}
+
 void setup_ui_manager() {
     INFO("\n=== UI Manager Initialization ===");
 
@@ -1308,6 +1330,7 @@ void setup_ui_manager() {
         ERROR("UI manager initialization failed!");
         while (1) delay(1000);
     }
+    update_radio_activity_source();
 
     // Set initial RNS connection status (check all interfaces)
     {
@@ -1479,6 +1502,7 @@ void setup_ui_manager() {
                 } else {
                     INFO("LoRa interface disabled");
                 }
+                update_radio_activity_source();
             }
 
             // Handle Auto interface changes at runtime
@@ -2744,6 +2768,12 @@ void loop() {
     // Process Reticulum
     LOOP_STEP(4);  // reticulum->loop()
     reticulum->loop();
+
+    // Best-effort instantaneous RSSI sampling is main-loop owned and enabled
+    // only for the dedicated view. The interface skips TX and SPI contention.
+    if (lora_interface_impl && ui_manager && ui_manager->radio_activity_visible()) {
+        lora_interface_impl->sample_radio_activity(millis());
+    }
 
     // Pump TX audio immediately after Reticulum — low-latency path that
     // bypasses LVGL lock and all other loop steps.  No-ops when not in a call.

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -1,0 +1,73 @@
+#include <cstdint>
+#include <iostream>
+
+#include "RadioActivityHistory.h"
+
+using RadioActivity::Event;
+using RadioActivity::History;
+
+int main() {
+    int passed = 0;
+    int failed = 0;
+
+    auto check = [&](const char* name, bool condition) {
+        if (condition) {
+            ++passed;
+        } else {
+            ++failed;
+            std::cerr << "FAIL: " << name << "\n";
+        }
+    };
+
+    History history;
+    for (std::size_t i = 0; i < History::CAPACITY + 5; ++i) {
+        history.record(-130 + static_cast<int16_t>(i % 3));
+    }
+    auto bounded = history.snapshot();
+    check("history has fixed capacity", bounded.count == History::CAPACITY);
+    check("snapshot is chronological after wrap",
+          bounded.samples[0].sequence == 5 &&
+          bounded.samples[bounded.count - 1].sequence == History::CAPACITY + 4);
+
+    History baseline;
+    baseline.record(-121);
+    baseline.record(-120);
+    baseline.record(-119);
+    baseline.record(-120);
+    auto learned = baseline.snapshot();
+    check("noise floor becomes ready from accepted samples", learned.noise_floor_ready);
+    check("noise floor learns a stable baseline", learned.noise_floor == -120);
+
+    baseline.record(-95);
+    auto interference = baseline.snapshot();
+    check("sample above noise threshold is interference",
+          interference.samples[interference.count - 1].event == Event::Interference);
+    check("interference does not raise learned noise floor", interference.noise_floor == -120);
+
+    baseline.record(-112);
+    auto accepted = baseline.snapshot();
+    check("sample within eleven dB is accepted as noise",
+          accepted.samples[accepted.count - 1].event == Event::Noise);
+    check("accepted sample updates bounded noise estimator", accepted.noise_floor > -120);
+
+    History events;
+    events.record(-118, Event::Rx);
+    events.mark_event(Event::Tx);
+    events.record(-119);
+    auto marked = events.snapshot();
+    check("decoded receive metadata is preserved", marked.samples[0].event == Event::Rx);
+    check("pending transmit metadata is attached to next sample", marked.samples[1].event == Event::Tx);
+    check("channel load counts activity", marked.channel_load_percent == 100);
+
+    History clamped;
+    clamped.record(-200);
+    clamped.record(20);
+    auto limits = clamped.snapshot();
+    check("RSSI is clamped to graph bounds",
+          limits.samples[0].rssi_dbm == History::MIN_RSSI_DBM &&
+          limits.samples[1].rssi_dbm == History::MAX_RSSI_DBM);
+    check("channel load is bounded", limits.channel_load_percent <= 100);
+
+    std::cout << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -62,6 +62,49 @@ int main() {
     check("receive metadata shares the next bucket", has_event(marked.samples[0], Event::Rx));
     check("channel load counts activity", marked.channel_load_percent == 100);
 
+    History skipped;
+    skipped.mark_event(Event::Tx, 3);
+    skipped.record_gap();
+    skipped.record_gap();
+    skipped.record_gap();
+    auto tx_gap = skipped.snapshot();
+    check("skipped cadence buckets are represented", tx_gap.count == 3);
+    check("TX duration spans every queued bucket",
+          has_event(tx_gap.samples[0], Event::Tx) &&
+          has_event(tx_gap.samples[1], Event::Tx) &&
+          has_event(tx_gap.samples[2], Event::Tx));
+    check("gap buckets do not invent RSSI", !tx_gap.samples[0].rssi_valid);
+    check("TX gap buckets contribute to load", tx_gap.channel_load_percent == 100);
+
+    History aligned;
+    aligned.mark_event(Event::Tx, 2);
+    aligned.record_gap(false);
+    aligned.record_gap();
+    aligned.record(-100);
+    auto right_aligned = aligned.snapshot();
+    check("pending duration does not mark older catch-up gaps",
+          !has_event(right_aligned.samples[0], Event::Tx));
+    check("pending duration is right-aligned to current time",
+          has_event(right_aligned.samples[1], Event::Tx) &&
+          has_event(right_aligned.samples[2], Event::Tx));
+
+    History rx_burst;
+    rx_burst.mark_event(Event::Rx);
+    rx_burst.mark_event(Event::Rx);
+    rx_burst.record(-110);
+    rx_burst.record(-120);
+    auto rx_bucket = rx_burst.snapshot();
+    check("multiple RX events coalesce within one cadence bucket",
+          has_event(rx_bucket.samples[0], Event::Rx));
+    check("coalesced RX does not spill into a future bucket",
+          !has_event(rx_bucket.samples[1], Event::Rx));
+
+    History unknown_gap;
+    unknown_gap.record_gap();
+    auto unknown = unknown_gap.snapshot();
+    check("unknown contention gap advances time without activity",
+          unknown.count == 1 && unknown.channel_load_percent == 0);
+
     History clamped;
     clamped.record(-200);
     clamped.record(20);

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -5,6 +5,7 @@
 
 using RadioActivity::Event;
 using RadioActivity::History;
+using RadioActivity::has_event;
 
 int main() {
     int passed = 0;
@@ -41,22 +42,24 @@ int main() {
     baseline.record(-95);
     auto interference = baseline.snapshot();
     check("sample above noise threshold is interference",
-          interference.samples[interference.count - 1].event == Event::Interference);
+          has_event(interference.samples[interference.count - 1], Event::Interference));
     check("interference does not raise learned noise floor", interference.noise_floor == -120);
 
     baseline.record(-112);
     auto accepted = baseline.snapshot();
     check("sample within eleven dB is accepted as noise",
-          accepted.samples[accepted.count - 1].event == Event::Noise);
+          accepted.samples[accepted.count - 1].events == 0);
     check("accepted sample updates bounded noise estimator", accepted.noise_floor > -120);
 
     History events;
     events.mark_event(Event::Tx);
-    events.record(-118, Event::Rx);
+    events.mark_event(Event::Rx);
+    check("events do not append off-cadence samples", events.snapshot().count == 0);
+    events.record(-118);
     auto marked = events.snapshot();
-    check("transmit metadata is recorded immediately", marked.samples[0].event == Event::Tx);
-    check("decoded receive metadata is preserved", marked.samples[1].event == Event::Rx);
-    check("receive does not erase prior transmit marker", marked.count == 2);
+    check("events share one fixed-cadence bucket", marked.count == 1);
+    check("transmit metadata survives until the next bucket", has_event(marked.samples[0], Event::Tx));
+    check("receive metadata shares the next bucket", has_event(marked.samples[0], Event::Rx));
     check("channel load counts activity", marked.channel_load_percent == 100);
 
     History clamped;

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -104,6 +104,12 @@ int main() {
     auto unknown = unknown_gap.snapshot();
     check("unknown contention gap advances time without activity",
           unknown.count == 1 && unknown.channel_load_percent == 0);
+    check("newest gap makes current RSSI unavailable", !unknown.current_rssi_valid);
+
+    unknown_gap.record(-101);
+    auto current = unknown_gap.snapshot();
+    check("newest measured bucket makes current RSSI valid", current.current_rssi_valid);
+    check("current RSSI comes from the newest measured bucket", current.current_rssi == -101);
 
     History clamped;
     clamped.record(-200);

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -51,12 +51,12 @@ int main() {
     check("accepted sample updates bounded noise estimator", accepted.noise_floor > -120);
 
     History events;
-    events.record(-118, Event::Rx);
     events.mark_event(Event::Tx);
-    events.record(-119);
+    events.record(-118, Event::Rx);
     auto marked = events.snapshot();
-    check("decoded receive metadata is preserved", marked.samples[0].event == Event::Rx);
-    check("pending transmit metadata is attached to next sample", marked.samples[1].event == Event::Tx);
+    check("transmit metadata is recorded immediately", marked.samples[0].event == Event::Tx);
+    check("decoded receive metadata is preserved", marked.samples[1].event == Event::Rx);
+    check("receive does not erase prior transmit marker", marked.count == 2);
     check("channel load counts activity", marked.channel_load_percent == 100);
 
     History clamped;

--- a/tests/native/test_radio_activity.cpp
+++ b/tests/native/test_radio_activity.cpp
@@ -120,6 +120,27 @@ int main() {
           limits.samples[1].rssi_dbm == History::MAX_RSSI_DBM);
     check("channel load is bounded", limits.channel_load_percent <= 100);
 
+    History resettable;
+    resettable.record(-121);
+    resettable.record(-120);
+    resettable.record(-119);
+    resettable.record(-120);
+    resettable.mark_event(Event::Tx);
+    const uint32_t prior_generation = resettable.generation();
+    resettable.reset();
+    auto cleared = resettable.snapshot();
+    check("reset clears samples", cleared.count == 0);
+    check("reset invalidates current RSSI", !cleared.current_rssi_valid);
+    check("reset clears learned noise floor", !cleared.noise_floor_ready);
+    check("reset clears channel load", cleared.channel_load_percent == 0);
+    check("reset advances the current-channel generation",
+          resettable.generation() != prior_generation);
+    resettable.record(-100);
+    auto after_reset = resettable.snapshot();
+    check("reset clears pending events and restarts sequence",
+          after_reset.samples[0].events == 0 &&
+          after_reset.samples[0].sequence == 0);
+
     std::cout << passed << " passed, " << failed << " failed\n";
     return failed == 0 ? 0 : 1;
 }

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -43,7 +43,7 @@ def test_radio_activity_history_native(tmp_path):
 
     result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stdout.strip() == "15 passed, 0 failed"
+    assert result.stdout.strip() == "24 passed, 0 failed"
 
 
 def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
@@ -55,6 +55,9 @@ def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
     assert "_radio->getRSSI(false)" in sx_cpp
     assert "xSemaphoreTake(_spi_mutex, 0)" in sx_cpp
     assert "if (_transmitting)" in sx_cpp
+    assert "record_gap" in sx_cpp
+    assert "elapsed / ACTIVITY_SAMPLE_INTERVAL_MS" in sx_cpp
+    assert "_last_activity_sample_ms +=" in sx_cpp
     assert "sample_radio_activity" in main_cpp
     assert "radio_activity_visible()" in main_cpp
     assert "setFrequency" not in sx_cpp
@@ -76,6 +79,7 @@ def test_ui_contract_uses_dedicated_status_child_and_snapshot_only_rendering():
     assert "lv_canvas" not in screen_cpp
     assert "lv_chart" not in screen_cpp
     assert "lv_draw_line" in screen_cpp
+    assert "rssi_valid" in screen_cpp
     assert " · " not in screen_cpp
     assert "■" not in screen_cpp
     assert " | " in screen_cpp

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -43,7 +43,7 @@ def test_radio_activity_history_native(tmp_path):
 
     result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stdout.strip() == "24 passed, 0 failed"
+    assert result.stdout.strip() == "27 passed, 0 failed"
 
 
 def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
@@ -58,6 +58,9 @@ def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
     assert "record_gap" in sx_cpp
     assert "elapsed / ACTIVITY_SAMPLE_INTERVAL_MS" in sx_cpp
     assert "_last_activity_sample_ms +=" in sx_cpp
+    assert "portENTER_CRITICAL(&_activity_mux)" not in sx_cpp
+    assert "xSemaphoreTake(_activity_mutex" in sx_cpp
+    assert sx_cpp.count("lock_activity(portMAX_DELAY)") == 2
     assert "sample_radio_activity" in main_cpp
     assert "radio_activity_visible()" in main_cpp
     assert "setFrequency" not in sx_cpp
@@ -76,13 +79,21 @@ def test_ui_contract_uses_dedicated_status_child_and_snapshot_only_rendering():
     assert "Radio Activity" in screen_cpp
     assert "LIVE | 7 FPS" in screen_cpp
     assert "RENDER_INTERVAL_MS = 143" in screen_cpp
+    assert "render_due" in screen_cpp
+    assert manager_cpp.index("render_due(now)") < manager_cpp.index("_radio_activity_snapshot_provider()")
     assert "lv_canvas" not in screen_cpp
     assert "lv_chart" not in screen_cpp
     assert "lv_draw_line" in screen_cpp
     assert "rssi_valid" in screen_cpp
+    assert "current_rssi_valid" in screen_cpp
+    assert '"-- dBm"' in screen_cpp
     assert " · " not in screen_cpp
     assert "■" not in screen_cpp
     assert " | " in screen_cpp
     assert "getRSSI" not in screen_cpp
     assert "SPI" not in screen_cpp
     assert "setFrequency" not in screen_cpp
+    assert "legend_noise" in screen_cpp
+    assert "legend_rx" in screen_cpp
+    assert "legend_other" in screen_cpp
+    assert "legend_tx" in screen_cpp

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -43,7 +43,7 @@ def test_radio_activity_history_native(tmp_path):
 
     result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stdout.strip() == "14 passed, 0 failed"
+    assert result.stdout.strip() == "15 passed, 0 failed"
 
 
 def test_sampler_is_main_loop_owned_bounded_and_instantaneous():

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -43,7 +43,7 @@ def test_radio_activity_history_native(tmp_path):
 
     result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stdout.strip() == "27 passed, 0 failed"
+    assert result.stdout.strip() == "33 passed, 0 failed"
 
 
 def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
@@ -57,13 +57,54 @@ def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
     assert "if (_transmitting)" in sx_cpp
     assert "record_gap" in sx_cpp
     assert "elapsed / ACTIVITY_SAMPLE_INTERVAL_MS" in sx_cpp
-    assert "_last_activity_sample_ms +=" in sx_cpp
+    assert "_last_activity_sample_ms = last_activity_sample_ms +" in sx_cpp
     assert "portENTER_CRITICAL(&_activity_mux)" not in sx_cpp
     assert "xSemaphoreTake(_activity_mutex" in sx_cpp
-    assert sx_cpp.count("lock_activity(portMAX_DELAY)") == 2
+    assert sx_cpp.count("lock_activity(portMAX_DELAY)") == 5
     assert "sample_radio_activity" in main_cpp
     assert "radio_activity_visible()" in main_cpp
     assert "setFrequency" not in sx_cpp
+
+
+def test_radio_reconfiguration_resets_current_channel_history_and_clock():
+    sx_cpp = SX_CPP.read_text()
+    set_config_start = sx_cpp.index("void SX1262Interface::set_config(")
+    set_config_end = sx_cpp.index("std::string SX1262Interface::toString()")
+    set_config = sx_cpp[set_config_start:set_config_end]
+
+    assert "lock_activity(portMAX_DELAY)" in set_config
+    assert "_activity_history.reset()" in set_config
+    assert "_last_activity_sample_ms = millis()" in set_config
+    assert set_config.index("lock_activity(portMAX_DELAY)") < set_config.index("_activity_history.reset()")
+    assert set_config.index("_activity_history.reset()") < set_config.index("unlock_activity()")
+
+
+def test_stale_radio_operations_cannot_repopulate_a_new_channel_generation():
+    sx_cpp = SX_CPP.read_text()
+    sampler = sx_cpp[sx_cpp.index("void SX1262Interface::sample_radio_activity("):
+                     sx_cpp.index("RadioActivity::Snapshot SX1262Interface::radio_activity_snapshot()")]
+    receiver = sx_cpp[sx_cpp.index("void SX1262Interface::loop()"):
+                      sx_cpp.index("bool SX1262Interface::send_outgoing(")]
+    transmitter = sx_cpp[sx_cpp.index("bool SX1262Interface::send_outgoing("):
+                         sx_cpp.index("void SX1262Interface::on_incoming(")]
+
+    for operation in (sampler, receiver, transmitter):
+        assert "activity_generation = _activity_history.generation()" in operation
+        assert "_activity_history.generation() != activity_generation" in operation
+
+    initial_lock = sampler.index("lock_activity(pdMS_TO_TICKS(2))")
+    refreshed_now = sampler.index("now_ms = millis()")
+    initial_unlock = sampler.index("unlock_activity()")
+    assert initial_lock < refreshed_now < initial_unlock
+
+    first_generation_check = sampler.index("_activity_history.generation() != activity_generation")
+    second_generation_check = sampler.index("_activity_history.generation() != activity_generation", first_generation_check + 1)
+    first_clock_advance = sampler.index("advance_clock();")
+    second_clock_advance = sampler.index("advance_clock();", first_clock_advance + 1)
+    assert first_generation_check < first_clock_advance
+    assert second_generation_check < second_clock_advance
+    assert receiver.index("_activity_history.generation() != activity_generation") < receiver.index("mark_event(RadioActivity::Event::Rx)")
+    assert transmitter.index("_activity_history.generation() != activity_generation") < transmitter.index("mark_event(RadioActivity::Event::Tx")
 
 
 def test_ui_contract_uses_dedicated_status_child_and_snapshot_only_rendering():

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -1,0 +1,81 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent
+TEST_SOURCE = HERE / "test_radio_activity.cpp"
+HISTORY_INCLUDE = ROOT / "lib" / "radio_activity"
+SX_CPP = ROOT / "lib" / "sx1262_interface" / "SX1262Interface.cpp"
+SX_H = ROOT / "lib" / "sx1262_interface" / "SX1262Interface.h"
+MAIN_CPP = ROOT / "src" / "main.cpp"
+UI_MANAGER_CPP = ROOT / "lib" / "tdeck_ui" / "UI" / "LXMF" / "UIManager.cpp"
+UI_MANAGER_H = ROOT / "lib" / "tdeck_ui" / "UI" / "LXMF" / "UIManager.h"
+SCREEN_CPP = ROOT / "lib" / "tdeck_ui" / "UI" / "LXMF" / "RadioActivityScreen.cpp"
+STATUS_CPP = ROOT / "lib" / "tdeck_ui" / "UI" / "LXMF" / "StatusScreen.cpp"
+
+
+def _find_cxx():
+    for command in ("clang++", "g++"):
+        if shutil.which(command):
+            return command
+    pytest.skip("no C++ compiler found")
+
+
+def test_radio_activity_history_native(tmp_path):
+    binary = tmp_path / "test_radio_activity"
+    command = [
+        _find_cxx(),
+        "-std=c++17",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        f"-I{HISTORY_INCLUDE}",
+        str(TEST_SOURCE),
+        "-o",
+        str(binary),
+    ]
+    compiled = subprocess.run(command, capture_output=True, text=True)
+    assert compiled.returncode == 0, compiled.stderr
+
+    result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip() == "13 passed, 0 failed"
+
+
+def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
+    sx_cpp = SX_CPP.read_text()
+    sx_h = SX_H.read_text()
+    main_cpp = MAIN_CPP.read_text()
+
+    assert "sample_radio_activity" in sx_h
+    assert "_radio->getRSSI(false)" in sx_cpp
+    assert "xSemaphoreTake(_spi_mutex, 0)" in sx_cpp
+    assert "if (_transmitting)" in sx_cpp
+    assert "sample_radio_activity" in main_cpp
+    assert "radio_activity_visible()" in main_cpp
+    assert "setFrequency" not in sx_cpp
+
+
+def test_ui_contract_uses_dedicated_status_child_and_snapshot_only_rendering():
+    manager_cpp = UI_MANAGER_CPP.read_text()
+    manager_h = UI_MANAGER_H.read_text()
+    screen_cpp = SCREEN_CPP.read_text()
+    status_cpp = STATUS_CPP.read_text()
+
+    assert "SCREEN_RADIO_ACTIVITY" in manager_h
+    assert "set_radio_activity_callback" in status_cpp
+    assert "show_radio_activity" in manager_cpp
+    assert "on_back_from_radio_activity" in manager_cpp
+    assert "Radio Activity" in screen_cpp
+    assert "LIVE · 7 FPS" in screen_cpp
+    assert "RENDER_INTERVAL_MS = 143" in screen_cpp
+    assert "lv_canvas" not in screen_cpp
+    assert "lv_chart" not in screen_cpp
+    assert "lv_draw_line" in screen_cpp
+    assert "getRSSI" not in screen_cpp
+    assert "SPI" not in screen_cpp
+    assert "setFrequency" not in screen_cpp

--- a/tests/native/test_radio_activity.py
+++ b/tests/native/test_radio_activity.py
@@ -43,7 +43,7 @@ def test_radio_activity_history_native(tmp_path):
 
     result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert result.stdout.strip() == "13 passed, 0 failed"
+    assert result.stdout.strip() == "14 passed, 0 failed"
 
 
 def test_sampler_is_main_loop_owned_bounded_and_instantaneous():
@@ -71,11 +71,14 @@ def test_ui_contract_uses_dedicated_status_child_and_snapshot_only_rendering():
     assert "show_radio_activity" in manager_cpp
     assert "on_back_from_radio_activity" in manager_cpp
     assert "Radio Activity" in screen_cpp
-    assert "LIVE · 7 FPS" in screen_cpp
+    assert "LIVE | 7 FPS" in screen_cpp
     assert "RENDER_INTERVAL_MS = 143" in screen_cpp
     assert "lv_canvas" not in screen_cpp
     assert "lv_chart" not in screen_cpp
     assert "lv_draw_line" in screen_cpp
+    assert " · " not in screen_cpp
+    assert "■" not in screen_cpp
+    assert " | " in screen_cpp
     assert "getRSSI" not in screen_cpp
     assert "SPI" not in screen_cpp
     assert "setFrequency" not in screen_cpp


### PR DESCRIPTION
## Summary

- adds a dedicated **Status → Radio Activity** screen without adding another persistent navigation tab
- displays a read-only, current-channel RSSI timeline with learned noise floor, channel load, and RX/TX/interference markers
- shows the active LoRa frequency, bandwidth, spreading factor, coding rate, and transmit power
- samples instantaneous RSSI from the radio-owner/main-loop side using `getRSSI(false)` without retuning or changing Reticulum/LXMF behavior
- preserves fixed 100 ms time buckets across TX, SPI contention, and missed sampling opportunities
- renders at a gated 143 ms cadence using lightweight LVGL draw primitives

## Concurrency and memory safety

- uses the existing nonblocking shared-SPI ownership boundary
- never calls radio or SPI APIs while holding the LVGL lock
- protects the bounded 96-sample history with a task mutex rather than disabling interrupts during snapshot copies
- coalesces snapshot acquisition to the screen render cadence
- retains RX/TX markers durably after SPI release and represents invalid RSSI gaps explicitly
- uses a fixed-capacity history and no canvas or `lv_chart` allocation

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q tests/build_scripts tests/native` — **103 passed**
- `pio run -e tdeck-release` — **passed**
- `pio run -e tdeck` — **passed**
- exact release image SHA-256: `a4f2030954804db1e43eaeca6a828e70fffd8b7206e4aa65b0b147fd6a9f672a`
- embedded firmware version: `0.2.7-12-g7daac84`
- independent exact-head code review: **PASS**

## Physical T-Deck validation

The exact release image was deployed application-only to the active `app0` slot and read back before reset:

- exact application read-back matched the candidate SHA-256
- every byte outside the selected application partition was unchanged
- bootloader, partition table, NVS, OTA metadata, alternate app slot, coredump, and LittleFS were preserved
- first boot and two subsequent reboot cycles ran `0.2.7-12-g7daac84` from `app0` without panic, assertion, watchdog trigger, rollback, or invalid-image errors
- identity, six stored conversations, and LoRa settings persisted across all three boots
- LoRa initialized at 927.250 MHz, 500 kHz, SF7, CR 4/5, and 17 dBm; LXMF and LXST announces succeeded

## Remaining manual acceptance

- visually inspect **Status → Radio Activity** on the physical display
- exercise real-peer RX/TX/interference markers and confirm the graph under live RF activity

## Scope

This does not change RF frequency, modulation, bandwidth, spreading factor, coding rate, power, framing, CSMA behavior, Reticulum/LXMF protocol behavior, identities, settings, or storage formats. Pinned microReticulum and microLXMF revisions remain unchanged.
