### PR TITLE
feat: add composable sparse map packs and browser installer

### DIFF
--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -235,6 +235,19 @@
         .custom-firmware-status.success { color: var(--success); }
         .custom-firmware-status.error { color: var(--error); }
 
+        .map-installer-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 1rem;
+            margin: 1rem 0;
+        }
+        .map-field label { display: block; color: var(--muted); font-size: 0.875rem; margin-bottom: 0.4rem; }
+        .map-field input { width: 100%; box-sizing: border-box; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.65rem; }
+        .map-status { margin: 0.8rem 0; color: var(--muted); overflow-wrap: anywhere; }
+        .map-status.success { color: var(--success); }
+        .map-status.error { color: var(--error); }
+        .map-note { color: var(--muted); font-size: 0.875rem; line-height: 1.5; }
+
         footer {
             text-align: center;
             margin-top: 2rem;
@@ -297,6 +310,37 @@
             <p class="version">Firmware version: <span id="firmware-version">loading...</span></p>
         </div>
 
+        <div class="card map-section">
+            <h2>Install Offline Maps</h2>
+            <p class="map-note">
+                Select a Coalition/MUI XYZ ZIP already downloaded to this computer, then choose the mounted SD-card root.
+                Turn the T-Deck off and remove its SD card before installation. Existing unrelated SD-card files are preserved.
+            </p>
+            <div class="map-installer-grid">
+                <div class="map-field">
+                    <label for="map-archive">Map tile ZIP</label>
+                    <input id="map-archive" type="file" accept=".zip,application/zip">
+                </div>
+                <div class="map-field">
+                    <label for="map-pack-name">Map name</label>
+                    <input id="map-pack-name" type="text" maxlength="63" placeholder="Offline map">
+                </div>
+                <div class="map-field">
+                    <label for="map-pack-id">Pack ID</label>
+                    <input id="map-pack-id" type="text" maxlength="31" pattern="[a-z0-9_-]+" placeholder="offline-map">
+                </div>
+            </div>
+            <p class="map-note">
+                Source profile: Coalition MUI OSM Bright user download.<br>
+                Attribution: Map data (c) OpenStreetMap contributors — ODbL-1.0.<br>
+                Compatible OSM Bright packs are enabled together. The newest pack takes priority where coverage overlaps.
+            </p>
+            <div id="map-install-status" class="map-status">Choose a ZIP to validate it locally. No tiles are uploaded.</div>
+            <div class="button-group">
+                <button id="map-install-btn" class="btn-primary" disabled>Install and Enable</button>
+            </div>
+        </div>
+
         <div class="card requirements">
             <h2>Requirements</h2>
             <ul>
@@ -332,6 +376,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
+        import { inspectMuiZip, installMuiZip } from './js/map-installer.js';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');
@@ -344,6 +389,11 @@
         const versionNote = document.getElementById('version-note');
         const customFirmwareInput = document.getElementById('custom-firmware');
         const customFirmwareStatus = document.getElementById('custom-firmware-status');
+        const mapArchiveInput = document.getElementById('map-archive');
+        const mapPackNameInput = document.getElementById('map-pack-name');
+        const mapPackIdInput = document.getElementById('map-pack-id');
+        const mapInstallStatus = document.getElementById('map-install-status');
+        const mapInstallBtn = document.getElementById('map-install-btn');
 
         const REQUIRED_FULL_ASSETS = ['bootloader.bin', 'partitions.bin', 'boot_app0.bin', 'firmware.bin'];
         const RELEASE_METADATA_ASSET = 'pyxis-release.json';
@@ -357,6 +407,89 @@
         let customFirmwareSelectionToken = 0;
         // Track whether the selected release has all assets for full install
         let releaseHasFullAssets = false;
+        let validatedMapArchive = null;
+        let mapSelectionToken = 0;
+
+        function setMapStatus(text, state = '') {
+            mapInstallStatus.textContent = text;
+            mapInstallStatus.className = `map-status ${state}`.trim();
+        }
+
+        function slugifyMapName(value) {
+            return value.toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 31);
+        }
+
+        mapPackNameInput.addEventListener('input', () => {
+            if (!mapPackIdInput.dataset.edited) mapPackIdInput.value = slugifyMapName(mapPackNameInput.value);
+        });
+        mapPackIdInput.addEventListener('input', () => { mapPackIdInput.dataset.edited = 'true'; });
+
+        mapArchiveInput.addEventListener('change', async function() {
+            const token = ++mapSelectionToken;
+            validatedMapArchive = null;
+            mapInstallBtn.disabled = true;
+            const file = this.files?.[0];
+            if (!file) { setMapStatus('Choose a ZIP to validate it locally. No tiles are uploaded.'); return; }
+            if (!mapPackNameInput.value) mapPackNameInput.value = file.name.replace(/\.zip$/i, '') || 'Offline map';
+            if (!mapPackIdInput.value) mapPackIdInput.value = slugifyMapName(mapPackNameInput.value);
+            setMapStatus(`Validating ${file.name} locally...`);
+            try {
+                const report = await inspectMuiZip(file, {onProgress(progress) {
+                    if (token === mapSelectionToken && progress.completed % 25 === 0) {
+                        setMapStatus(`Validating tiles: ${progress.completed}/${progress.total}`);
+                    }
+                }});
+                if (token !== mapSelectionToken) return;
+                validatedMapArchive = {file, report};
+                mapInstallBtn.disabled = false;
+                setMapStatus(`Ready: ${report.tileCount} tiles, zoom ${report.minZoom}-${report.maxZoom}, ${report.rowSpans.length} sparse row spans, ${report.totalBytes.toLocaleString()} bytes.`, 'success');
+            } catch (error) {
+                if (token !== mapSelectionToken) return;
+                this.value = '';
+                setMapStatus(error.message, 'error');
+            }
+        });
+
+        mapInstallBtn.addEventListener('click', async () => {
+            if (!validatedMapArchive) return;
+            const name = mapPackNameInput.value.trim();
+            const packId = mapPackIdInput.value.trim();
+            if (!name || !/^[a-z0-9_-]{1,31}$/.test(packId)) {
+                setMapStatus('Enter a map name and a lowercase pack ID using letters, numbers, _ or -.', 'error');
+                return;
+            }
+            if (typeof window.showDirectoryPicker !== 'function') {
+                setMapStatus('This browser does not provide writable directory access. Use Chrome, Chromium, or Edge; Brave currently disables this API.', 'error');
+                return;
+            }
+            mapInstallBtn.disabled = true;
+            try {
+                const rootDirectory = await window.showDirectoryPicker({mode: 'readwrite'});
+                setMapStatus('Installing validated tiles to the selected SD card...');
+                const result = await installMuiZip({
+                    archive: validatedMapArchive.file,
+                    rootDirectory,
+                    metadata: {
+                        packId,
+                        mapSetId: 'osm-bright',
+                        name,
+                        attribution: 'Map data (c) OpenStreetMap contributors',
+                        source: 'Coalition MUI OSM Bright user download',
+                        license: 'ODbL-1.0',
+                    },
+                    onProgress(progress) {
+                        if (progress.phase === 'write' && (progress.completed % 25 === 0 || progress.completed === progress.total)) {
+                            setMapStatus(`Writing tiles: ${progress.completed}/${progress.total}`);
+                        }
+                    },
+                });
+                setMapStatus(`Installed and enabled ${name} in OSM Bright: ${result.tileCount} tiles; ${result.enabledPacks.length} compatible pack(s) active. Safely eject the SD card before returning it to the T-Deck.`, 'success');
+            } catch (error) {
+                if (error?.name !== 'AbortError') setMapStatus(`Installation failed: ${error.message}`, 'error');
+            } finally {
+                mapInstallBtn.disabled = validatedMapArchive === null;
+            }
+        });
 
         function makeFirmwareFiles(prefix) {
             return {

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -462,6 +462,10 @@
                 setMapStatus('This browser does not provide writable directory access. Use Chrome, Chromium, or Edge; Brave currently disables this API.', 'error');
                 return;
             }
+            if (typeof navigator.locks?.request !== 'function') {
+                setMapStatus('This browser does not provide the cross-tab locking required for safe map installation. Use a current Chrome, Chromium, or Edge release.', 'error');
+                return;
+            }
             mapInstallBtn.disabled = true;
             try {
                 const rootDirectory = await window.showDirectoryPicker({mode: 'readwrite'});

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -19,7 +19,7 @@ const textDecoder = new TextDecoder('utf-8', {fatal: true});
 const textEncoder = new TextEncoder();
 const installTails = new WeakMap();
 
-async function withInstallLock(rootDirectory, operation) {
+async function withInProcessInstallLock(rootDirectory, operation) {
   const previous = installTails.get(rootDirectory) || Promise.resolve();
   let release;
   const gate = new Promise(resolve => { release = resolve; });
@@ -31,6 +31,28 @@ async function withInstallLock(rootDirectory, operation) {
     release();
     if (installTails.get(rootDirectory) === tail) installTails.delete(rootDirectory);
   }
+}
+
+async function withInstallLock(rootDirectory, operation) {
+  const lockManager = globalThis.navigator?.locks;
+  if (typeof lockManager?.request === 'function') {
+    if (typeof rootDirectory?.name !== 'string' || rootDirectory.name.length === 0) {
+      fail('Selected SD root has no stable directory name');
+    }
+    // Web Locks are shared by every same-origin installer tab. Distinct
+    // FileSystemDirectoryHandle objects for the same root have the same name;
+    // equal names on unrelated roots merely serialize harmlessly.
+    return lockManager.request(
+      `pyxis-map-installer:${rootDirectory.name}`,
+      {mode:'exclusive'},
+      operation,
+    );
+  }
+  if (typeof globalThis.window?.showDirectoryPicker === 'function') {
+    fail('This browser lacks the cross-tab locking required for safe map installation');
+  }
+  // Headless contract tests do not expose browser lock primitives.
+  return withInProcessInstallLock(rootDirectory, operation);
 }
 
 export class MapInstallerError extends Error {}

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -1,0 +1,602 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+import {Unzlib} from './vendor/fflate.js';
+// Local-only, bounded MUI XYZ ZIP importer. This module deliberately has no
+// network path: users select an archive and an SD-card directory themselves.
+
+const MAX_ZOOM = 22;
+const MAX_TILES = 100000;
+const MAX_TOTAL_BYTES = 8 * 1024 * 1024 * 1024;
+const MAX_TILE_BYTES = 384 * 1024;
+const MAX_ROW_SPANS = 512;
+const MAX_ZIP_ENTRIES = MAX_TILES + 64;
+const MAX_CENTRAL_BYTES = 16 * 1024 * 1024;
+const MAX_ZIP_NAME_BYTES = 255;
+const MANIFEST_MAGIC = 0x4b504d50; // PMPK, little endian
+const SELECTION_MAGIC = 0x53414d50; // PMAS, little endian
+const textDecoder = new TextDecoder('utf-8', {fatal: true});
+const textEncoder = new TextEncoder();
+const installTails = new WeakMap();
+
+async function withInstallLock(rootDirectory, operation) {
+  const previous = installTails.get(rootDirectory) || Promise.resolve();
+  let release;
+  const gate = new Promise(resolve => { release = resolve; });
+  const tail = previous.then(() => gate);
+  installTails.set(rootDirectory, tail);
+  await previous;
+  try { return await operation(); }
+  finally {
+    release();
+    if (installTails.get(rootDirectory) === tail) installTails.delete(rootDirectory);
+  }
+}
+
+export class MapInstallerError extends Error {}
+function fail(message) { throw new MapInstallerError(message); }
+function u16(view, offset) { return view.getUint16(offset, true); }
+function u32(view, offset) { return view.getUint32(offset, true); }
+function putU16(view, offset, value) { view.setUint16(offset, value, true); }
+function putU32(view, offset, value) { view.setUint32(offset, value >>> 0, true); }
+
+export function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  return (~crc) >>> 0;
+}
+
+function checkedAscii(label, value, maximum) {
+  if (typeof value !== 'string' || value.length === 0) fail(`${label} is required`);
+  const bytes = textEncoder.encode(value);
+  if (bytes.length > maximum || [...bytes].some(byte => byte < 0x20 || byte > 0x7e)) {
+    fail(`${label} must be 1-${maximum} printable ASCII bytes`);
+  }
+  return bytes;
+}
+
+function validateMetadata(metadata) {
+  if (!metadata || !/^[a-z0-9_-]{1,31}$/.test(metadata.packId || '')) {
+    fail('Pack ID must match [a-z0-9_-]{1,31}');
+  }
+  return {
+    packId: checkedAscii('Pack ID', metadata.packId, 31),
+    name: checkedAscii('Name', metadata.name, 63),
+    attribution: checkedAscii('Attribution', metadata.attribution, 127),
+    source: checkedAscii('Source', metadata.source, 127),
+    license: checkedAscii('License', metadata.license, 63),
+  };
+}
+
+async function blobBytes(blob, start = 0, end = blob.size) {
+  return new Uint8Array(await blob.slice(start, end).arrayBuffer());
+}
+
+function findEocd(bytes, absoluteStart) {
+  for (let offset = bytes.length - 22; offset >= 0; offset--) {
+    if (new DataView(bytes.buffer, bytes.byteOffset + offset, 4).getUint32(0, true) === 0x06054b50) {
+      return absoluteStart + offset;
+    }
+  }
+  fail('ZIP end record is missing');
+}
+
+async function parseZipDirectory(archive) {
+  if (!(archive instanceof Blob) || archive.size < 22) fail('Selected ZIP is empty or truncated');
+  const tailStart = Math.max(0, archive.size - 65557);
+  const tail = await blobBytes(archive, tailStart);
+  const eocdOffset = findEocd(tail, tailStart);
+  const eocd = new DataView((await blobBytes(archive, eocdOffset, eocdOffset + 22)).buffer);
+  if (u16(eocd, 4) !== 0 || u16(eocd, 6) !== 0) fail('Multi-disk ZIPs are unsupported');
+  const diskCount = u16(eocd, 8);
+  const count = u16(eocd, 10);
+  const centralSize = u32(eocd, 12);
+  const centralOffset = u32(eocd, 16);
+  const commentLength = u16(eocd, 20);
+  if (commentLength !== 0 || eocdOffset + 22 !== archive.size) fail('ZIP comments are unsupported');
+  if (diskCount !== count || count === 0 || count === 0xffff || count > MAX_ZIP_ENTRIES ||
+      centralSize === 0xffffffff || centralOffset === 0xffffffff) {
+    fail('ZIP entry count exceeds the bounded limit or requires ZIP64');
+  }
+  if (centralOffset + centralSize !== eocdOffset || centralOffset + centralSize > archive.size) {
+    fail('ZIP central directory bounds are invalid');
+  }
+  if (centralSize > MAX_CENTRAL_BYTES) fail('ZIP central directory exceeds the bounded limit');
+  const central = await blobBytes(archive, centralOffset, centralOffset + centralSize);
+  const view = new DataView(central.buffer, central.byteOffset, central.byteLength);
+  const records = [];
+  const names = new Set();
+  let position = 0;
+  for (let index = 0; index < count; index++) {
+    if (position + 46 > central.length || u32(view, position) !== 0x02014b50) fail('ZIP central directory is malformed');
+    const flags = u16(view, position + 8);
+    const method = u16(view, position + 10);
+    const checksum = u32(view, position + 16);
+    const compressedSize = u32(view, position + 20);
+    const size = u32(view, position + 24);
+    const nameLength = u16(view, position + 28);
+    const extraLength = u16(view, position + 30);
+    const commentLength = u16(view, position + 32);
+    const disk = u16(view, position + 34);
+    const externalAttributes = u32(view, position + 38);
+    const localOffset = u32(view, position + 42);
+    const end = position + 46 + nameLength + extraLength + commentLength;
+    if (end > central.length || nameLength === 0 || nameLength > MAX_ZIP_NAME_BYTES ||
+        extraLength !== 0 || commentLength !== 0 || disk !== 0) {
+      fail('ZIP entry metadata or extra fields are unsupported');
+    }
+    if ((flags & 1) !== 0) fail('Encrypted ZIP entries are unsupported');
+    if ((flags & ~0x0808) !== 0) fail('ZIP entry uses unsupported flags');
+    if (method !== 0 || compressedSize !== size) fail('Only stored MUI PNG ZIP entries are supported');
+    if (size === 0 || size > MAX_TILE_BYTES) fail('ZIP tile exceeds the per-tile size limit');
+    const unixMode = externalAttributes >>> 16;
+    if ((externalAttributes & 0x10) !== 0) fail('ZIP directory entries are forbidden');
+    if ((unixMode & 0xf000) === 0xa000) fail('ZIP symlinks are forbidden');
+    if ((unixMode & 0xf000) !== 0 && (unixMode & 0xf000) !== 0x8000) fail('ZIP entry is not a regular file');
+    let name;
+    try { name = textDecoder.decode(central.subarray(position + 46, position + 46 + nameLength)); }
+    catch { fail('ZIP filename is not valid UTF-8'); }
+    if (name.startsWith('/') || name.includes('\\') || name.split('/').some(part => part === '' || part === '.' || part === '..')) {
+      fail(`Unsafe ZIP path or traversal: ${name}`);
+    }
+    if (names.has(name)) fail(`Duplicate ZIP path: ${name}`);
+    names.add(name);
+    records.push({name, flags, method, checksum, compressedSize, size, localOffset});
+    position = end;
+  }
+  if (position !== central.length) fail('ZIP central directory contains trailing records');
+  return {records, centralOffset};
+}
+
+async function locateEntry(archive, record, centralOffset) {
+  if (record.localOffset + 30 > centralOffset) fail(`ZIP local header is outside bounds: ${record.name}`);
+  const headerBytes = await blobBytes(archive, record.localOffset, record.localOffset + 30);
+  const header = new DataView(headerBytes.buffer, headerBytes.byteOffset, headerBytes.byteLength);
+  const usesDescriptor = (record.flags & 8) !== 0;
+  const localCrc = u32(header, 14), localCompressed = u32(header, 18), localSize = u32(header, 22);
+  if (u32(header, 0) !== 0x04034b50 || u16(header, 6) !== record.flags || u16(header, 8) !== record.method ||
+      (!usesDescriptor && (localCrc !== record.checksum || localCompressed !== record.compressedSize || localSize !== record.size)) ||
+      (usesDescriptor && !((localCrc === 0 && localCompressed === 0 && localSize === 0) ||
+                           (localCrc === record.checksum && localCompressed === record.compressedSize && localSize === record.size)))) {
+    fail(`ZIP local header mismatch: ${record.name}`);
+  }
+  const nameLength = u16(header, 26);
+  const extraLength = u16(header, 28);
+  if (nameLength === 0 || nameLength > MAX_ZIP_NAME_BYTES || extraLength !== 0) {
+    fail(`ZIP local extra fields are unsupported: ${record.name}`);
+  }
+  const nameBytes = await blobBytes(archive, record.localOffset + 30, record.localOffset + 30 + nameLength);
+  let localName;
+  try { localName = textDecoder.decode(nameBytes); } catch { fail('ZIP local filename is invalid'); }
+  if (localName !== record.name) fail(`ZIP local filename mismatch: ${record.name}`);
+  const dataOffset = record.localOffset + 30 + nameLength + extraLength;
+  if (dataOffset + record.size > centralOffset) fail(`ZIP payload exceeds bounds: ${record.name}`);
+  return {...record, dataOffset};
+}
+
+function adler32(bytes) {
+  let a=1,b=0;
+  for(let offset=0;offset<bytes.length;offset+=5552){const end=Math.min(bytes.length,offset+5552);for(let index=offset;index<end;index++){a+=bytes[index];b+=a;}a%=65521;b%=65521;}
+  return ((b<<16)|a)>>>0;
+}
+
+async function inflatePngIdat(parts, maximum) {
+  let compressedLength=0;for(const part of parts)compressedLength+=part.length;
+  if(compressedLength<6||compressedLength>MAX_TILE_BYTES)fail('PNG zlib stream has an invalid length');
+  const compressed=new Uint8Array(compressedLength);let compressedOffset=0;for(const part of parts){compressed.set(part,compressedOffset);compressedOffset+=part.length;}
+  const cmf=compressed[0],flg=compressed[1];
+  if((cmf&15)!==8||(cmf>>>4)>7||((cmf<<8)|flg)%31!==0||(flg&32)!==0)fail('PNG zlib header is invalid');
+  const expectedAdler=new DataView(compressed.buffer,compressed.byteOffset+compressed.length-4,4).getUint32(0,false);
+  let total=0;const output=[];let inflater;
+  try {
+    inflater=new Unzlib((part)=>{if(total+part.byteLength>maximum)fail('PNG decoded data exceeds its bounded size');total+=part.byteLength;output.push(part.slice());});
+    const inputChunk=128;
+    for(let offset=0;offset<compressed.length;offset+=inputChunk)inflater.push(compressed.subarray(offset,Math.min(compressed.length,offset+inputChunk)),offset+inputChunk>=compressed.length);
+  } catch (error) {
+    if (error instanceof MapInstallerError) throw error;
+    fail('PNG zlib stream is invalid');
+  }
+  const residualBits=inflater.s?.p||0;
+  if(inflater.p.length!==(residualBits===0?0:1))fail('PNG deflate stream contains trailing data');
+  const joined=new Uint8Array(total);let offset=0;for(const part of output){joined.set(part,offset);offset+=part.length;}
+  if(adler32(joined)!==expectedAdler)fail('PNG zlib checksum is invalid');
+  return joined;
+}
+
+export async function validatePng(bytes, label = 'tile') {
+  if (!(bytes instanceof Uint8Array) || bytes.length < 45 || bytes.length > MAX_TILE_BYTES) fail(`Invalid PNG: ${label}`);
+  const signature = [137,80,78,71,13,10,26,10];
+  if (!signature.every((byte, index) => bytes[index] === byte)) fail(`Invalid PNG signature: ${label}`);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let position = 8;
+  let first = true;
+  let sawIdat = false;
+  let idatClosed = false;
+  let sawIend = false;
+  let sawPlte = false;
+  let sawTrns = false;
+  let sawPhys = false;
+  let bitDepth = 0;
+  let colorType = 0;
+  let rowBytes = 0;
+  let bytesPerPixel = 0;
+  let paletteEntries = 0;
+  const idat = [];
+  while (position < bytes.length) {
+    if (position + 12 > bytes.length) fail(`Invalid PNG structure: ${label}`);
+    const length = view.getUint32(position, false);
+    const typeBytes = bytes.subarray(position + 4, position + 8);
+    const type = String.fromCharCode(...typeBytes);
+    const end = position + 12 + length;
+    if (end > bytes.length || !/^[A-Za-z]{4}$/.test(type) || (typeBytes[2] & 0x20)) fail(`Invalid PNG chunk: ${label}`);
+    const payload = bytes.subarray(position + 8, position + 8 + length);
+    const encodedCrc = view.getUint32(position + 8 + length, false);
+    const crcInput = new Uint8Array(4 + length); crcInput.set(typeBytes); crcInput.set(payload, 4);
+    if (crc32(crcInput) !== encodedCrc) fail(`Invalid PNG chunk CRC: ${label}`);
+    if (first && (type !== 'IHDR' || length !== 13)) fail(`Invalid PNG IHDR: ${label}`);
+    if (!first && type === 'IHDR') fail(`Duplicate PNG IHDR: ${label}`);
+    if (!['IHDR','PLTE','tRNS','pHYs','IDAT','IEND'].includes(type)) fail(`Unsupported PNG chunk: ${label}`);
+    if (sawIdat && type !== 'IDAT' && type !== 'IEND') idatClosed = true;
+    if (type === 'IDAT' && idatClosed) fail(`Nonconsecutive PNG IDAT: ${label}`);
+    if (type === 'IHDR') {
+      const ihdr = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+      const width = ihdr.getUint32(0, false), height = ihdr.getUint32(4, false);
+      bitDepth = payload[8]; colorType = payload[9];
+      const depths = {0:[1,2,4,8],2:[8],3:[1,2,4,8],4:[8],6:[8]};
+      if (width !== 256 || height !== 256 || !depths[colorType]?.includes(bitDepth) ||
+          payload[10] !== 0 || payload[11] !== 0 || payload[12] !== 0) fail(`Unsupported 256x256 non-interlaced PNG: ${label}`);
+      const channels = {0:1,2:3,3:1,4:2,6:4}[colorType];
+      rowBytes = Math.ceil(width * channels * bitDepth / 8);
+      bytesPerPixel = Math.max(1, Math.ceil(channels * bitDepth / 8));
+      first = false;
+    } else if (type === 'PLTE') {
+      if (sawPlte || sawIdat || [0,4].includes(colorType) || length === 0 || length % 3 || length > 768) fail(`Invalid PNG palette: ${label}`);
+      paletteEntries = length / 3; sawPlte = true;
+      if (colorType === 3 && paletteEntries > (1 << bitDepth)) fail(`Invalid PNG palette: ${label}`);
+    } else if (type === 'tRNS') {
+      if (sawTrns || sawIdat) fail(`Invalid PNG transparency: ${label}`);
+      if (colorType === 3) {
+        if (!sawPlte || length === 0 || length > paletteEntries) fail(`Invalid PNG transparency: ${label}`);
+      } else if (colorType === 0) {
+        if (length !== 2) fail(`Invalid PNG transparency: ${label}`);
+        if (bitDepth < 16 && new DataView(payload.buffer,payload.byteOffset,2).getUint16(0,false) >= 2 ** bitDepth) fail(`Invalid PNG transparency sample: ${label}`);
+      } else if (colorType === 2) {
+        if (length !== 6) fail(`Invalid PNG transparency: ${label}`);
+        if (bitDepth < 16) {
+          const transparent = new DataView(payload.buffer,payload.byteOffset,6);
+          if ([0,2,4].some(offset => transparent.getUint16(offset,false) >= 2 ** bitDepth)) fail(`Invalid PNG transparency sample: ${label}`);
+        }
+      } else fail(`PNG color type cannot contain transparency: ${label}`);
+      sawTrns = true;
+    } else if (type === 'pHYs') {
+      if (sawPhys || sawIdat || length !== 9 || payload[8] > 1) fail(`Invalid PNG pixel dimensions: ${label}`);
+      sawPhys = true;
+    } else if (type === 'IDAT') {
+      if (colorType === 3 && !sawPlte) fail(`Indexed PNG lacks palette: ${label}`);
+      sawIdat = true; idat.push(payload);
+    } else if (type === 'IEND') {
+      if (length !== 0 || !sawIdat || end !== bytes.length) fail(`Invalid PNG terminal chunk: ${label}`);
+      sawIend = true;
+    }
+    position = end;
+  }
+  if (first || !sawIend) fail(`Invalid PNG terminal state: ${label}`);
+  let decoded;
+  try { decoded = await inflatePngIdat(idat, (rowBytes + 1) * 256); }
+  catch (error) { fail(`Invalid PNG deflate stream: ${label}: ${error.message}`); }
+  if (decoded.length !== (rowBytes + 1) * 256) fail(`Invalid PNG decoded length: ${label}`);
+  let previous = new Uint8Array(rowBytes);
+  for (let row = 0; row < 256; row++) {
+    const base = row * (rowBytes + 1);
+    const filter = decoded[base];
+    if (filter > 4) fail(`Invalid PNG row filter: ${label}`);
+    const current = new Uint8Array(rowBytes);
+    for (let index = 0; index < rowBytes; index++) {
+      const encoded = decoded[base + 1 + index];
+      const left = index >= bytesPerPixel ? current[index - bytesPerPixel] : 0;
+      const above = previous[index];
+      const upperLeft = index >= bytesPerPixel ? previous[index - bytesPerPixel] : 0;
+      let predictor = 0;
+      if (filter === 1) predictor = left;
+      else if (filter === 2) predictor = above;
+      else if (filter === 3) predictor = Math.floor((left + above) / 2);
+      else if (filter === 4) {
+        const estimate = left + above - upperLeft;
+        const pa = Math.abs(estimate - left), pb = Math.abs(estimate - above), pc = Math.abs(estimate - upperLeft);
+        predictor = pa <= pb && pa <= pc ? left : pb <= pc ? above : upperLeft;
+      }
+      current[index] = (encoded + predictor) & 0xff;
+    }
+    if (colorType === 3) {
+      for (let column = 0; column < 256; column++) {
+        const bitOffset = column * bitDepth;
+        const shift = 8 - bitDepth - (bitOffset % 8);
+        const paletteIndex = (current[Math.floor(bitOffset / 8)] >>> shift) & ((1 << bitDepth) - 1);
+        if (paletteIndex >= paletteEntries) fail(`PNG palette index is out of range: ${label}`);
+      }
+    }
+    previous = current;
+  }
+  return {bitDepth, colorType};
+}
+
+function tilePath(name) {
+  const match = /^(.*?)(\d+)\/(\d+)\/(\d+)\.png$/.exec(name);
+  if (!match) fail(`Unexpected ZIP entry; expected XYZ PNG: ${name}`);
+  const prefix = match[1];
+  if (prefix && !/^maps\/[^/]+\/$/.test(prefix)) fail(`Unsupported MUI ZIP root: ${name}`);
+  for (const value of match.slice(2)) if (!/^(0|[1-9]\d*)$/.test(value)) fail(`Noncanonical XYZ path: ${name}`);
+  const [zoom, x, y] = match.slice(2).map(Number);
+  if (zoom > MAX_ZOOM || x >= 2 ** zoom || y >= 2 ** zoom) fail(`XYZ coordinate out of range: ${name}`);
+  return {prefix, zoom, x, y};
+}
+
+function makeRowSpans(entries) {
+  const rows = new Map();
+  for (const entry of entries) {
+    const key = `${entry.zoom}/${entry.y}`;
+    if (!rows.has(key)) rows.set(key, {zoom: entry.zoom, y: entry.y, xs: []});
+    rows.get(key).xs.push(entry.x);
+  }
+  const spans = [];
+  const ordered = [...rows.values()].sort((a,b) => a.zoom - b.zoom || a.y - b.y);
+  for (const row of ordered) {
+    row.xs.sort((a,b) => a-b);
+    let start = row.xs[0], previous = start;
+    for (const x of row.xs.slice(1)) {
+      if (x !== previous + 1) { spans.push({zoom:row.zoom,y:row.y,xMinimum:start,xMaximum:previous}); start = x; }
+      previous = x;
+    }
+    spans.push({zoom:row.zoom,y:row.y,xMinimum:start,xMaximum:previous});
+    if (spans.length > MAX_ROW_SPANS) fail(`Sparse coverage exceeds ${MAX_ROW_SPANS} row spans`);
+  }
+  return spans;
+}
+
+async function validateZipLayout(archive, records, centralOffset) {
+  const ordered = [...records].sort((a,b) => a.localOffset - b.localOffset);
+  if (ordered[0].localOffset !== 0) fail('ZIP preambles are unsupported');
+  for (let index = 0; index < ordered.length; index++) {
+    const record = ordered[index];
+    const dataEnd = record.dataOffset + record.size;
+    const nextOffset = index + 1 < ordered.length ? ordered[index + 1].localOffset : centralOffset;
+    if (record.localOffset < (index ? ordered[index - 1].dataOffset + ordered[index - 1].size : 0) || dataEnd > nextOffset) {
+      fail(`Overlapping ZIP entries: ${record.name}`);
+    }
+    const descriptorLength = nextOffset - dataEnd;
+    if ((record.flags & 8) === 0) {
+      if (descriptorLength !== 0) fail(`Unexpected ZIP bytes after entry: ${record.name}`);
+      continue;
+    }
+    if (descriptorLength !== 12 && descriptorLength !== 16) fail(`Invalid ZIP data descriptor: ${record.name}`);
+    const descriptorBytes = await blobBytes(archive, dataEnd, nextOffset);
+    const descriptor = new DataView(descriptorBytes.buffer, descriptorBytes.byteOffset, descriptorBytes.byteLength);
+    const offset = descriptorLength === 16 ? 4 : 0;
+    if ((descriptorLength === 16 && u32(descriptor, 0) !== 0x08074b50) ||
+        u32(descriptor, offset) !== record.checksum ||
+        u32(descriptor, offset + 4) !== record.compressedSize ||
+        u32(descriptor, offset + 8) !== record.size) fail(`Invalid ZIP data descriptor: ${record.name}`);
+  }
+}
+
+export async function inspectMuiZip(archive, {onProgress = () => {}} = {}) {
+  const {records, centralOffset} = await parseZipDirectory(archive);
+  const locatedRecords = [];
+  for (const record of records) locatedRecords.push(await locateEntry(archive, record, centralOffset));
+  await validateZipLayout(archive, locatedRecords, centralOffset);
+  const entries = [];
+  const tileKeys = new Set();
+  let prefix = null;
+  let totalBytes = 0;
+  for (let index = 0; index < locatedRecords.length; index++) {
+    const located = locatedRecords[index];
+    const xyz = tilePath(located.name);
+    if (prefix === null) prefix = xyz.prefix;
+    if (prefix !== xyz.prefix) fail('ZIP contains multiple tile roots or styles');
+    const key = `${xyz.zoom}/${xyz.x}/${xyz.y}`;
+    if (tileKeys.has(key)) fail(`Duplicate tile key: ${key}`);
+    tileKeys.add(key);
+    totalBytes += located.size;
+    if (entries.length >= MAX_TILES || totalBytes > MAX_TOTAL_BYTES) fail('ZIP exceeds map-pack quota');
+    const bytes = await blobBytes(archive, located.dataOffset, located.dataOffset + located.size);
+    if (crc32(bytes) !== located.checksum) fail(`ZIP CRC mismatch: ${located.name}`);
+    await validatePng(bytes, located.name);
+    entries.push({...located, ...xyz});
+    onProgress({phase:'validate', completed:index + 1, total:records.length});
+  }
+  entries.sort((a,b) => a.zoom-b.zoom || a.x-b.x || a.y-b.y);
+  const zooms = [...new Set(entries.map(entry => entry.zoom))].sort((a,b) => a-b);
+  if (zooms.some((zoom,index) => zoom !== zooms[0] + index)) fail('ZIP zoom levels must be contiguous');
+  return {entries, rowSpans:makeRowSpans(entries), tileCount:entries.length,
+          totalBytes, minZoom:zooms[0], maxZoom:zooms.at(-1), prefix};
+}
+
+export function serializeSparseManifest(metadata, rowSpans, tileCount) {
+  const fields = validateMetadata(metadata);
+  if (!rowSpans.length || rowSpans.length > MAX_ROW_SPANS) fail('Invalid row-span count');
+  let total = 0;
+  for (let index = 0; index < rowSpans.length; index++) {
+    const span = rowSpans[index];
+    const world = 2 ** span.zoom;
+    if (!Number.isInteger(span.zoom) || !Number.isInteger(span.y) || !Number.isInteger(span.xMinimum) ||
+        !Number.isInteger(span.xMaximum) || span.zoom < 0 || span.zoom > MAX_ZOOM || span.y < 0 ||
+        span.y >= world || span.xMinimum < 0 || span.xMinimum > span.xMaximum || span.xMaximum >= world) fail('Invalid row span');
+    if (index && (span.zoom < rowSpans[index-1].zoom ||
+        (span.zoom === rowSpans[index-1].zoom && span.y < rowSpans[index-1].y) ||
+        (span.zoom === rowSpans[index-1].zoom && span.y === rowSpans[index-1].y && span.xMinimum <= rowSpans[index-1].xMaximum + 1))) fail('Noncanonical row spans');
+    total += span.xMaximum - span.xMinimum + 1;
+  }
+  if (total !== tileCount || tileCount <= 0) fail('Manifest tile count mismatch');
+  const stringsSize = Object.values(fields).reduce((sum, bytes) => sum + 1 + bytes.length, 0);
+  const length = 16 + stringsSize + 8 + rowSpans.length * 13 + 4;
+  const bytes = new Uint8Array(length); const view = new DataView(bytes.buffer);
+  putU32(view, 0, MANIFEST_MAGIC); bytes[4] = 2; putU16(view, 6, 16); putU32(view, 8, length);
+  let position = 16;
+  for (const field of ['packId','name','attribution','source','license']) { const value=fields[field]; bytes[position++]=value.length; bytes.set(value,position); position+=value.length; }
+  bytes[position++] = rowSpans[0].zoom; bytes[position++] = rowSpans.at(-1).zoom;
+  putU16(view, position, rowSpans.length); position += 2; putU32(view, position, tileCount); position += 4;
+  for (const span of rowSpans) { bytes[position++]=span.zoom; putU32(view,position,span.y); position+=4; putU32(view,position,span.xMinimum); position+=4; putU32(view,position,span.xMaximum); position+=4; }
+  putU32(view, position, crc32(bytes.subarray(0, position)));
+  return bytes;
+}
+
+export function parseSparseManifest(bytes) {
+  bytes = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  if (bytes.length < 28 || bytes.length > 7100) fail('Manifest length is invalid');
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (u32(view,0)!==MANIFEST_MAGIC || bytes[4]!==2 || bytes[5]!==0 || u16(view,6)!==16 || u32(view,8)!==bytes.length || u32(view,12)!==0 || u32(view,bytes.length-4)!==crc32(bytes.subarray(0,-4))) fail('Manifest header or CRC is invalid');
+  let position=16; const names=['packId','name','attribution','source','license']; const values={};
+  for (const name of names) { if(position>=bytes.length-4) fail('Manifest string truncated'); const size=bytes[position++]; if(!size||position+size>bytes.length-4) fail('Manifest string truncated'); values[name]=textDecoder.decode(bytes.subarray(position,position+size)); position+=size; }
+  if(position+8>bytes.length-4) fail('Manifest fields truncated'); const minZoom=bytes[position++], maxZoom=bytes[position++]; const count=u16(view,position); position+=2; const tileCount=u32(view,position); position+=4;
+  if(!count||count>MAX_ROW_SPANS||position+count*13!==bytes.length-4) fail('Manifest span count invalid'); const rowSpans=[];
+  for(let i=0;i<count;i++){ const zoom=bytes[position++], y=u32(view,position); position+=4; const xMinimum=u32(view,position); position+=4; const xMaximum=u32(view,position); position+=4; rowSpans.push({zoom,y,xMinimum,xMaximum}); }
+  if(minZoom!==rowSpans[0].zoom||maxZoom!==rowSpans.at(-1).zoom) fail('Manifest zoom range invalid');
+  return {...values,minZoom,maxZoom,tileCount,rowSpans};
+}
+
+function validateSelectionSpans(spans) {
+  if (!Array.isArray(spans) || spans.length === 0 || spans.length > MAX_ROW_SPANS) fail('Invalid active map-set spans');
+  let previous = null;
+  for (const span of spans) {
+    const world = 2 ** span.zoom;
+    if (!Number.isInteger(span.zoom) || !Number.isInteger(span.y) || !Number.isInteger(span.xMinimum) ||
+        !Number.isInteger(span.xMaximum) || span.zoom < 0 || span.zoom > MAX_ZOOM || span.y < 0 ||
+        span.y >= world || span.xMinimum < 0 || span.xMinimum > span.xMaximum || span.xMaximum >= world ||
+        (previous && (span.zoom < previous.zoom ||
+          (span.zoom === previous.zoom && span.y < previous.y) ||
+          (span.zoom === previous.zoom && span.y === previous.y && span.xMinimum <= previous.xMaximum + 1)))) {
+      fail('Invalid or noncanonical active map-set spans');
+    }
+    previous = span;
+  }
+}
+
+export function encodeActiveMapSet({generation, mapSetId, attribution, packs}) {
+  const mapSet = checkedAscii('Map set ID', mapSetId, 31);
+  const credit = checkedAscii('Attribution', attribution, 127);
+  if (!/^[a-z0-9_-]{1,31}$/.test(mapSetId) || !Number.isInteger(generation) || generation < 1 ||
+      generation > 0xffffffff || !Array.isArray(packs) || packs.length === 0 || packs.length > 8) {
+    fail('Invalid active map set');
+  }
+  const seen = new Set(); let spanTotal = 0; let length = 12 + 1 + mapSet.length + 1 + credit.length + 1 + 4;
+  const encodedPacks = packs.map(pack => {
+    const id = checkedAscii('Pack ID', pack.packId, 31);
+    if (!/^[a-z0-9_-]{1,31}$/.test(pack.packId) || seen.has(pack.packId)) fail('Invalid or duplicate active map-set pack');
+    seen.add(pack.packId); validateSelectionSpans(pack.rowSpans); spanTotal += pack.rowSpans.length;
+    if (spanTotal > MAX_ROW_SPANS) fail('Active map set exceeds the total row-span limit');
+    length += 1 + id.length + 2 + pack.rowSpans.length * 13;
+    return {id, pack};
+  });
+  const bytes = new Uint8Array(length); const view = new DataView(bytes.buffer);
+  putU32(view,0,SELECTION_MAGIC); bytes[4]=2; putU16(view,6,length); putU32(view,8,generation);
+  let position=12; bytes[position++]=mapSet.length; bytes.set(mapSet,position); position+=mapSet.length;
+  bytes[position++]=credit.length; bytes.set(credit,position); position+=credit.length; bytes[position++]=encodedPacks.length;
+  for (const {id,pack} of encodedPacks) {
+    bytes[position++]=id.length; bytes.set(id,position); position+=id.length; putU16(view,position,pack.rowSpans.length); position+=2;
+    for (const span of pack.rowSpans) {bytes[position++]=span.zoom;putU32(view,position,span.y);position+=4;putU32(view,position,span.xMinimum);position+=4;putU32(view,position,span.xMaximum);position+=4;}
+  }
+  putU32(view,position,crc32(bytes.subarray(0,position))); return bytes;
+}
+
+export function decodeActiveSelection(bytes) {
+  bytes=bytes instanceof Uint8Array?bytes:new Uint8Array(bytes); if(bytes.length<16||bytes.length>7105)fail('Invalid active selection length'); const view=new DataView(bytes.buffer,bytes.byteOffset,bytes.byteLength);
+  const version=bytes[4]; if(u32(view,0)!==SELECTION_MAGIC||![1,2].includes(version)||bytes[5]!==0||u16(view,6)!==bytes.length||u32(view,bytes.length-4)!==crc32(bytes.subarray(0,-4)))fail('Invalid active selection record');
+  const generation=u32(view,8);if(!generation)fail('Invalid active selection generation');
+  if(version===1){if(bytes.length!==48)fail('Invalid active selection length');const size=bytes[12];if(!size||size>31||[...bytes.subarray(13+size,44)].some(byte=>byte!==0))fail('Invalid active selection pack ID');const packId=textDecoder.decode(bytes.subarray(13,13+size));if(!/^[a-z0-9_-]{1,31}$/.test(packId))fail('Invalid active selection pack ID');return{version,packId,generation};}
+  let position=12;const readText=(label,maximum,grammar=false)=>{if(position>=bytes.length-4)fail(`${label} is truncated`);const size=bytes[position++];if(!size||size>maximum||position+size>bytes.length-4)fail(`${label} is invalid`);const value=textDecoder.decode(bytes.subarray(position,position+size));position+=size;if([...textEncoder.encode(value)].some(byte=>byte<0x20||byte>0x7e)||(grammar&&!/^[a-z0-9_-]{1,31}$/.test(value)))fail(`${label} is invalid`);return value;};
+  const mapSetId=readText('Map set ID',31,true),attribution=readText('Attribution',127);if(position>=bytes.length-4)fail('Active map-set pack count is truncated');const count=bytes[position++];if(!count||count>8)fail('Active map-set pack count is invalid');const packs=[],seen=new Set();let total=0;
+  for(let packIndex=0;packIndex<count;packIndex++){const packId=readText('Pack ID',31,true);if(seen.has(packId))fail('Duplicate active map-set pack');seen.add(packId);if(position+2>bytes.length-4)fail('Active map-set span count is truncated');const spanCount=u16(view,position);position+=2;if(!spanCount||spanCount>MAX_ROW_SPANS||position+spanCount*13>bytes.length-4)fail('Active map-set span count is invalid');const rowSpans=[];for(let index=0;index<spanCount;index++){const zoom=bytes[position++],y=u32(view,position);position+=4;const xMinimum=u32(view,position);position+=4;const xMaximum=u32(view,position);position+=4;rowSpans.push({zoom,y,xMinimum,xMaximum});}validateSelectionSpans(rowSpans);total+=spanCount;if(total>MAX_ROW_SPANS)fail('Active map set exceeds the total row-span limit');packs.push({packId,rowSpans});}
+  if(position!==bytes.length-4)fail('Active map-set record has trailing data');return{version,mapSetId,attribution,packs,generation};
+}
+
+async function getDirectory(parent,name,create=true){ return parent.getDirectoryHandle(name,{create}); }
+async function sameDirectoryEntry(left,right){return left===right||(typeof left?.isSameEntry==='function'&&await left.isSameEntry(right));}
+async function verifyNamedDirectory(parent,name,expected,allowedEntries){
+  const named=await parent.getDirectoryHandle(name);
+  if(!(await sameDirectoryEntry(expected,named)))fail(`SD destination changed during installation: ${name}`);
+  const entries=[];for await(const [entryName] of expected.entries()){entries.push(entryName);if(entries.length>allowedEntries.length)break;}
+  entries.sort();const allowed=[...allowedEntries].sort();
+  if(entries.length!==allowed.length||entries.some((entry,index)=>entry!==allowed[index]))fail(`SD destination was created concurrently or is not empty: ${name}`);
+}
+async function writeVerified(parent,name,bytes){ const handle=await parent.getFileHandle(name,{create:true}); const writable=await handle.createWritable({keepExistingData:false}); try{await writable.write(bytes);await writable.close();}catch(error){try{await writable.abort();}catch{} throw error;} const actual=new Uint8Array(await (await handle.getFile()).arrayBuffer()); if(actual.length!==bytes.length) fail(`SD read-back mismatch: ${name}`); for(let index=0;index<bytes.length;index++) if(actual[index]!==bytes[index]) fail(`SD read-back mismatch: ${name}`); return handle; }
+async function readSelection(pyxis,name){ let handle; try{handle=await pyxis.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;} const bytes=new Uint8Array(await(await handle.getFile()).arrayBuffer()); try{return decodeActiveSelection(bytes);}catch{return null;} }
+async function fileBytes(parent,name){const handle=await parent.getFileHandle(name);return new Uint8Array(await(await handle.getFile()).arrayBuffer());}
+function equalBytes(left,right){if(left.length!==right.length)return false;for(let index=0;index<left.length;index++)if(left[index]!==right[index])return false;return true;}
+async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
+  try{
+    const named=await packs.getDirectoryHandle(packId);if(!(await sameDirectoryEntry(pack,named)))return false;
+    const actual=await fileBytes(pack,receiptName);if(!equalBytes(actual,receipt))return false;
+    let tiles=null;try{tiles=await getDirectory(pack,'tiles',false);}catch(error){if(error?.name!=='NotFoundError')throw error;}
+    if(tiles){
+      const groups=new Map();for(const entry of entries){const zoom=String(entry.zoom),x=String(entry.x);if(!groups.has(zoom))groups.set(zoom,new Set());groups.get(zoom).add(x);let zoomDir,xDir;try{zoomDir=await getDirectory(tiles,zoom,false);xDir=await getDirectory(zoomDir,x,false);await xDir.removeEntry(`${entry.y}.png`);}catch(error){if(error?.name!=='NotFoundError')throw error;}}
+      for(const [zoom,xs] of groups){let zoomDir;try{zoomDir=await getDirectory(tiles,zoom,false);}catch(error){if(error?.name==='NotFoundError')continue;throw error;}for(const x of xs){try{await zoomDir.removeEntry(x);}catch(error){if(error?.name!=='NotFoundError')return false;}}try{await tiles.removeEntry(zoom);}catch(error){if(error?.name!=='NotFoundError')return false;}}
+      try{await pack.removeEntry('tiles');}catch(error){if(error?.name!=='NotFoundError')return false;}
+    }
+    try{await pack.removeEntry('manifest.pmp');}catch(error){if(error?.name!=='NotFoundError')return false;}
+    for await(const [name] of pack.entries()){if(name!==receiptName)return false;}
+    await pack.removeEntry(receiptName);await packs.removeEntry(packId);return true;
+  }catch{return false;}
+}
+
+async function prepareActiveMapSet(pyxis,metadata,rowSpans){
+  const slots=await Promise.all([readSelection(pyxis,'active-pack.0'),readSelection(pyxis,'active-pack.1')]);
+  if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
+  const valid=slots.filter(Boolean);const highest=Math.max(0,...valid.map(slot=>slot.generation));if(highest===0xffffffff)fail('Active selection generation is exhausted');
+  const current=valid.sort((left,right)=>right.generation-left.generation)[0];
+  let packs=[];
+  if(current?.version===2&&current.mapSetId===metadata.mapSetId){
+    if(current.attribution!==metadata.attribution)fail('Installed map set attribution does not match');
+    packs=current.packs.filter(pack=>pack.packId!==metadata.packId);
+  }
+  packs.unshift({packId:metadata.packId,rowSpans});
+  const target=!slots[0]?'active-pack.0':!slots[1]?'active-pack.1':slots[0].generation<=slots[1].generation?'active-pack.0':'active-pack.1';
+  const record=encodeActiveMapSet({generation:highest+1,mapSetId:metadata.mapSetId,attribution:metadata.attribution,packs});
+  return {target,record,packs};
+}
+
+async function activateMapSet(pyxis,metadata,rowSpans){
+  const {target,record}=await prepareActiveMapSet(pyxis,metadata,rowSpans);
+  await writeVerified(pyxis,target,record);const selected=decodeActiveSelection(await fileBytes(pyxis,target));
+  if(selected.version!==2||selected.mapSetId!==metadata.mapSetId||selected.packs[0].packId!==metadata.packId)fail('Active map-set verification failed');
+  return {selectionFile:target,enabledPacks:selected.packs.map(pack=>pack.packId)};
+}
+
+async function verifyExistingPack(pack,archive,report,manifest){
+  if(!equalBytes(await fileBytes(pack,'manifest.pmp'),manifest))fail('Existing pack does not match this ZIP and metadata');
+  const tiles=await getDirectory(pack,'tiles',false);
+  for(const entry of report.entries){const zoom=await getDirectory(tiles,String(entry.zoom),false);const x=await getDirectory(zoom,String(entry.x),false);const actual=await fileBytes(x,`${entry.y}.png`);const expected=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(!equalBytes(actual,expected))fail(`Existing pack tile differs: ${entry.name}`);}
+}
+
+async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()=>{}}){
+  validateMetadata(metadata);if(!/^[a-z0-9_-]{1,31}$/.test(metadata.mapSetId||''))fail('Map set ID is invalid');if(!rootDirectory||rootDirectory.kind!=='directory')fail('Choose an SD-card directory');
+  const report=await inspectMuiZip(archive,{onProgress});const manifest=serializeSparseManifest(metadata,report.rowSpans,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
+  await prepareActiveMapSet(pyxis,metadata,report.rowSpans);const packs=await getDirectory(pyxis,'packs');
+  let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
+  if(existing){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata,report.rowSpans);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
+  const pack=await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
+  try{
+    await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
+    const tiles=await getDirectory(pack,'tiles');
+    for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});}
+    await writeVerified(pack,'manifest.pmp',manifest);parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
+    try{await pack.removeEntry(receiptName);}catch(error){throw new Error(`Map pack is installed and verified, but its ownership receipt could not be removed: ${error.message}`);}
+    try{const active=await activateMapSet(pyxis,metadata,report.rowSpans);return{...report,manifestBytes:manifest.length,resumed:false,...active};}
+    catch(error){throw new Error(`Map pack is installed and verified, but activation failed; retry with the same ZIP and pack ID: ${error.message}`);}
+  }catch(error){
+    if(!published&&!(await removeOwnedPack(packs,metadata.packId,pack,receiptName,receipt,report.entries))){
+      throw new Error(`${error.message}; the incomplete pack could not be safely removed because its ownership receipt was missing or cleanup failed`);
+    }
+    throw error;
+  }
+}
+
+export async function installMuiZip(arguments_) {
+  const rootDirectory = arguments_?.rootDirectory;
+  if (!rootDirectory || (typeof rootDirectory !== 'object' && typeof rootDirectory !== 'function')) {
+    return installMuiZipLocked(arguments_ || {});
+  }
+  return withInstallLock(rootDirectory, () => installMuiZipLocked(arguments_));
+}

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -537,7 +537,7 @@ async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
     }
     try{await pack.removeEntry('manifest.pmp');}catch(error){if(error?.name!=='NotFoundError')return false;}
     for await(const [name] of pack.entries()){if(name!==receiptName)return false;}
-    await pack.removeEntry(receiptName);await packs.removeEntry(packId);return true;
+    await pack.removeEntry(receiptName);return true;
   }catch{return false;}
 }
 
@@ -575,8 +575,11 @@ async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()
   const report=await inspectMuiZip(archive,{onProgress});const manifest=serializeSparseManifest(metadata,report.rowSpans,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
   await prepareActiveMapSet(pyxis,metadata,report.rowSpans);const packs=await getDirectory(pyxis,'packs');
   let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
-  if(existing){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata,report.rowSpans);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
-  const pack=await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
+  if(existing){
+    let empty=true;for await(const _entry of existing.entries()){empty=false;break;}
+    if(!empty){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata,report.rowSpans);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
+  }
+  const pack=existing||await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
   try{
     await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
     const tiles=await getDirectory(pack,'tiles');

--- a/docs/flasher/js/vendor/README.md
+++ b/docs/flasher/js/vendor/README.md
@@ -1,0 +1,11 @@
+# Vendored fflate
+
+- Version: 0.8.3
+- Source: https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz
+- npm integrity: `sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==`
+- Repository: https://github.com/101arrowz/fflate
+- Vendored file: `esm/browser.js`
+- Vendored file SHA-256: `b7ca4450b19559a1d50eb381adcee94b82449674be4cd17789d9beba7e6122a1`
+- License: MIT; see `fflate.LICENSE`.
+
+This local copy supplies bounded streaming zlib inflation for hostile PNG validation. The installer makes no runtime CDN requests.

--- a/docs/flasher/js/vendor/fflate.LICENSE
+++ b/docs/flasher/js/vendor/fflate.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Arjun Barrett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/flasher/js/vendor/fflate.js
+++ b/docs/flasher/js/vendor/fflate.js
@@ -1,0 +1,2692 @@
+// DEFLATE is a complex format; to read this code, you should probably check the RFC first:
+// https://tools.ietf.org/html/rfc1951
+// You may also wish to take a look at the guide I made about this program:
+// https://gist.github.com/101arrowz/253f31eb5abc3d9275ab943003ffecad
+// Some of the following code is similar to that of UZIP.js:
+// https://github.com/photopea/UZIP.js
+// However, the vast majority of the codebase has diverged from UZIP.js to increase performance and reduce bundle size.
+// Sometimes 0 will appear where -1 would be more appropriate. This is because using a uint
+// is better for memory in most engines (I *think*).
+var ch2 = {};
+var wk = (function (c, id, msg, transfer, cb) {
+    var w = new Worker(ch2[id] || (ch2[id] = URL.createObjectURL(new Blob([
+        c + ';addEventListener("error",function(e){e=e.error;postMessage({$e$:[e.message,e.code,e.stack]})})'
+    ], { type: 'text/javascript' }))));
+    w.onmessage = function (e) {
+        var d = e.data, ed = d.$e$;
+        if (ed) {
+            var err = new Error(ed[0]);
+            err['code'] = ed[1];
+            err.stack = ed[2];
+            cb(err, null);
+        }
+        else
+            cb(null, d);
+    };
+    w.postMessage(msg, transfer);
+    return w;
+});
+
+// aliases for shorter compressed code (most minifers don't do this)
+var u8 = Uint8Array, u16 = Uint16Array, i32 = Int32Array;
+// fixed length extra bits
+var fleb = new u8([0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0, /* unused */ 0, 0, /* impossible */ 0]);
+// fixed distance extra bits
+var fdeb = new u8([0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, /* unused */ 0, 0]);
+// code length index map
+var clim = new u8([16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15]);
+// get base, reverse index map from extra bits
+var freb = function (eb, start) {
+    var b = new u16(31);
+    for (var i = 0; i < 31; ++i) {
+        b[i] = start += 1 << eb[i - 1];
+    }
+    // numbers here are at max 18 bits
+    var r = new i32(b[30]);
+    for (var i = 1; i < 30; ++i) {
+        for (var j = b[i]; j < b[i + 1]; ++j) {
+            r[j] = ((j - b[i]) << 5) | i;
+        }
+    }
+    return { b: b, r: r };
+};
+var _a = freb(fleb, 2), fl = _a.b, revfl = _a.r;
+// we can ignore the fact that the other numbers are wrong; they never happen anyway
+fl[28] = 258, revfl[258] = 28;
+var _b = freb(fdeb, 0), fd = _b.b, revfd = _b.r;
+// map of value to reverse (assuming 16 bits)
+var rev = new u16(32768);
+for (var i = 0; i < 32768; ++i) {
+    // reverse table algorithm from SO
+    var x = ((i & 0xAAAA) >> 1) | ((i & 0x5555) << 1);
+    x = ((x & 0xCCCC) >> 2) | ((x & 0x3333) << 2);
+    x = ((x & 0xF0F0) >> 4) | ((x & 0x0F0F) << 4);
+    rev[i] = (((x & 0xFF00) >> 8) | ((x & 0x00FF) << 8)) >> 1;
+}
+// create huffman tree from u8 "map": index -> code length for code index
+// mb (max bits) must be at most 15
+// TODO: optimize/split up?
+var hMap = (function (cd, mb, r) {
+    var s = cd.length;
+    // index
+    var i = 0;
+    // u16 "map": index -> # of codes with bit length = index
+    var l = new u16(mb);
+    // length of cd must be 288 (total # of codes)
+    for (; i < s; ++i) {
+        if (cd[i])
+            ++l[cd[i] - 1];
+    }
+    // u16 "map": index -> minimum code for bit length = index
+    var le = new u16(mb);
+    for (i = 1; i < mb; ++i) {
+        le[i] = (le[i - 1] + l[i - 1]) << 1;
+    }
+    var co;
+    if (r) {
+        // u16 "map": index -> number of actual bits, symbol for code
+        co = new u16(1 << mb);
+        // bits to remove for reverser
+        var rvb = 15 - mb;
+        for (i = 0; i < s; ++i) {
+            // ignore 0 lengths
+            if (cd[i]) {
+                // num encoding both symbol and bits read
+                var sv = (i << 4) | cd[i];
+                // free bits
+                var r_1 = mb - cd[i];
+                // start value
+                var v = le[cd[i] - 1]++ << r_1;
+                // m is end value
+                for (var m = v | ((1 << r_1) - 1); v <= m; ++v) {
+                    // every 16 bit value starting with the code yields the same result
+                    co[rev[v] >> rvb] = sv;
+                }
+            }
+        }
+    }
+    else {
+        co = new u16(s);
+        for (i = 0; i < s; ++i) {
+            if (cd[i]) {
+                co[i] = rev[le[cd[i] - 1]++] >> (15 - cd[i]);
+            }
+        }
+    }
+    return co;
+});
+// fixed length tree
+var flt = new u8(288);
+for (var i = 0; i < 144; ++i)
+    flt[i] = 8;
+for (var i = 144; i < 256; ++i)
+    flt[i] = 9;
+for (var i = 256; i < 280; ++i)
+    flt[i] = 7;
+for (var i = 280; i < 288; ++i)
+    flt[i] = 8;
+// fixed distance tree
+var fdt = new u8(32);
+for (var i = 0; i < 32; ++i)
+    fdt[i] = 5;
+// fixed length map
+var flm = /*#__PURE__*/ hMap(flt, 9, 0), flrm = /*#__PURE__*/ hMap(flt, 9, 1);
+// fixed distance map
+var fdm = /*#__PURE__*/ hMap(fdt, 5, 0), fdrm = /*#__PURE__*/ hMap(fdt, 5, 1);
+// find max of array
+var max = function (a) {
+    var m = a[0];
+    for (var i = 1; i < a.length; ++i) {
+        if (a[i] > m)
+            m = a[i];
+    }
+    return m;
+};
+// read d, starting at bit p and mask with m
+var bits = function (d, p, m) {
+    var o = (p / 8) | 0;
+    return ((d[o] | (d[o + 1] << 8)) >> (p & 7)) & m;
+};
+// read d, starting at bit p continuing for at least 16 bits
+var bits16 = function (d, p) {
+    var o = (p / 8) | 0;
+    return ((d[o] | (d[o + 1] << 8) | (d[o + 2] << 16)) >> (p & 7));
+};
+// get end of byte
+var shft = function (p) { return ((p + 7) / 8) | 0; };
+// typed array slice - allows garbage collector to free original reference,
+// while being more compatible than .slice
+var slc = function (v, s, e) {
+    if (s == null || s < 0)
+        s = 0;
+    if (e == null || e > v.length)
+        e = v.length;
+    // can't use .constructor in case user-supplied
+    return new u8(v.subarray(s, e));
+};
+/**
+ * Codes for errors generated within this library
+ */
+export var FlateErrorCode = {
+    UnexpectedEOF: 0,
+    InvalidBlockType: 1,
+    InvalidLengthLiteral: 2,
+    InvalidDistance: 3,
+    StreamFinished: 4,
+    NoStreamHandler: 5,
+    InvalidHeader: 6,
+    NoCallback: 7,
+    InvalidUTF8: 8,
+    ExtraFieldTooLong: 9,
+    InvalidDate: 10,
+    FilenameTooLong: 11,
+    StreamFinishing: 12,
+    InvalidZipData: 13,
+    UnknownCompressionMethod: 14
+};
+// error codes
+var ec = [
+    'unexpected EOF',
+    'invalid block type',
+    'invalid length/literal',
+    'invalid distance',
+    'stream finished',
+    'no stream handler',
+    , // determined by compression function
+    'no callback',
+    'invalid UTF-8 data',
+    'extra field too long',
+    'date not in range 1980-2099',
+    'filename too long',
+    'stream finishing',
+    'invalid zip data'
+    // determined by unknown compression method
+];
+;
+var err = function (ind, msg, nt) {
+    var e = new Error(msg || ec[ind]);
+    e.code = ind;
+    if (Error.captureStackTrace)
+        Error.captureStackTrace(e, err);
+    if (!nt)
+        throw e;
+    return e;
+};
+// expands raw DEFLATE data
+var inflt = function (dat, st, buf, dict) {
+    // source length       dict length
+    var sl = dat.length, dl = dict ? dict.length : 0;
+    if (!sl || st.f && !st.l)
+        return buf || new u8(0);
+    var noBuf = !buf;
+    // have to estimate size
+    var resize = noBuf || st.i != 2;
+    // no state
+    var noSt = st.i;
+    // Assumes roughly 33% compression ratio average
+    if (noBuf)
+        buf = new u8(sl * 3);
+    // ensure buffer can fit at least l elements
+    var cbuf = function (l) {
+        var bl = buf.length;
+        // need to increase size to fit
+        if (l > bl) {
+            // Double or set to necessary, whichever is greater
+            var nbuf = new u8(Math.max(bl * 2, l));
+            nbuf.set(buf);
+            buf = nbuf;
+        }
+    };
+    //  last chunk         bitpos           bytes
+    var final = st.f || 0, pos = st.p || 0, bt = st.b || 0, lm = st.l, dm = st.d, lbt = st.m, dbt = st.n;
+    // total bits
+    var tbts = sl * 8;
+    do {
+        if (!lm) {
+            // BFINAL - this is only 1 when last chunk is next
+            final = bits(dat, pos, 1);
+            // type: 0 = no compression, 1 = fixed huffman, 2 = dynamic huffman
+            var type = bits(dat, pos + 1, 3);
+            pos += 3;
+            if (!type) {
+                // go to end of byte boundary
+                var s = shft(pos) + 4, l = dat[s - 4] | (dat[s - 3] << 8), t = s + l;
+                if (t > sl) {
+                    if (noSt)
+                        err(0);
+                    break;
+                }
+                // ensure size
+                if (resize)
+                    cbuf(bt + l);
+                // Copy over uncompressed data
+                buf.set(dat.subarray(s, t), bt);
+                // Get new bitpos, update byte count
+                st.b = bt += l, st.p = pos = t * 8, st.f = final;
+                continue;
+            }
+            else if (type == 1)
+                lm = flrm, dm = fdrm, lbt = 9, dbt = 5;
+            else if (type == 2) {
+                //  literal                            lengths
+                var hLit = bits(dat, pos, 31) + 257, hcLen = bits(dat, pos + 10, 15) + 4;
+                var tl = hLit + bits(dat, pos + 5, 31) + 1;
+                pos += 14;
+                // length+distance tree
+                var ldt = new u8(tl);
+                // code length tree
+                var clt = new u8(19);
+                for (var i = 0; i < hcLen; ++i) {
+                    // use index map to get real code
+                    clt[clim[i]] = bits(dat, pos + i * 3, 7);
+                }
+                pos += hcLen * 3;
+                // code lengths bits
+                var clb = max(clt), clbmsk = (1 << clb) - 1;
+                // code lengths map
+                var clm = hMap(clt, clb, 1);
+                for (var i = 0; i < tl;) {
+                    var r = clm[bits(dat, pos, clbmsk)];
+                    // bits read
+                    pos += r & 15;
+                    // symbol
+                    var s = r >> 4;
+                    // code length to copy
+                    if (s < 16) {
+                        ldt[i++] = s;
+                    }
+                    else {
+                        //  copy   count
+                        var c = 0, n = 0;
+                        if (s == 16)
+                            n = 3 + bits(dat, pos, 3), pos += 2, c = ldt[i - 1];
+                        else if (s == 17)
+                            n = 3 + bits(dat, pos, 7), pos += 3;
+                        else if (s == 18)
+                            n = 11 + bits(dat, pos, 127), pos += 7;
+                        while (n--)
+                            ldt[i++] = c;
+                    }
+                }
+                //    length tree                 distance tree
+                var lt = ldt.subarray(0, hLit), dt = ldt.subarray(hLit);
+                // max length bits
+                lbt = max(lt);
+                // max dist bits
+                dbt = max(dt);
+                lm = hMap(lt, lbt, 1);
+                dm = hMap(dt, dbt, 1);
+            }
+            else
+                err(1);
+            if (pos > tbts) {
+                if (noSt)
+                    err(0);
+                break;
+            }
+        }
+        // Make sure the buffer can hold this + the largest possible addition
+        // Maximum chunk size (practically, theoretically infinite) is 2^17
+        if (resize)
+            cbuf(bt + 131072);
+        var lms = (1 << lbt) - 1, dms = (1 << dbt) - 1;
+        var lpos = pos;
+        for (;; lpos = pos) {
+            // bits read, code
+            var c = lm[bits16(dat, pos) & lms], sym = c >> 4;
+            pos += c & 15;
+            if (pos > tbts) {
+                if (noSt)
+                    err(0);
+                break;
+            }
+            if (!c)
+                err(2);
+            if (sym < 256)
+                buf[bt++] = sym;
+            else if (sym == 256) {
+                lpos = pos, lm = null;
+                break;
+            }
+            else {
+                var add = sym - 254;
+                // no extra bits needed if less
+                if (sym > 264) {
+                    // index
+                    var i = sym - 257, b = fleb[i];
+                    add = bits(dat, pos, (1 << b) - 1) + fl[i];
+                    pos += b;
+                }
+                // dist
+                var d = dm[bits16(dat, pos) & dms], dsym = d >> 4;
+                if (!d)
+                    err(3);
+                pos += d & 15;
+                var dt = fd[dsym];
+                if (dsym > 3) {
+                    var b = fdeb[dsym];
+                    dt += bits16(dat, pos) & (1 << b) - 1, pos += b;
+                }
+                if (pos > tbts) {
+                    if (noSt)
+                        err(0);
+                    break;
+                }
+                if (resize)
+                    cbuf(bt + 131072);
+                var end = bt + add;
+                if (bt < dt) {
+                    var shift = dl - dt, dend = Math.min(dt, end);
+                    if (shift + bt < 0)
+                        err(3);
+                    for (; bt < dend; ++bt)
+                        buf[bt] = dict[shift + bt];
+                }
+                for (; bt < end; ++bt)
+                    buf[bt] = buf[bt - dt];
+            }
+        }
+        st.l = lm, st.p = lpos, st.b = bt, st.f = final;
+        if (lm)
+            final = 1, st.m = lbt, st.d = dm, st.n = dbt;
+    } while (!final);
+    // don't reallocate for streams or user buffers
+    return bt != buf.length && noBuf ? slc(buf, 0, bt) : buf.subarray(0, bt);
+};
+// starting at p, write the minimum number of bits that can hold v to d
+var wbits = function (d, p, v) {
+    v <<= p & 7;
+    var o = (p / 8) | 0;
+    d[o] |= v;
+    d[o + 1] |= v >> 8;
+};
+// starting at p, write the minimum number of bits (>8) that can hold v to d
+var wbits16 = function (d, p, v) {
+    v <<= p & 7;
+    var o = (p / 8) | 0;
+    d[o] |= v;
+    d[o + 1] |= v >> 8;
+    d[o + 2] |= v >> 16;
+};
+// creates code lengths from a frequency table
+var hTree = function (d, mb) {
+    // Need extra info to make a tree
+    var t = [];
+    for (var i = 0; i < d.length; ++i) {
+        if (d[i])
+            t.push({ s: i, f: d[i] });
+    }
+    var s = t.length;
+    var t2 = t.slice();
+    if (!s)
+        return { t: et, l: 0 };
+    if (s == 1) {
+        var v = new u8(t[0].s + 1);
+        v[t[0].s] = 1;
+        return { t: v, l: 1 };
+    }
+    t.sort(function (a, b) { return a.f - b.f; });
+    // after i2 reaches last ind, will be stopped
+    // freq must be greater than largest possible number of symbols
+    t.push({ s: -1, f: 25001 });
+    var l = t[0], r = t[1], i0 = 0, i1 = 1, i2 = 2;
+    t[0] = { s: -1, f: l.f + r.f, l: l, r: r };
+    // efficient algorithm from UZIP.js
+    // i0 is lookbehind, i2 is lookahead - after processing two low-freq
+    // symbols that combined have high freq, will start processing i2 (high-freq,
+    // non-composite) symbols instead
+    // see https://reddit.com/r/photopea/comments/ikekht/uzipjs_questions/
+    while (i1 != s - 1) {
+        l = t[t[i0].f < t[i2].f ? i0++ : i2++];
+        r = t[i0 != i1 && t[i0].f < t[i2].f ? i0++ : i2++];
+        t[i1++] = { s: -1, f: l.f + r.f, l: l, r: r };
+    }
+    var maxSym = t2[0].s;
+    for (var i = 1; i < s; ++i) {
+        if (t2[i].s > maxSym)
+            maxSym = t2[i].s;
+    }
+    // code lengths
+    var tr = new u16(maxSym + 1);
+    // max bits in tree
+    var mbt = ln(t[i1 - 1], tr, 0);
+    if (mbt > mb) {
+        // more algorithms from UZIP.js
+        // TODO: find out how this code works (debt)
+        //  ind    debt
+        var i = 0, dt = 0;
+        //    left            cost
+        var lft = mbt - mb, cst = 1 << lft;
+        t2.sort(function (a, b) { return tr[b.s] - tr[a.s] || a.f - b.f; });
+        for (; i < s; ++i) {
+            var i2_1 = t2[i].s;
+            if (tr[i2_1] > mb) {
+                dt += cst - (1 << (mbt - tr[i2_1]));
+                tr[i2_1] = mb;
+            }
+            else
+                break;
+        }
+        dt >>= lft;
+        while (dt > 0) {
+            var i2_2 = t2[i].s;
+            if (tr[i2_2] < mb)
+                dt -= 1 << (mb - tr[i2_2]++ - 1);
+            else
+                ++i;
+        }
+        for (; i >= 0 && dt; --i) {
+            var i2_3 = t2[i].s;
+            if (tr[i2_3] == mb) {
+                --tr[i2_3];
+                ++dt;
+            }
+        }
+        mbt = mb;
+    }
+    return { t: new u8(tr), l: mbt };
+};
+// get the max length and assign length codes
+var ln = function (n, l, d) {
+    return n.s == -1
+        ? Math.max(ln(n.l, l, d + 1), ln(n.r, l, d + 1))
+        : (l[n.s] = d);
+};
+// length codes generation
+var lc = function (c) {
+    var s = c.length;
+    // Note that the semicolon was intentional
+    while (s && !c[--s])
+        ;
+    var cl = new u16(++s);
+    //  ind      num         streak
+    var cli = 0, cln = c[0], cls = 1;
+    var w = function (v) { cl[cli++] = v; };
+    for (var i = 1; i <= s; ++i) {
+        if (c[i] == cln && i != s)
+            ++cls;
+        else {
+            if (!cln && cls > 2) {
+                for (; cls > 138; cls -= 138)
+                    w(32754);
+                if (cls > 2) {
+                    w(cls > 10 ? ((cls - 11) << 5) | 28690 : ((cls - 3) << 5) | 12305);
+                    cls = 0;
+                }
+            }
+            else if (cls > 3) {
+                w(cln), --cls;
+                for (; cls > 6; cls -= 6)
+                    w(8304);
+                if (cls > 2)
+                    w(((cls - 3) << 5) | 8208), cls = 0;
+            }
+            while (cls--)
+                w(cln);
+            cls = 1;
+            cln = c[i];
+        }
+    }
+    return { c: cl.subarray(0, cli), n: s };
+};
+// calculate the length of output from tree, code lengths
+var clen = function (cf, cl) {
+    var l = 0;
+    for (var i = 0; i < cl.length; ++i)
+        l += cf[i] * cl[i];
+    return l;
+};
+// writes a fixed block
+// returns the new bit pos
+var wfblk = function (out, pos, dat) {
+    // no need to write 00 as type: TypedArray defaults to 0
+    var s = dat.length;
+    var o = shft(pos + 2);
+    out[o] = s & 255;
+    out[o + 1] = s >> 8;
+    out[o + 2] = out[o] ^ 255;
+    out[o + 3] = out[o + 1] ^ 255;
+    for (var i = 0; i < s; ++i)
+        out[o + i + 4] = dat[i];
+    return (o + 4 + s) * 8;
+};
+// writes a block
+var wblk = function (dat, out, final, syms, lf, df, eb, li, bs, bl, p) {
+    wbits(out, p++, final);
+    ++lf[256];
+    var _a = hTree(lf, 15), dlt = _a.t, mlb = _a.l;
+    var _b = hTree(df, 15), ddt = _b.t, mdb = _b.l;
+    var _c = lc(dlt), lclt = _c.c, nlc = _c.n;
+    var _d = lc(ddt), lcdt = _d.c, ndc = _d.n;
+    var lcfreq = new u16(19);
+    for (var i = 0; i < lclt.length; ++i)
+        ++lcfreq[lclt[i] & 31];
+    for (var i = 0; i < lcdt.length; ++i)
+        ++lcfreq[lcdt[i] & 31];
+    var _e = hTree(lcfreq, 7), lct = _e.t, mlcb = _e.l;
+    var nlcc = 19;
+    for (; nlcc > 4 && !lct[clim[nlcc - 1]]; --nlcc)
+        ;
+    var flen = (bl + 5) << 3;
+    var ftlen = clen(lf, flt) + clen(df, fdt) + eb;
+    var dtlen = clen(lf, dlt) + clen(df, ddt) + eb + 14 + 3 * nlcc + clen(lcfreq, lct) + 2 * lcfreq[16] + 3 * lcfreq[17] + 7 * lcfreq[18];
+    if (bs >= 0 && flen <= ftlen && flen <= dtlen)
+        return wfblk(out, p, dat.subarray(bs, bs + bl));
+    var lm, ll, dm, dl;
+    wbits(out, p, 1 + (dtlen < ftlen)), p += 2;
+    if (dtlen < ftlen) {
+        lm = hMap(dlt, mlb, 0), ll = dlt, dm = hMap(ddt, mdb, 0), dl = ddt;
+        var llm = hMap(lct, mlcb, 0);
+        wbits(out, p, nlc - 257);
+        wbits(out, p + 5, ndc - 1);
+        wbits(out, p + 10, nlcc - 4);
+        p += 14;
+        for (var i = 0; i < nlcc; ++i)
+            wbits(out, p + 3 * i, lct[clim[i]]);
+        p += 3 * nlcc;
+        var lcts = [lclt, lcdt];
+        for (var it = 0; it < 2; ++it) {
+            var clct = lcts[it];
+            for (var i = 0; i < clct.length; ++i) {
+                var len = clct[i] & 31;
+                wbits(out, p, llm[len]), p += lct[len];
+                if (len > 15)
+                    wbits(out, p, (clct[i] >> 5) & 127), p += clct[i] >> 12;
+            }
+        }
+    }
+    else {
+        lm = flm, ll = flt, dm = fdm, dl = fdt;
+    }
+    for (var i = 0; i < li; ++i) {
+        var sym = syms[i];
+        if (sym > 255) {
+            var len = (sym >> 18) & 31;
+            wbits16(out, p, lm[len + 257]), p += ll[len + 257];
+            if (len > 7)
+                wbits(out, p, (sym >> 23) & 31), p += fleb[len];
+            var dst = sym & 31;
+            wbits16(out, p, dm[dst]), p += dl[dst];
+            if (dst > 3)
+                wbits16(out, p, (sym >> 5) & 8191), p += fdeb[dst];
+        }
+        else {
+            wbits16(out, p, lm[sym]), p += ll[sym];
+        }
+    }
+    wbits16(out, p, lm[256]);
+    return p + ll[256];
+};
+// deflate options (nice << 13) | chain
+var deo = /*#__PURE__*/ new i32([65540, 131080, 131088, 131104, 262176, 1048704, 1048832, 2114560, 2117632]);
+// empty
+var et = /*#__PURE__*/ new u8(0);
+// compresses data into a raw DEFLATE buffer
+var dflt = function (dat, lvl, plvl, pre, post, st) {
+    var s = st.z || dat.length;
+    var o = new u8(pre + s + 5 * (1 + Math.ceil(s / 7000)) + post);
+    // writing to this writes to the output buffer
+    var w = o.subarray(pre, o.length - post);
+    var lst = st.l;
+    var pos = (st.r || 0) & 7;
+    if (lvl) {
+        if (pos)
+            w[0] = st.r >> 3;
+        var opt = deo[lvl - 1];
+        var n = opt >> 13, c = opt & 8191;
+        var msk_1 = (1 << plvl) - 1;
+        //    prev 2-byte val map    curr 2-byte val map
+        var prev = st.p || new u16(32768), head = st.h || new u16(msk_1 + 1);
+        var bs1_1 = Math.ceil(plvl / 3), bs2_1 = 2 * bs1_1;
+        var hsh = function (i) { return (dat[i] ^ (dat[i + 1] << bs1_1) ^ (dat[i + 2] << bs2_1)) & msk_1; };
+        // 24576 is an arbitrary number of maximum symbols per block
+        // 424 buffer for last block
+        var syms = new i32(25000);
+        // length/literal freq   distance freq
+        var lf = new u16(288), df = new u16(32);
+        //  l/lcnt  exbits  index          l/lind  waitdx          blkpos
+        var lc_1 = 0, eb = 0, i = st.i || 0, li = 0, wi = st.w || 0, bs = 0;
+        for (; i + 2 < s; ++i) {
+            // hash value
+            var hv = hsh(i);
+            // index mod 32768    previous index mod
+            var imod = i & 32767, pimod = head[hv];
+            prev[imod] = pimod;
+            head[hv] = imod;
+            // We always should modify head and prev, but only add symbols if
+            // this data is not yet processed ("wait" for wait index)
+            if (wi <= i) {
+                // bytes remaining
+                var rem = s - i;
+                if ((lc_1 > 7000 || li > 24576) && (rem > 423 || !lst)) {
+                    pos = wblk(dat, w, 0, syms, lf, df, eb, li, bs, i - bs, pos);
+                    li = lc_1 = eb = 0, bs = i;
+                    for (var j = 0; j < 286; ++j)
+                        lf[j] = 0;
+                    for (var j = 0; j < 30; ++j)
+                        df[j] = 0;
+                }
+                //  len    dist   chain
+                var l = 2, d = 0, ch_1 = c, dif = imod - pimod & 32767;
+                if (rem > 2 && hv == hsh(i - dif)) {
+                    var maxn = Math.min(n, rem) - 1;
+                    var maxd = Math.min(32767, i);
+                    // max possible length
+                    // not capped at dif because decompressors implement "rolling" index population
+                    var ml = Math.min(258, rem);
+                    while (dif <= maxd && --ch_1 && imod != pimod) {
+                        if (dat[i + l] == dat[i + l - dif]) {
+                            var nl = 0;
+                            for (; nl < ml && dat[i + nl] == dat[i + nl - dif]; ++nl)
+                                ;
+                            if (nl > l) {
+                                l = nl, d = dif;
+                                // break out early when we reach "nice" (we are satisfied enough)
+                                if (nl > maxn)
+                                    break;
+                                // now, find the rarest 2-byte sequence within this
+                                // length of literals and search for that instead.
+                                // Much faster than just using the start
+                                var mmd = Math.min(dif, nl - 2);
+                                var md = 0;
+                                for (var j = 0; j < mmd; ++j) {
+                                    var ti = i - dif + j & 32767;
+                                    var pti = prev[ti];
+                                    var cd = ti - pti & 32767;
+                                    if (cd > md)
+                                        md = cd, pimod = ti;
+                                }
+                            }
+                        }
+                        // check the previous match
+                        imod = pimod, pimod = prev[imod];
+                        dif += imod - pimod & 32767;
+                    }
+                }
+                // d will be nonzero only when a match was found
+                if (d) {
+                    // store both dist and len data in one int32
+                    // Make sure this is recognized as a len/dist with 28th bit (2^28)
+                    syms[li++] = 268435456 | (revfl[l] << 18) | revfd[d];
+                    var lin = revfl[l] & 31, din = revfd[d] & 31;
+                    eb += fleb[lin] + fdeb[din];
+                    ++lf[257 + lin];
+                    ++df[din];
+                    wi = i + l;
+                    ++lc_1;
+                }
+                else {
+                    syms[li++] = dat[i];
+                    ++lf[dat[i]];
+                }
+            }
+        }
+        for (i = Math.max(i, wi); i < s; ++i) {
+            syms[li++] = dat[i];
+            ++lf[dat[i]];
+        }
+        pos = wblk(dat, w, lst, syms, lf, df, eb, li, bs, i - bs, pos);
+        if (!lst) {
+            st.r = (pos & 7) | w[(pos / 8) | 0] << 3;
+            // shft(pos) now 1 less if pos & 7 != 0
+            pos -= 7;
+            st.h = head, st.p = prev, st.i = i, st.w = wi;
+        }
+    }
+    else {
+        for (var i = st.w || 0; i < s + lst; i += 65535) {
+            // end
+            var e = i + 65535;
+            if (e >= s) {
+                // write final block
+                w[(pos / 8) | 0] = lst;
+                e = s;
+            }
+            pos = wfblk(w, pos + 1, dat.subarray(i, e));
+        }
+        st.i = s;
+    }
+    return slc(o, 0, pre + shft(pos) + post);
+};
+// CRC32 table
+var crct = /*#__PURE__*/ (function () {
+    var t = new Int32Array(256);
+    for (var i = 0; i < 256; ++i) {
+        var c = i, k = 9;
+        while (--k)
+            c = ((c & 1) && -306674912) ^ (c >>> 1);
+        t[i] = c;
+    }
+    return t;
+})();
+// CRC32
+var crc = function () {
+    var c = -1;
+    return {
+        p: function (d) {
+            // closures have awful performance
+            var cr = c;
+            for (var i = 0; i < d.length; ++i)
+                cr = crct[(cr & 255) ^ d[i]] ^ (cr >>> 8);
+            c = cr;
+        },
+        d: function () { return ~c; }
+    };
+};
+// Adler32
+var adler = function () {
+    var a = 1, b = 0;
+    return {
+        p: function (d) {
+            // closures have awful performance
+            var n = a, m = b;
+            var l = d.length | 0;
+            for (var i = 0; i != l;) {
+                var e = Math.min(i + 2655, l);
+                for (; i < e; ++i)
+                    m += n += d[i];
+                n = (n & 65535) + 15 * (n >> 16), m = (m & 65535) + 15 * (m >> 16);
+            }
+            a = n, b = m;
+        },
+        d: function () {
+            a %= 65521, b %= 65521;
+            return (a & 255) << 24 | (a & 0xFF00) << 8 | (b & 255) << 8 | (b >> 8);
+        }
+    };
+};
+;
+// deflate with opts
+var dopt = function (dat, opt, pre, post, st) {
+    if (!st) {
+        st = { l: 1 };
+        if (opt.dictionary) {
+            var dict = opt.dictionary.subarray(-32768);
+            var newDat = new u8(dict.length + dat.length);
+            newDat.set(dict);
+            newDat.set(dat, dict.length);
+            dat = newDat;
+            st.w = dict.length;
+        }
+    }
+    return dflt(dat, opt.level == null ? 6 : opt.level, opt.mem == null ? (st.l ? Math.ceil(Math.max(8, Math.min(13, Math.log(dat.length))) * 1.5) : 20) : (12 + opt.mem), pre, post, st);
+};
+// Walmart object spread
+var mrg = function (a, b) {
+    var o = {};
+    for (var k in a)
+        o[k] = a[k];
+    for (var k in b)
+        o[k] = b[k];
+    return o;
+};
+// worker clone
+// This is possibly the craziest part of the entire codebase, despite how simple it may seem.
+// The only parameter to this function is a closure that returns an array of variables outside of the function scope.
+// We're going to try to figure out the variable names used in the closure as strings because that is crucial for workerization.
+// We will return an object mapping of true variable name to value (basically, the current scope as a JS object).
+// The reason we can't just use the original variable names is minifiers mangling the toplevel scope.
+// This took me three weeks to figure out how to do.
+var wcln = function (fn, fnStr, td) {
+    var dt = fn();
+    var st = fn.toString();
+    var ks = st.slice(st.indexOf('[') + 1, st.lastIndexOf(']')).replace(/\s+/g, '').split(',');
+    for (var i = 0; i < dt.length; ++i) {
+        var v = dt[i], k = ks[i];
+        if (typeof v == 'function') {
+            fnStr += ';' + k + '=';
+            var st_1 = v.toString();
+            if (v.prototype) {
+                // for global objects
+                if (st_1.indexOf('[native code]') != -1) {
+                    var spInd = st_1.indexOf(' ', 8) + 1;
+                    fnStr += st_1.slice(spInd, st_1.indexOf('(', spInd));
+                }
+                else {
+                    fnStr += st_1;
+                    for (var t in v.prototype)
+                        fnStr += ';' + k + '.prototype.' + t + '=' + v.prototype[t].toString();
+                }
+            }
+            else
+                fnStr += st_1;
+        }
+        else
+            td[k] = v;
+    }
+    return fnStr;
+};
+var ch = [];
+// clone bufs
+var cbfs = function (v) {
+    var tl = [];
+    for (var k in v) {
+        if (v[k].buffer) {
+            tl.push((v[k] = new v[k].constructor(v[k])).buffer);
+        }
+    }
+    return tl;
+};
+// use a worker to execute code
+var wrkr = function (fns, init, id, cb) {
+    if (!ch[id]) {
+        var fnStr = '', td_1 = {}, m = fns.length - 1;
+        for (var i = 0; i < m; ++i)
+            fnStr = wcln(fns[i], fnStr, td_1);
+        ch[id] = { c: wcln(fns[m], fnStr, td_1), e: td_1 };
+    }
+    var td = mrg({}, ch[id].e);
+    return wk(ch[id].c + ';onmessage=function(e){for(var k in e.data)self[k]=e.data[k];onmessage=' + init.toString() + '}', id, td, cbfs(td), cb);
+};
+// base async inflate fn
+var bInflt = function () { return [u8, u16, i32, fleb, fdeb, clim, fl, fd, flrm, fdrm, rev, ec, hMap, max, bits, bits16, shft, slc, err, inflt, inflateSync, pbf, gopt]; };
+var bDflt = function () { return [u8, u16, i32, fleb, fdeb, clim, revfl, revfd, flm, flt, fdm, fdt, rev, deo, et, hMap, wbits, wbits16, hTree, ln, lc, clen, wfblk, wblk, shft, slc, dflt, dopt, deflateSync, pbf]; };
+// gzip extra
+var gze = function () { return [gzh, gzhl, wbytes, crc, crct]; };
+// gunzip extra
+var guze = function () { return [gzs, gzl]; };
+// zlib extra
+var zle = function () { return [zlh, wbytes, adler]; };
+// unzlib extra
+var zule = function () { return [zls]; };
+// post buf
+var pbf = function (msg) { return postMessage(msg, [msg.buffer]); };
+// get opts
+var gopt = function (o) { return o && {
+    out: o.size && new u8(o.size),
+    dictionary: o.dictionary
+}; };
+// async helper
+var cbify = function (dat, opts, fns, init, id, cb) {
+    var w = wrkr(fns, init, id, function (err, dat) {
+        w.terminate();
+        cb(err, dat);
+    });
+    w.postMessage([dat, opts], opts.consume ? [dat.buffer] : []);
+    return function () { w.terminate(); };
+};
+// auto stream
+var astrm = function (strm) {
+    strm.ondata = function (dat, final) { return postMessage([dat, final], [dat.buffer]); };
+    return function (ev) {
+        if (ev.data[0]) {
+            strm.push(ev.data[0], ev.data[1]);
+            postMessage([ev.data[0].length]);
+        }
+        else
+            strm.flush(ev.data[1]);
+    };
+};
+// async stream attach
+var astrmify = function (fns, strm, opts, init, id, flush, ext) {
+    var t;
+    var w = wrkr(fns, init, id, function (err, dat) {
+        if (err)
+            w.terminate(), strm.ondata.call(strm, err);
+        else if (!Array.isArray(dat))
+            ext(dat);
+        else if (dat.length == 1) {
+            strm.queuedSize -= dat[0];
+            if (strm.ondrain)
+                strm.ondrain(dat[0]);
+        }
+        else {
+            if (dat[1])
+                w.terminate();
+            strm.ondata.call(strm, err, dat[0], dat[1]);
+        }
+    });
+    w.postMessage(opts);
+    strm.queuedSize = 0;
+    strm.push = function (d, f) {
+        if (!strm.ondata)
+            err(5);
+        if (t)
+            strm.ondata(err(4, 0, 1), null, !!f);
+        strm.queuedSize += d.length;
+        // can fail for cross-realm Uint8Array, but ok - only a small performance penalty
+        w.postMessage([d, t = f], d.buffer instanceof ArrayBuffer ? [d.buffer] : []);
+    };
+    strm.terminate = function () { w.terminate(); };
+    if (flush) {
+        strm.flush = function (sync) { w.postMessage([0, sync]); };
+    }
+};
+// read 2 bytes
+var b2 = function (d, b) { return d[b] | (d[b + 1] << 8); };
+// read 4 bytes
+var b4 = function (d, b) { return (d[b] | (d[b + 1] << 8) | (d[b + 2] << 16) | (d[b + 3] << 24)) >>> 0; };
+// read 8 bytes
+var b8 = function (d, b) { return b4(d, b) + (b4(d, b + 4) * 4294967296); };
+// write bytes
+var wbytes = function (d, b, v) {
+    for (; v; ++b)
+        d[b] = v, v >>>= 8;
+};
+// gzip header
+var gzh = function (c, o) {
+    var fn = o.filename;
+    c[0] = 31, c[1] = 139, c[2] = 8, c[8] = o.level < 2 ? 4 : o.level == 9 ? 2 : 0, c[9] = 3; // assume Unix
+    if (o.mtime != 0)
+        wbytes(c, 4, Math.floor(new Date(o.mtime || Date.now()) / 1000));
+    if (fn) {
+        c[3] = 8;
+        for (var i = 0; i <= fn.length; ++i)
+            c[i + 10] = fn.charCodeAt(i);
+    }
+};
+// gzip footer: -8 to -4 = CRC, -4 to -0 is length
+// gzip start
+var gzs = function (d) {
+    if (d[0] != 31 || d[1] != 139 || d[2] != 8)
+        err(6, 'invalid gzip data');
+    var flg = d[3];
+    var st = 10;
+    if (flg & 4)
+        st += (d[10] | d[11] << 8) + 2;
+    for (var zs = (flg >> 3 & 1) + (flg >> 4 & 1); zs > 0; zs -= !d[st++])
+        ;
+    return st + (flg & 2);
+};
+// gzip length
+var gzl = function (d) {
+    var l = d.length;
+    return (d[l - 4] | d[l - 3] << 8 | d[l - 2] << 16 | d[l - 1] << 24) >>> 0;
+};
+// gzip header length
+var gzhl = function (o) { return 10 + (o.filename ? o.filename.length + 1 : 0); };
+// zlib header
+var zlh = function (c, o) {
+    var lv = o.level, fl = lv == 0 ? 0 : lv < 6 ? 1 : lv == 9 ? 3 : 2;
+    c[0] = 120, c[1] = (fl << 6) | (o.dictionary && 32);
+    c[1] |= 31 - ((c[0] << 8) | c[1]) % 31;
+    if (o.dictionary) {
+        var h = adler();
+        h.p(o.dictionary);
+        wbytes(c, 2, h.d());
+    }
+};
+// zlib start
+var zls = function (d, dict) {
+    if ((d[0] & 15) != 8 || (d[0] >> 4) > 7 || ((d[0] << 8 | d[1]) % 31))
+        err(6, 'invalid zlib data');
+    if ((d[1] >> 5 & 1) == +!dict)
+        err(6, 'invalid zlib data: ' + (d[1] & 32 ? 'need' : 'unexpected') + ' dictionary');
+    return (d[1] >> 3 & 4) + 2;
+};
+function StrmOpt(opts, cb) {
+    if (typeof opts == 'function')
+        cb = opts, opts = {};
+    this.ondata = cb;
+    return opts;
+}
+/**
+ * Streaming DEFLATE compression
+ */
+var Deflate = /*#__PURE__*/ (function () {
+    function Deflate(opts, cb) {
+        if (typeof opts == 'function')
+            cb = opts, opts = {};
+        this.ondata = cb;
+        this.o = opts || {};
+        this.s = { l: 0, i: 32768, w: 32768, z: 32768 };
+        // Buffer length must always be 0 mod 32768 for index calculations to be correct when modifying head and prev
+        // 98304 = 32768 (lookback) + 65536 (common chunk size)
+        this.b = new u8(98304);
+        if (this.o.dictionary) {
+            var dict = this.o.dictionary.subarray(-32768);
+            this.b.set(dict, 32768 - dict.length);
+            this.s.i = 32768 - dict.length;
+        }
+    }
+    Deflate.prototype.p = function (c, f) {
+        this.ondata(dopt(c, this.o, 0, 0, this.s), f);
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Deflate.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (this.s.l)
+            err(4);
+        var endLen = chunk.length + this.s.z;
+        if (endLen > this.b.length) {
+            if (endLen > 2 * this.b.length - 32768) {
+                var newBuf = new u8(endLen & -32768);
+                newBuf.set(this.b.subarray(0, this.s.z));
+                this.b = newBuf;
+            }
+            var split = this.b.length - this.s.z;
+            this.b.set(chunk.subarray(0, split), this.s.z);
+            this.s.z = this.b.length;
+            this.p(this.b, false);
+            this.b.set(this.b.subarray(-32768));
+            this.b.set(chunk.subarray(split), 32768);
+            this.s.z = chunk.length - split + 32768;
+            this.s.i = 32766, this.s.w = 32768;
+        }
+        else {
+            this.b.set(chunk, this.s.z);
+            this.s.z += chunk.length;
+        }
+        this.s.l = final & 1;
+        if (this.s.z > this.s.w + 8191 || final) {
+            this.p(this.b, final || false);
+            this.s.w = this.s.i, this.s.i -= 2;
+        }
+        if (final) {
+            // cleanup unneeded buffers/state to reduce memory usage
+            this.s = this.o = {};
+            this.b = et;
+        }
+    };
+    /**
+     * Flushes buffered uncompressed data. Useful to immediately retrieve the
+     * deflated output for small inputs.
+     * @param sync Whether to flush to a byte boundary. A sync flush takes 4-5
+     *             extra bytes, but guarantees all pushed data is immediately
+     *             decompressible. A separate DEFLATE stream may be concatenated
+     *             with the current output after a sync flush.
+     */
+    Deflate.prototype.flush = function (sync) {
+        if (!this.ondata)
+            err(5);
+        if (this.s.l)
+            err(4);
+        this.p(this.b, false);
+        this.s.w = this.s.i, this.s.i -= 2;
+        // could technically skip writing the type-0 block for (this.s.r & 7) == 0,
+        // but the deterministic trailer (00 00 FF FF) is useful in some situations
+        if (sync) {
+            var c = new u8(6);
+            c[0] = this.s.r >> 3;
+            // write empty, non-final type-0 block
+            var ep = wfblk(c, this.s.r, et);
+            this.s.r = 0;
+            this.ondata(c.subarray(0, ep >> 3), false);
+        }
+    };
+    return Deflate;
+}());
+export { Deflate };
+/**
+ * Asynchronous streaming DEFLATE compression
+ */
+var AsyncDeflate = /*#__PURE__*/ (function () {
+    function AsyncDeflate(opts, cb) {
+        astrmify([
+            bDflt,
+            function () { return [astrm, Deflate]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Deflate(ev.data);
+            onmessage = astrm(strm);
+        }, 6, 1);
+    }
+    return AsyncDeflate;
+}());
+export { AsyncDeflate };
+export function deflate(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+    ], function (ev) { return pbf(deflateSync(ev.data[0], ev.data[1])); }, 0, cb);
+}
+/**
+ * Compresses data with DEFLATE without any wrapper
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The deflated version of the data
+ */
+export function deflateSync(data, opts) {
+    return dopt(data, opts || {}, 0, 0);
+}
+/**
+ * Streaming DEFLATE decompression
+ */
+var Inflate = /*#__PURE__*/ (function () {
+    function Inflate(opts, cb) {
+        // no StrmOpt here to avoid adding to workerizer
+        if (typeof opts == 'function')
+            cb = opts, opts = {};
+        this.ondata = cb;
+        var dict = opts && opts.dictionary && opts.dictionary.subarray(-32768);
+        this.s = { i: 0, b: dict ? dict.length : 0 };
+        this.o = new u8(32768);
+        this.p = new u8(0);
+        if (dict)
+            this.o.set(dict);
+    }
+    Inflate.prototype.e = function (c) {
+        if (!this.ondata)
+            err(5);
+        if (this.d)
+            err(4);
+        if (!this.p.length)
+            this.p = c;
+        else if (c.length) {
+            var n = new u8(this.p.length + c.length);
+            n.set(this.p), n.set(c, this.p.length), this.p = n;
+        }
+    };
+    Inflate.prototype.c = function (final) {
+        this.s.i = +(this.d = final || false);
+        var bts = this.s.b;
+        var dt = inflt(this.p, this.s, this.o);
+        this.ondata(slc(dt, bts, this.s.b), this.d);
+        this.o = slc(dt, this.s.b - 32768), this.s.b = this.o.length;
+        this.p = slc(this.p, (this.s.p / 8) | 0), this.s.p &= 7;
+    };
+    /**
+     * Pushes a chunk to be inflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the final chunk
+     */
+    Inflate.prototype.push = function (chunk, final) {
+        this.e(chunk), this.c(final);
+    };
+    return Inflate;
+}());
+export { Inflate };
+/**
+ * Asynchronous streaming DEFLATE decompression
+ */
+var AsyncInflate = /*#__PURE__*/ (function () {
+    function AsyncInflate(opts, cb) {
+        astrmify([
+            bInflt,
+            function () { return [astrm, Inflate]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Inflate(ev.data);
+            onmessage = astrm(strm);
+        }, 7, 0);
+    }
+    return AsyncInflate;
+}());
+export { AsyncInflate };
+export function inflate(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt
+    ], function (ev) { return pbf(inflateSync(ev.data[0], gopt(ev.data[1]))); }, 1, cb);
+}
+export function inflateSync(data, opts) {
+    return inflt(data, { i: 2 }, opts && opts.out, opts && opts.dictionary);
+}
+// before you yell at me for not just using extends, my reason is that TS inheritance is hard to workerize.
+/**
+ * Streaming GZIP compression
+ */
+var Gzip = /*#__PURE__*/ (function () {
+    function Gzip(opts, cb) {
+        this.c = crc();
+        this.l = 0;
+        this.v = 1;
+        Deflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be GZIPped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Gzip.prototype.push = function (chunk, final) {
+        this.c.p(chunk);
+        this.l += chunk.length;
+        Deflate.prototype.push.call(this, chunk, final);
+    };
+    Gzip.prototype.p = function (c, f) {
+        var raw = dopt(c, this.o, this.v && gzhl(this.o), f && 8, this.s);
+        if (this.v)
+            gzh(raw, this.o), this.v = 0;
+        if (f)
+            wbytes(raw, raw.length - 8, this.c.d()), wbytes(raw, raw.length - 4, this.l);
+        this.ondata(raw, f);
+    };
+    /**
+     * Flushes buffered uncompressed data. Useful to immediately retrieve the
+     * GZIPped output for small inputs.
+     * @param sync Whether to flush to a byte boundary. A sync flush takes 4-5
+     *             extra bytes, but guarantees all pushed data is immediately
+     *             decompressible.
+     */
+    Gzip.prototype.flush = function (sync) {
+        Deflate.prototype.flush.call(this, sync);
+    };
+    return Gzip;
+}());
+export { Gzip };
+/**
+ * Asynchronous streaming GZIP compression
+ */
+var AsyncGzip = /*#__PURE__*/ (function () {
+    function AsyncGzip(opts, cb) {
+        astrmify([
+            bDflt,
+            gze,
+            function () { return [astrm, Deflate, Gzip]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Gzip(ev.data);
+            onmessage = astrm(strm);
+        }, 8, 1);
+    }
+    return AsyncGzip;
+}());
+export { AsyncGzip };
+export function gzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+        gze,
+        function () { return [gzipSync]; }
+    ], function (ev) { return pbf(gzipSync(ev.data[0], ev.data[1])); }, 2, cb);
+}
+/**
+ * Compresses data with GZIP
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The gzipped version of the data
+ */
+export function gzipSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var c = crc(), l = data.length;
+    c.p(data);
+    var d = dopt(data, opts, gzhl(opts), 8), s = d.length;
+    return gzh(d, opts), wbytes(d, s - 8, c.d()), wbytes(d, s - 4, l), d;
+}
+/**
+ * Streaming single or multi-member GZIP decompression
+ */
+var Gunzip = /*#__PURE__*/ (function () {
+    function Gunzip(opts, cb) {
+        this.v = 1;
+        this.r = 0;
+        Inflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be GUNZIPped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Gunzip.prototype.push = function (chunk, final) {
+        Inflate.prototype.e.call(this, chunk);
+        this.r += chunk.length;
+        if (this.v) {
+            var p = this.p.subarray(this.v - 1);
+            var s = p.length > 3 ? gzs(p) : 4;
+            if (s > p.length) {
+                if (!final)
+                    return;
+            }
+            else if (this.v > 1 && this.onmember) {
+                this.onmember(this.r - p.length);
+            }
+            this.p = p.subarray(s), this.v = 0;
+        }
+        // necessary to prevent TS from using the closure value
+        // This allows for workerization to function correctly
+        Inflate.prototype.c.call(this, 0);
+        // process concatenated GZIP
+        if (this.s.f && !this.s.l) {
+            this.v = shft(this.s.p) + 9;
+            this.s = { i: 0 };
+            this.o = new u8(0);
+            this.push(new u8(0), final);
+        }
+        else if (final) {
+            Inflate.prototype.c.call(this, final);
+        }
+    };
+    return Gunzip;
+}());
+export { Gunzip };
+/**
+ * Asynchronous streaming single or multi-member GZIP decompression
+ */
+var AsyncGunzip = /*#__PURE__*/ (function () {
+    function AsyncGunzip(opts, cb) {
+        var _this = this;
+        astrmify([
+            bInflt,
+            guze,
+            function () { return [astrm, Inflate, Gunzip]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Gunzip(ev.data);
+            strm.onmember = function (offset) { return postMessage(offset); };
+            onmessage = astrm(strm);
+        }, 9, 0, function (offset) { return _this.onmember && _this.onmember(offset); });
+    }
+    return AsyncGunzip;
+}());
+export { AsyncGunzip };
+export function gunzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt,
+        guze,
+        function () { return [gunzipSync]; }
+    ], function (ev) { return pbf(gunzipSync(ev.data[0], ev.data[1])); }, 3, cb);
+}
+export function gunzipSync(data, opts) {
+    var st = gzs(data);
+    if (st + 8 > data.length)
+        err(6, 'invalid gzip data');
+    return inflt(data.subarray(st, -8), { i: 2 }, opts && opts.out || new u8(gzl(data)), opts && opts.dictionary);
+}
+/**
+ * Streaming Zlib compression
+ */
+var Zlib = /*#__PURE__*/ (function () {
+    function Zlib(opts, cb) {
+        this.c = adler();
+        this.v = 1;
+        Deflate.call(this, opts, cb);
+    }
+    /**
+     * Pushes a chunk to be zlibbed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Zlib.prototype.push = function (chunk, final) {
+        this.c.p(chunk);
+        Deflate.prototype.push.call(this, chunk, final);
+    };
+    Zlib.prototype.p = function (c, f) {
+        var raw = dopt(c, this.o, this.v && (this.o.dictionary ? 6 : 2), f && 4, this.s);
+        if (this.v)
+            zlh(raw, this.o), this.v = 0;
+        if (f)
+            wbytes(raw, raw.length - 4, this.c.d());
+        this.ondata(raw, f);
+    };
+    /**
+     * Flushes buffered uncompressed data. Useful to immediately retrieve the
+     * zlibbed output for small inputs.
+     * @param sync Whether to flush to a byte boundary. A sync flush takes 4-5
+     *             extra bytes, but guarantees all pushed data is immediately
+     *             decompressible.
+     */
+    Zlib.prototype.flush = function (sync) {
+        Deflate.prototype.flush.call(this, sync);
+    };
+    return Zlib;
+}());
+export { Zlib };
+/**
+ * Asynchronous streaming Zlib compression
+ */
+var AsyncZlib = /*#__PURE__*/ (function () {
+    function AsyncZlib(opts, cb) {
+        astrmify([
+            bDflt,
+            zle,
+            function () { return [astrm, Deflate, Zlib]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Zlib(ev.data);
+            onmessage = astrm(strm);
+        }, 10, 1);
+    }
+    return AsyncZlib;
+}());
+export { AsyncZlib };
+export function zlib(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bDflt,
+        zle,
+        function () { return [zlibSync]; }
+    ], function (ev) { return pbf(zlibSync(ev.data[0], ev.data[1])); }, 4, cb);
+}
+/**
+ * Compress data with Zlib
+ * @param data The data to compress
+ * @param opts The compression options
+ * @returns The zlib-compressed version of the data
+ */
+export function zlibSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var a = adler();
+    a.p(data);
+    var d = dopt(data, opts, opts.dictionary ? 6 : 2, 4);
+    return zlh(d, opts), wbytes(d, d.length - 4, a.d()), d;
+}
+/**
+ * Streaming Zlib decompression
+ */
+var Unzlib = /*#__PURE__*/ (function () {
+    function Unzlib(opts, cb) {
+        Inflate.call(this, opts, cb);
+        this.v = opts && opts.dictionary ? 2 : 1;
+    }
+    /**
+     * Pushes a chunk to be unzlibbed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Unzlib.prototype.push = function (chunk, final) {
+        Inflate.prototype.e.call(this, chunk);
+        if (this.v) {
+            if (this.p.length < 6 && !final)
+                return;
+            this.p = this.p.subarray(zls(this.p, this.v - 1)), this.v = 0;
+        }
+        if (final) {
+            if (this.p.length < 4)
+                err(6, 'invalid zlib data');
+            this.p = this.p.subarray(0, -4);
+        }
+        // necessary to prevent TS from using the closure value
+        // This allows for workerization to function correctly
+        Inflate.prototype.c.call(this, final);
+    };
+    return Unzlib;
+}());
+export { Unzlib };
+/**
+ * Asynchronous streaming Zlib decompression
+ */
+var AsyncUnzlib = /*#__PURE__*/ (function () {
+    function AsyncUnzlib(opts, cb) {
+        astrmify([
+            bInflt,
+            zule,
+            function () { return [astrm, Inflate, Unzlib]; }
+        ], this, StrmOpt.call(this, opts, cb), function (ev) {
+            var strm = new Unzlib(ev.data);
+            onmessage = astrm(strm);
+        }, 11, 0);
+    }
+    return AsyncUnzlib;
+}());
+export { AsyncUnzlib };
+export function unzlib(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return cbify(data, opts, [
+        bInflt,
+        zule,
+        function () { return [unzlibSync]; }
+    ], function (ev) { return pbf(unzlibSync(ev.data[0], gopt(ev.data[1]))); }, 5, cb);
+}
+export function unzlibSync(data, opts) {
+    return inflt(data.subarray(zls(data, opts && opts.dictionary), -4), { i: 2 }, opts && opts.out, opts && opts.dictionary);
+}
+// Default algorithm for compression (used because having a known output size allows faster decompression)
+export { gzip as compress, AsyncGzip as AsyncCompress };
+export { gzipSync as compressSync, Gzip as Compress };
+/**
+ * Streaming GZIP, Zlib, or raw DEFLATE decompression
+ */
+var Decompress = /*#__PURE__*/ (function () {
+    function Decompress(opts, cb) {
+        this.o = StrmOpt.call(this, opts, cb) || {};
+        this.G = Gunzip;
+        this.I = Inflate;
+        this.Z = Unzlib;
+    }
+    // init substream
+    // overriden by AsyncDecompress
+    Decompress.prototype.i = function () {
+        var _this = this;
+        this.s.ondata = function (dat, final) {
+            _this.ondata(dat, final);
+        };
+    };
+    /**
+     * Pushes a chunk to be decompressed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Decompress.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (!this.s) {
+            if (this.p && this.p.length) {
+                var n = new u8(this.p.length + chunk.length);
+                n.set(this.p), n.set(chunk, this.p.length);
+            }
+            else
+                this.p = chunk;
+            if (this.p.length > 2) {
+                this.s = (this.p[0] == 31 && this.p[1] == 139 && this.p[2] == 8)
+                    ? new this.G(this.o)
+                    : ((this.p[0] & 15) != 8 || (this.p[0] >> 4) > 7 || ((this.p[0] << 8 | this.p[1]) % 31))
+                        ? new this.I(this.o)
+                        : new this.Z(this.o);
+                this.i();
+                this.s.push(this.p, final);
+                this.p = null;
+            }
+        }
+        else
+            this.s.push(chunk, final);
+    };
+    return Decompress;
+}());
+export { Decompress };
+/**
+ * Asynchronous streaming GZIP, Zlib, or raw DEFLATE decompression
+ */
+var AsyncDecompress = /*#__PURE__*/ (function () {
+    function AsyncDecompress(opts, cb) {
+        Decompress.call(this, opts, cb);
+        this.queuedSize = 0;
+        this.G = AsyncGunzip;
+        this.I = AsyncInflate;
+        this.Z = AsyncUnzlib;
+    }
+    AsyncDecompress.prototype.i = function () {
+        var _this = this;
+        this.s.ondata = function (err, dat, final) {
+            _this.ondata(err, dat, final);
+        };
+        this.s.ondrain = function (size) {
+            _this.queuedSize -= size;
+            if (_this.ondrain)
+                _this.ondrain(size);
+        };
+    };
+    /**
+     * Pushes a chunk to be decompressed
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    AsyncDecompress.prototype.push = function (chunk, final) {
+        this.queuedSize += chunk.length;
+        Decompress.prototype.push.call(this, chunk, final);
+    };
+    return AsyncDecompress;
+}());
+export { AsyncDecompress };
+export function decompress(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    return (data[0] == 31 && data[1] == 139 && data[2] == 8)
+        ? gunzip(data, opts, cb)
+        : ((data[0] & 15) != 8 || (data[0] >> 4) > 7 || ((data[0] << 8 | data[1]) % 31))
+            ? inflate(data, opts, cb)
+            : unzlib(data, opts, cb);
+}
+/**
+ * Expands compressed GZIP, Zlib, or raw DEFLATE data, automatically detecting the format
+ * @param data The data to decompress
+ * @param opts The decompression options
+ * @returns The decompressed version of the data
+ */
+export function decompressSync(data, opts) {
+    return (data[0] == 31 && data[1] == 139 && data[2] == 8)
+        ? gunzipSync(data, opts)
+        : ((data[0] & 15) != 8 || (data[0] >> 4) > 7 || ((data[0] << 8 | data[1]) % 31))
+            ? inflateSync(data, opts)
+            : unzlibSync(data, opts);
+}
+// flatten a directory structure
+var fltn = function (d, p, t, o) {
+    for (var k in d) {
+        var val = d[k], n = p + k, op = o;
+        if (Array.isArray(val))
+            op = mrg(o, val[1]), val = val[0];
+        if (ArrayBuffer.isView(val))
+            t[n] = [val, op];
+        else {
+            t[n += '/'] = [new u8(0), op];
+            fltn(val, n, t, o);
+        }
+    }
+};
+// text encoder
+var te = typeof TextEncoder != 'undefined' && /*#__PURE__*/ new TextEncoder();
+// text decoder
+var td = typeof TextDecoder != 'undefined' && /*#__PURE__*/ new TextDecoder();
+// text decoder stream
+var tds = 0;
+try {
+    td.decode(et, { stream: true });
+    tds = 1;
+}
+catch (e) { }
+// decode UTF8
+var dutf8 = function (d) {
+    for (var r = '', i = 0;;) {
+        var c = d[i++];
+        var eb = (c > 127) + (c > 223) + (c > 239);
+        if (i + eb > d.length)
+            return { s: r, r: slc(d, i - 1) };
+        if (!eb)
+            r += String.fromCharCode(c);
+        else if (eb == 3) {
+            c = ((c & 15) << 18 | (d[i++] & 63) << 12 | (d[i++] & 63) << 6 | (d[i++] & 63)) - 65536,
+                r += String.fromCharCode(55296 | (c >> 10), 56320 | (c & 1023));
+        }
+        else if (eb & 1)
+            r += String.fromCharCode((c & 31) << 6 | (d[i++] & 63));
+        else
+            r += String.fromCharCode((c & 15) << 12 | (d[i++] & 63) << 6 | (d[i++] & 63));
+    }
+};
+/**
+ * Streaming UTF-8 decoding
+ */
+var DecodeUTF8 = /*#__PURE__*/ (function () {
+    /**
+     * Creates a UTF-8 decoding stream
+     * @param cb The callback to call whenever data is decoded
+     */
+    function DecodeUTF8(cb) {
+        this.ondata = cb;
+        if (tds)
+            this.t = new TextDecoder();
+        else
+            this.p = et;
+    }
+    /**
+     * Pushes a chunk to be decoded from UTF-8 binary
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    DecodeUTF8.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        final = !!final;
+        if (this.t) {
+            this.ondata(this.t.decode(chunk, { stream: true }), final);
+            if (final) {
+                if (this.t.decode().length)
+                    err(8);
+                this.t = null;
+            }
+            return;
+        }
+        if (!this.p)
+            err(4);
+        var dat = new u8(this.p.length + chunk.length);
+        dat.set(this.p);
+        dat.set(chunk, this.p.length);
+        var _a = dutf8(dat), s = _a.s, r = _a.r;
+        if (final) {
+            if (r.length)
+                err(8);
+            this.p = null;
+        }
+        else
+            this.p = r;
+        this.ondata(s, final);
+    };
+    return DecodeUTF8;
+}());
+export { DecodeUTF8 };
+/**
+ * Streaming UTF-8 encoding
+ */
+var EncodeUTF8 = /*#__PURE__*/ (function () {
+    /**
+     * Creates a UTF-8 decoding stream
+     * @param cb The callback to call whenever data is encoded
+     */
+    function EncodeUTF8(cb) {
+        this.ondata = cb;
+    }
+    /**
+     * Pushes a chunk to be encoded to UTF-8
+     * @param chunk The string data to push
+     * @param final Whether this is the last chunk
+     */
+    EncodeUTF8.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        if (this.d)
+            err(4);
+        this.ondata(strToU8(chunk), this.d = final || false);
+    };
+    return EncodeUTF8;
+}());
+export { EncodeUTF8 };
+/**
+ * Converts a string into a Uint8Array for use with compression/decompression methods
+ * @param str The string to encode
+ * @param latin1 Whether or not to interpret the data as Latin-1. This should
+ *               not need to be true unless decoding a binary string.
+ * @returns The string encoded in UTF-8/Latin-1 binary
+ */
+export function strToU8(str, latin1) {
+    if (latin1) {
+        var ar_1 = new u8(str.length);
+        for (var i = 0; i < str.length; ++i)
+            ar_1[i] = str.charCodeAt(i);
+        return ar_1;
+    }
+    if (te)
+        return te.encode(str);
+    var l = str.length;
+    var ar = new u8(str.length + (str.length >> 1));
+    var ai = 0;
+    var w = function (v) { ar[ai++] = v; };
+    for (var i = 0; i < l; ++i) {
+        if (ai + 5 > ar.length) {
+            var n = new u8(ai + 8 + ((l - i) << 1));
+            n.set(ar);
+            ar = n;
+        }
+        var c = str.charCodeAt(i);
+        if (c < 128 || latin1)
+            w(c);
+        else if (c < 2048)
+            w(192 | (c >> 6)), w(128 | (c & 63));
+        else if (c > 55295 && c < 57344)
+            c = 65536 + (c & 1023 << 10) | (str.charCodeAt(++i) & 1023),
+                w(240 | (c >> 18)), w(128 | ((c >> 12) & 63)), w(128 | ((c >> 6) & 63)), w(128 | (c & 63));
+        else
+            w(224 | (c >> 12)), w(128 | ((c >> 6) & 63)), w(128 | (c & 63));
+    }
+    return slc(ar, 0, ai);
+}
+/**
+ * Converts a Uint8Array to a string
+ * @param dat The data to decode to string
+ * @param latin1 Whether or not to interpret the data as Latin-1. This should
+ *               not need to be true unless encoding to binary string.
+ * @returns The original UTF-8/Latin-1 string
+ */
+export function strFromU8(dat, latin1) {
+    if (latin1) {
+        var r = '';
+        for (var i = 0; i < dat.length; i += 16384)
+            r += String.fromCharCode.apply(null, dat.subarray(i, i + 16384));
+        return r;
+    }
+    else if (td) {
+        return td.decode(dat);
+    }
+    else {
+        var _a = dutf8(dat), s = _a.s, r = _a.r;
+        if (r.length)
+            err(8);
+        return s;
+    }
+}
+;
+// deflate bit flag
+var dbf = function (l) { return l == 1 ? 3 : l < 6 ? 2 : l == 9 ? 1 : 0; };
+// skip local zip header
+var slzh = function (d, b) { return b + 30 + b2(d, b + 26) + b2(d, b + 28); };
+// read zip header
+var zh = function (d, b, z) {
+    var fnl = b2(d, b + 28), efl = b2(d, b + 30), fn = strFromU8(d.subarray(b + 46, b + 46 + fnl), !(b2(d, b + 8) & 2048)), es = b + 46 + fnl;
+    var _a = z64hs(d, es, efl, z, b4(d, b + 20), b4(d, b + 24), b4(d, b + 42)), sc = _a[0], su = _a[1], off = _a[2];
+    return [b2(d, b + 10), sc, su, fn, es + efl + b2(d, b + 32), off];
+};
+// read zip64 header sizes
+var z64hs = function (d, b, l, z, sc, su, off) {
+    var nsc = sc == 4294967295, nsu = su == 4294967295, noff = off == 4294967295, e = b + l;
+    var nf = nsc + nsu + noff;
+    if (z && nf) {
+        for (; b + 4 < e; b += 4 + b2(d, b + 2)) {
+            if (b2(d, b) == 1) {
+                return [
+                    nsc ? b8(d, b + 4 + 8 * nsu) : sc,
+                    nsu ? b8(d, b + 4) : su,
+                    noff ? b8(d, b + 4 + 8 * (nsu + nsc)) : off,
+                    1
+                ];
+            }
+        }
+        // z == 2 for unknown whether or not zip64
+        if (z < 2)
+            err(13);
+    }
+    return [sc, su, off, 0];
+};
+// extra field length
+var exfl = function (ex) {
+    var le = 0;
+    if (ex) {
+        for (var k in ex) {
+            var l = ex[k].length;
+            if (l > 65535)
+                err(9);
+            le += l + 4;
+        }
+    }
+    return le;
+};
+// write zip header
+var wzh = function (d, b, f, fn, u, c, ce, co) {
+    var fl = fn.length, ex = f.extra, col = co && co.length;
+    var exl = exfl(ex);
+    wbytes(d, b, ce != null ? 0x2014B50 : 0x4034B50), b += 4;
+    if (ce != null)
+        d[b++] = 20, d[b++] = f.os;
+    d[b] = 20, b += 2; // spec compliance? what's that?
+    d[b++] = (f.flag << 1) | (c < 0 && 8), d[b++] = u && 8;
+    d[b++] = f.compression & 255, d[b++] = f.compression >> 8;
+    var dt = new Date(f.mtime == null ? Date.now() : f.mtime), y = dt.getFullYear() - 1980;
+    if (y < 0 || y > 119)
+        err(10);
+    wbytes(d, b, (y << 25) | ((dt.getMonth() + 1) << 21) | (dt.getDate() << 16) | (dt.getHours() << 11) | (dt.getMinutes() << 5) | (dt.getSeconds() >> 1)), b += 4;
+    if (c != -1) {
+        wbytes(d, b, f.crc);
+        wbytes(d, b + 4, c < 0 ? -c - 2 : c);
+        wbytes(d, b + 8, f.size);
+    }
+    wbytes(d, b + 12, fl);
+    wbytes(d, b + 14, exl), b += 16;
+    if (ce != null) {
+        wbytes(d, b, col);
+        wbytes(d, b + 6, f.attrs);
+        wbytes(d, b + 10, ce), b += 14;
+    }
+    d.set(fn, b);
+    b += fl;
+    if (exl) {
+        for (var k in ex) {
+            var exf = ex[k], l = exf.length;
+            wbytes(d, b, +k);
+            wbytes(d, b + 2, l);
+            d.set(exf, b + 4), b += 4 + l;
+        }
+    }
+    if (col)
+        d.set(co, b), b += col;
+    return b;
+};
+// write zip footer (end of central directory)
+var wzf = function (o, b, c, d, e) {
+    wbytes(o, b, 0x6054B50); // skip disk
+    wbytes(o, b + 8, c);
+    wbytes(o, b + 10, c);
+    wbytes(o, b + 12, d);
+    wbytes(o, b + 16, e);
+};
+/**
+ * A pass-through stream to keep data uncompressed in a ZIP archive.
+ */
+var ZipPassThrough = /*#__PURE__*/ (function () {
+    /**
+     * Creates a pass-through stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     */
+    function ZipPassThrough(filename) {
+        this.filename = filename;
+        this.c = crc();
+        this.size = 0;
+        this.compression = 0;
+    }
+    /**
+     * Processes a chunk and pushes to the output stream. You can override this
+     * method in a subclass for custom behavior, but by default this passes
+     * the data through. You must call this.ondata(err, chunk, final) at some
+     * point in this method.
+     * @param chunk The chunk to process
+     * @param final Whether this is the last chunk
+     */
+    ZipPassThrough.prototype.process = function (chunk, final) {
+        this.ondata(null, chunk, final);
+    };
+    /**
+     * Pushes a chunk to be added. If you are subclassing this with a custom
+     * compression algorithm, note that you must push data from the source
+     * file only, pre-compression.
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    ZipPassThrough.prototype.push = function (chunk, final) {
+        if (!this.ondata)
+            err(5);
+        this.c.p(chunk);
+        this.size += chunk.length;
+        if (final)
+            this.crc = this.c.d();
+        // we shouldn't really do this cast, but properly handling ArrayBufferLike
+        // makes the API unergonomic with Buffer
+        this.process(chunk, final || false);
+    };
+    return ZipPassThrough;
+}());
+export { ZipPassThrough };
+// I don't extend because TypeScript extension adds 1kB of runtime bloat
+/**
+ * Streaming DEFLATE compression for ZIP archives. Prefer using AsyncZipDeflate
+ * for better performance
+ */
+var ZipDeflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     * @param opts The compression options
+     */
+    function ZipDeflate(filename, opts) {
+        var _this = this;
+        if (!opts)
+            opts = {};
+        ZipPassThrough.call(this, filename);
+        this.d = new Deflate(opts, function (dat, final) {
+            _this.ondata(null, dat, final);
+        });
+        this.compression = 8;
+        this.flag = dbf(opts.level);
+    }
+    ZipDeflate.prototype.process = function (chunk, final) {
+        try {
+            this.d.push(chunk, final);
+        }
+        catch (e) {
+            this.ondata(e, null, final);
+        }
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    ZipDeflate.prototype.push = function (chunk, final) {
+        ZipPassThrough.prototype.push.call(this, chunk, final);
+    };
+    return ZipDeflate;
+}());
+export { ZipDeflate };
+/**
+ * Asynchronous streaming DEFLATE compression for ZIP archives
+ */
+var AsyncZipDeflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates an asynchronous DEFLATE stream that can be added to ZIP archives
+     * @param filename The filename to associate with this data stream
+     * @param opts The compression options
+     */
+    function AsyncZipDeflate(filename, opts) {
+        var _this = this;
+        if (!opts)
+            opts = {};
+        ZipPassThrough.call(this, filename);
+        this.d = new AsyncDeflate(opts, function (err, dat, final) {
+            _this.ondata(err, dat, final);
+        });
+        this.compression = 8;
+        this.flag = dbf(opts.level);
+        this.terminate = this.d.terminate;
+    }
+    AsyncZipDeflate.prototype.process = function (chunk, final) {
+        this.d.push(chunk, final);
+    };
+    /**
+     * Pushes a chunk to be deflated
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    AsyncZipDeflate.prototype.push = function (chunk, final) {
+        ZipPassThrough.prototype.push.call(this, chunk, final);
+    };
+    return AsyncZipDeflate;
+}());
+export { AsyncZipDeflate };
+// TODO: Better tree shaking
+/**
+ * A zippable archive to which files can incrementally be added
+ */
+var Zip = /*#__PURE__*/ (function () {
+    /**
+     * Creates an empty ZIP archive to which files can be added
+     * @param cb The callback to call whenever data for the generated ZIP archive
+     *           is available
+     */
+    function Zip(cb) {
+        this.ondata = cb;
+        this.u = [];
+        this.d = 1;
+    }
+    /**
+     * Adds a file to the ZIP archive
+     * @param file The file stream to add
+     */
+    Zip.prototype.add = function (file) {
+        var _this = this;
+        if (!this.ondata)
+            err(5);
+        // finishing or finished
+        if (this.d & 2)
+            this.ondata(err(4 + (this.d & 1) * 8, 0, 1), null, false);
+        else {
+            var f = strToU8(file.filename), fl_1 = f.length;
+            var com = file.comment, o = com && strToU8(com);
+            var u = fl_1 != file.filename.length || (o && (com.length != o.length));
+            var hl_1 = fl_1 + exfl(file.extra) + 30;
+            if (fl_1 > 65535)
+                this.ondata(err(11, 0, 1), null, false);
+            var header = new u8(hl_1);
+            wzh(header, 0, file, f, u, -1);
+            var chks_1 = [header];
+            var pAll_1 = function () {
+                for (var _i = 0, chks_2 = chks_1; _i < chks_2.length; _i++) {
+                    var chk = chks_2[_i];
+                    _this.ondata(null, chk, false);
+                }
+                chks_1 = [];
+            };
+            var tr_1 = this.d;
+            this.d = 0;
+            var ind_1 = this.u.length;
+            var uf_1 = mrg(file, {
+                f: f,
+                u: u,
+                o: o,
+                t: function () {
+                    if (file.terminate)
+                        file.terminate();
+                },
+                r: function () {
+                    pAll_1();
+                    if (tr_1) {
+                        var nxt = _this.u[ind_1 + 1];
+                        if (nxt)
+                            nxt.r();
+                        else
+                            _this.d = 1;
+                    }
+                    tr_1 = 1;
+                }
+            });
+            var cl_1 = 0;
+            file.ondata = function (err, dat, final) {
+                if (err) {
+                    _this.ondata(err, dat, final);
+                    _this.terminate();
+                }
+                else {
+                    cl_1 += dat.length;
+                    chks_1.push(dat);
+                    if (final) {
+                        var dd = new u8(16);
+                        wbytes(dd, 0, 0x8074B50);
+                        wbytes(dd, 4, file.crc);
+                        wbytes(dd, 8, cl_1);
+                        wbytes(dd, 12, file.size);
+                        chks_1.push(dd);
+                        uf_1.c = cl_1, uf_1.b = hl_1 + cl_1 + 16, uf_1.crc = file.crc, uf_1.size = file.size;
+                        if (tr_1)
+                            uf_1.r();
+                        tr_1 = 1;
+                    }
+                    else if (tr_1)
+                        pAll_1();
+                }
+            };
+            this.u.push(uf_1);
+        }
+    };
+    /**
+     * Ends the process of adding files and prepares to emit the final chunks.
+     * This *must* be called after adding all desired files for the resulting
+     * ZIP file to work properly.
+     */
+    Zip.prototype.end = function () {
+        var _this = this;
+        if (this.d & 2) {
+            this.ondata(err(4 + (this.d & 1) * 8, 0, 1), null, true);
+            return;
+        }
+        if (this.d)
+            this.e();
+        else
+            this.u.push({
+                r: function () {
+                    if (!(_this.d & 1))
+                        return;
+                    _this.u.splice(-1, 1);
+                    _this.e();
+                },
+                t: function () { }
+            });
+        this.d = 3;
+    };
+    Zip.prototype.e = function () {
+        var bt = 0, l = 0, tl = 0;
+        for (var _i = 0, _a = this.u; _i < _a.length; _i++) {
+            var f = _a[_i];
+            tl += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0);
+        }
+        var out = new u8(tl + 22);
+        for (var _b = 0, _c = this.u; _b < _c.length; _b++) {
+            var f = _c[_b];
+            wzh(out, bt, f, f.f, f.u, -f.c - 2, l, f.o);
+            bt += 46 + f.f.length + exfl(f.extra) + (f.o ? f.o.length : 0), l += f.b;
+        }
+        wzf(out, bt, this.u.length, tl, l);
+        this.ondata(null, out, true);
+        this.d = 2;
+    };
+    /**
+     * A method to terminate any internal workers used by the stream. Subsequent
+     * calls to add() will fail.
+     */
+    Zip.prototype.terminate = function () {
+        for (var _i = 0, _a = this.u; _i < _a.length; _i++) {
+            var f = _a[_i];
+            f.t();
+        }
+        this.d = 2;
+    };
+    return Zip;
+}());
+export { Zip };
+export function zip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    var r = {};
+    fltn(data, '', r, opts);
+    var k = Object.keys(r);
+    var lft = k.length, o = 0, tot = 0;
+    var slft = lft, files = new Array(lft);
+    var term = [];
+    var tAll = function () {
+        for (var i = 0; i < term.length; ++i)
+            term[i]();
+    };
+    var cbd = function (a, b) {
+        mt(function () { cb(a, b); });
+    };
+    mt(function () { cbd = cb; });
+    var cbf = function () {
+        var out = new u8(tot + 22), oe = o, cdl = tot - o;
+        tot = 0;
+        for (var i = 0; i < slft; ++i) {
+            var f = files[i];
+            try {
+                var l = f.c.length;
+                wzh(out, tot, f, f.f, f.u, l);
+                var badd = 30 + f.f.length + exfl(f.extra);
+                var loc = tot + badd;
+                out.set(f.c, loc);
+                wzh(out, o, f, f.f, f.u, l, tot, f.m), o += 16 + badd + (f.m ? f.m.length : 0), tot = loc + l;
+            }
+            catch (e) {
+                return cbd(e, null);
+            }
+        }
+        wzf(out, o, files.length, cdl, oe);
+        cbd(null, out);
+    };
+    if (!lft)
+        cbf();
+    var _loop_1 = function (i) {
+        var fn = k[i];
+        var _a = r[fn], file = _a[0], p = _a[1];
+        var c = crc(), size = file.length;
+        c.p(file);
+        var f = strToU8(fn), s = f.length;
+        var com = p.comment, m = com && strToU8(com), ms = m && m.length;
+        var exl = exfl(p.extra);
+        var compression = p.level == 0 ? 0 : 8;
+        var cbl = function (e, d) {
+            if (e) {
+                tAll();
+                cbd(e, null);
+            }
+            else {
+                var l = d.length;
+                files[i] = mrg(p, {
+                    size: size,
+                    crc: c.d(),
+                    c: d,
+                    f: f,
+                    m: m,
+                    u: s != fn.length || (m && (com.length != ms)),
+                    compression: compression
+                });
+                o += 30 + s + exl + l;
+                tot += 76 + 2 * (s + exl) + (ms || 0) + l;
+                if (!--lft)
+                    cbf();
+            }
+        };
+        if (s > 65535)
+            cbl(err(11, 0, 1), null);
+        if (!compression)
+            cbl(null, file);
+        else if (size < 160000) {
+            try {
+                cbl(null, deflateSync(file, p));
+            }
+            catch (e) {
+                cbl(e, null);
+            }
+        }
+        else
+            term.push(deflate(file, p, cbl));
+    };
+    // Cannot use lft because it can decrease
+    for (var i = 0; i < slft; ++i) {
+        _loop_1(i);
+    }
+    return tAll;
+}
+/**
+ * Synchronously creates a ZIP file. Prefer using `zip` for better performance
+ * with more than one file.
+ * @param data The directory structure for the ZIP archive
+ * @param opts The main options, merged with per-file options
+ * @returns The generated ZIP archive
+ */
+export function zipSync(data, opts) {
+    if (!opts)
+        opts = {};
+    var r = {};
+    var files = [];
+    fltn(data, '', r, opts);
+    var o = 0;
+    var tot = 0;
+    for (var fn in r) {
+        var _a = r[fn], file = _a[0], p = _a[1];
+        var compression = p.level == 0 ? 0 : 8;
+        var f = strToU8(fn), s = f.length;
+        var com = p.comment, m = com && strToU8(com), ms = m && m.length;
+        var exl = exfl(p.extra);
+        if (s > 65535)
+            err(11);
+        var d = compression ? deflateSync(file, p) : file, l = d.length;
+        var c = crc();
+        c.p(file);
+        files.push(mrg(p, {
+            size: file.length,
+            crc: c.d(),
+            c: d,
+            f: f,
+            m: m,
+            u: s != fn.length || (m && (com.length != ms)),
+            o: o,
+            compression: compression
+        }));
+        o += 30 + s + exl + l;
+        tot += 76 + 2 * (s + exl) + (ms || 0) + l;
+    }
+    var out = new u8(tot + 22), oe = o, cdl = tot - o;
+    for (var i = 0; i < files.length; ++i) {
+        var f = files[i];
+        wzh(out, f.o, f, f.f, f.u, f.c.length);
+        var badd = 30 + f.f.length + exfl(f.extra);
+        out.set(f.c, f.o + badd);
+        wzh(out, o, f, f.f, f.u, f.c.length, f.o, f.m), o += 16 + badd + (f.m ? f.m.length : 0);
+    }
+    wzf(out, o, files.length, cdl, oe);
+    return out;
+}
+/**
+ * Streaming pass-through decompression for ZIP archives
+ */
+var UnzipPassThrough = /*#__PURE__*/ (function () {
+    function UnzipPassThrough() {
+    }
+    UnzipPassThrough.prototype.push = function (chunk, final) {
+        // same as ZipPassThrough: cast to retain Buffer ergonomics
+        this.ondata(null, chunk, final);
+    };
+    UnzipPassThrough.compression = 0;
+    return UnzipPassThrough;
+}());
+export { UnzipPassThrough };
+/**
+ * Streaming DEFLATE decompression for ZIP archives. Prefer AsyncZipInflate for
+ * better performance.
+ */
+var UnzipInflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE decompression that can be used in ZIP archives
+     */
+    function UnzipInflate() {
+        var _this = this;
+        this.i = new Inflate(function (dat, final) {
+            _this.ondata(null, dat, final);
+        });
+    }
+    UnzipInflate.prototype.push = function (chunk, final) {
+        try {
+            this.i.push(chunk, final);
+        }
+        catch (e) {
+            this.ondata(e, null, final);
+        }
+    };
+    UnzipInflate.compression = 8;
+    return UnzipInflate;
+}());
+export { UnzipInflate };
+/**
+ * Asynchronous streaming DEFLATE decompression for ZIP archives
+ */
+var AsyncUnzipInflate = /*#__PURE__*/ (function () {
+    /**
+     * Creates a DEFLATE decompression that can be used in ZIP archives
+     */
+    function AsyncUnzipInflate(_, sz) {
+        var _this = this;
+        if (sz < 320000) {
+            this.i = new Inflate(function (dat, final) {
+                _this.ondata(null, dat, final);
+            });
+        }
+        else {
+            this.i = new AsyncInflate(function (err, dat, final) {
+                _this.ondata(err, dat, final);
+            });
+            this.terminate = this.i.terminate;
+        }
+    }
+    AsyncUnzipInflate.prototype.push = function (chunk, final) {
+        if (this.i.terminate)
+            chunk = slc(chunk, 0);
+        this.i.push(chunk, final);
+    };
+    AsyncUnzipInflate.compression = 8;
+    return AsyncUnzipInflate;
+}());
+export { AsyncUnzipInflate };
+/**
+ * A ZIP archive decompression stream that emits files as they are discovered
+ */
+var Unzip = /*#__PURE__*/ (function () {
+    /**
+     * Creates a ZIP decompression stream
+     * @param cb The callback to call whenever a file in the ZIP archive is found
+     */
+    function Unzip(cb) {
+        this.onfile = cb;
+        this.k = [];
+        this.o = {
+            0: UnzipPassThrough
+        };
+        this.p = et;
+    }
+    /**
+     * Pushes a chunk to be unzipped
+     * @param chunk The chunk to push
+     * @param final Whether this is the last chunk
+     */
+    Unzip.prototype.push = function (chunk, final) {
+        var _this = this;
+        if (!this.onfile)
+            err(5);
+        if (!this.p)
+            err(4);
+        if (this.c > 0) {
+            var len = Math.min(this.c, chunk.length);
+            var toAdd = chunk.subarray(0, len);
+            this.c -= len;
+            if (this.d)
+                this.d.push(toAdd, !this.c);
+            else
+                this.k[0].push(toAdd);
+            chunk = chunk.subarray(len);
+            if (chunk.length)
+                return this.push(chunk, final);
+        }
+        else {
+            var f = 0, i = 0, is = void 0, buf = void 0;
+            if (!this.p.length)
+                buf = chunk;
+            else if (!chunk.length)
+                buf = this.p;
+            else {
+                buf = new u8(this.p.length + chunk.length);
+                buf.set(this.p), buf.set(chunk, this.p.length);
+            }
+            var l = buf.length, oc = this.c, add = oc && this.d;
+            var _loop_2 = function () {
+                var sig = b4(buf, i);
+                if (sig == 0x4034B50) {
+                    f = 1, is = i;
+                    this_1.d = null;
+                    this_1.c = 0;
+                    var bf = b2(buf, i + 6), cmp_1 = b2(buf, i + 8), u = bf & 2048, dd = bf & 8, fnl = b2(buf, i + 26), es = b2(buf, i + 28);
+                    if (l > i + 30 + fnl + es) {
+                        var chks_3 = [];
+                        this_1.k.unshift(chks_3);
+                        f = 2;
+                        var lsc = b4(buf, i + 18), lsu = b4(buf, i + 22);
+                        var fn_1 = strFromU8(buf.subarray(i + 30, i += 30 + fnl), !u);
+                        var _a = z64hs(buf, i, es, 2, lsc, lsu, 0), sc_1 = _a[0], su_1 = _a[1], z64 = _a[3];
+                        if (dd)
+                            sc_1 = -1 - z64;
+                        i += es;
+                        this_1.c = sc_1;
+                        var d_1;
+                        var file_1 = {
+                            name: fn_1,
+                            compression: cmp_1,
+                            start: function () {
+                                if (!file_1.ondata)
+                                    err(5);
+                                if (!sc_1)
+                                    file_1.ondata(null, et, true);
+                                else {
+                                    var ctr = _this.o[cmp_1];
+                                    if (!ctr)
+                                        file_1.ondata(err(14, 'unknown compression type ' + cmp_1, 1), null, false);
+                                    d_1 = sc_1 < 0 ? new ctr(fn_1) : new ctr(fn_1, sc_1, su_1);
+                                    d_1.ondata = function (err, dat, final) { file_1.ondata(err, dat, final); };
+                                    for (var _i = 0, chks_4 = chks_3; _i < chks_4.length; _i++) {
+                                        var dat = chks_4[_i];
+                                        d_1.push(dat, false);
+                                    }
+                                    if (_this.k[0] == chks_3 && _this.c)
+                                        _this.d = d_1;
+                                    else
+                                        d_1.push(et, true);
+                                }
+                            },
+                            terminate: function () {
+                                if (d_1 && d_1.terminate)
+                                    d_1.terminate();
+                            }
+                        };
+                        if (sc_1 >= 0)
+                            file_1.size = sc_1, file_1.originalSize = su_1;
+                        this_1.onfile(file_1);
+                    }
+                    return "break";
+                }
+                else if (oc) {
+                    if (sig == 0x8074B50) {
+                        is = i += 12 + (oc == -2 && 8), f = 3, this_1.c = 0;
+                        return "break";
+                    }
+                    else if (sig == 0x2014B50) {
+                        is = i -= 4, f = 3, this_1.c = 0;
+                        return "break";
+                    }
+                }
+            };
+            var this_1 = this;
+            for (; i < l - 4; ++i) {
+                var state_1 = _loop_2();
+                if (state_1 === "break")
+                    break;
+            }
+            this.p = et;
+            if (oc < 0) {
+                var dat = f ? buf.subarray(0, is - 12 - (oc == -2 && 8) - (b4(buf, is - 16) == 0x8074B50 && 4)) : buf.subarray(0, i);
+                if (add)
+                    add.push(dat, !!f);
+                else
+                    this.k[+(f == 2)].push(dat);
+            }
+            if (f & 2)
+                return this.push(buf.subarray(i), final);
+            this.p = buf.subarray(i);
+        }
+        if (final) {
+            if (this.c)
+                err(13);
+            this.p = null;
+        }
+    };
+    /**
+     * Registers a decoder with the stream, allowing for files compressed with
+     * the compression type provided to be expanded correctly
+     * @param decoder The decoder constructor
+     */
+    Unzip.prototype.register = function (decoder) {
+        this.o[decoder.compression] = decoder;
+    };
+    return Unzip;
+}());
+export { Unzip };
+var mt = typeof queueMicrotask == 'function' ? queueMicrotask : typeof setTimeout == 'function' ? setTimeout : function (fn) { fn(); };
+export function unzip(data, opts, cb) {
+    if (!cb)
+        cb = opts, opts = {};
+    if (typeof cb != 'function')
+        err(7);
+    var term = [];
+    var tAll = function () {
+        for (var i = 0; i < term.length; ++i)
+            term[i]();
+    };
+    var files = {};
+    var cbd = function (a, b) {
+        mt(function () { cb(a, b); });
+    };
+    mt(function () { cbd = cb; });
+    var e = data.length - 22;
+    for (; b4(data, e) != 0x6054B50; --e) {
+        if (!e || data.length - e > 65558) {
+            cbd(err(13, 0, 1), null);
+            return tAll;
+        }
+    }
+    ;
+    var lft = b2(data, e + 8);
+    if (lft) {
+        var c = lft;
+        var o = b4(data, e + 16);
+        var z = b4(data, e - 20) == 0x7064B50;
+        if (z) {
+            var ze = b4(data, e - 12);
+            z = b4(data, ze) == 0x6064B50;
+            if (z) {
+                c = lft = b4(data, ze + 32);
+                o = b4(data, ze + 48);
+            }
+        }
+        var fltr = opts && opts.filter;
+        var _loop_3 = function (i) {
+            var _a = zh(data, o, z), c_1 = _a[0], sc = _a[1], su = _a[2], fn = _a[3], no = _a[4], off = _a[5], b = slzh(data, off);
+            o = no;
+            var cbl = function (e, d) {
+                if (e) {
+                    tAll();
+                    cbd(e, null);
+                }
+                else {
+                    if (d)
+                        files[fn] = d;
+                    if (!--lft)
+                        cbd(null, files);
+                }
+            };
+            if (!fltr || fltr({
+                name: fn,
+                size: sc,
+                originalSize: su,
+                compression: c_1
+            })) {
+                if (!c_1)
+                    cbl(null, slc(data, b, b + sc));
+                else if (c_1 == 8) {
+                    var infl = data.subarray(b, b + sc);
+                    // Synchronously decompress under 512KB, or barely-compressed data
+                    if (su < 524288 || sc > 0.8 * su) {
+                        try {
+                            cbl(null, inflateSync(infl, { out: new u8(su) }));
+                        }
+                        catch (e) {
+                            cbl(e, null);
+                        }
+                    }
+                    else
+                        term.push(inflate(infl, { size: su }, cbl));
+                }
+                else
+                    cbl(err(14, 'unknown compression type ' + c_1, 1), null);
+            }
+            else
+                cbl(null, null);
+        };
+        for (var i = 0; i < c; ++i) {
+            _loop_3(i);
+        }
+    }
+    else
+        cbd(null, {});
+    return tAll;
+}
+/**
+ * Synchronously decompresses a ZIP archive. Prefer using `unzip` for better
+ * performance with more than one file.
+ * @param data The raw compressed ZIP file
+ * @param opts The ZIP extraction options
+ * @returns The decompressed files
+ */
+export function unzipSync(data, opts) {
+    var files = {};
+    var e = data.length - 22;
+    for (; b4(data, e) != 0x6054B50; --e) {
+        if (!e || data.length - e > 65558)
+            err(13);
+    }
+    ;
+    var c = b2(data, e + 8);
+    if (!c)
+        return {};
+    var o = b4(data, e + 16);
+    var z = b4(data, e - 20) == 0x7064B50;
+    if (z) {
+        var ze = b4(data, e - 12);
+        z = b4(data, ze) == 0x6064B50;
+        if (z) {
+            c = b4(data, ze + 32);
+            o = b4(data, ze + 48);
+        }
+    }
+    var fltr = opts && opts.filter;
+    for (var i = 0; i < c; ++i) {
+        var _a = zh(data, o, z), c_2 = _a[0], sc = _a[1], su = _a[2], fn = _a[3], no = _a[4], off = _a[5], b = slzh(data, off);
+        o = no;
+        if (!fltr || fltr({
+            name: fn,
+            size: sc,
+            originalSize: su,
+            compression: c_2
+        })) {
+            if (!c_2)
+                files[fn] = slc(data, b, b + sc);
+            else if (c_2 == 8)
+                files[fn] = inflateSync(data.subarray(b, b + sc), { out: new u8(su) });
+            else
+                err(14, 'unknown compression type ' + c_2);
+        }
+    }
+    return files;
+}

--- a/docs/offline-map-packs.md
+++ b/docs/offline-map-packs.md
@@ -1,6 +1,49 @@
 # Offline map packs
 
-Pyxis can read prebuilt raster map packs from an SD card. The host importer accepts only a **local, user-supplied XYZ PNG directory** and never downloads tiles. Before importing data, verify that its provider and license permit offline storage and use.
+Pyxis can read prebuilt raster map packs from an SD card. Importers accept only **local, user-supplied map files** and never download tiles. Before importing data, verify that its provider and license permit offline storage and use.
+
+## Browser installer (recommended)
+
+Open the Pyxis web flasher in current Chrome or Edge and use **Install Offline Maps**:
+
+1. Download a Coalition/MUI XYZ ZIP separately.
+2. Turn the T-Deck off, remove its SD card, and mount the card on the computer.
+3. Choose the ZIP, enter a map name and pack ID, and wait for local validation.
+4. Click **Install and Enable**, then choose the SD-card root.
+5. After the verified completion message, safely eject the card and return it to the T-Deck.
+
+The browser accepts stored ZIP entries rooted at either `<z>/<x>/<y>.png` or
+`maps/<style>/<z>/<x>/<y>.png`. It rejects mixed styles, traversal, duplicate
+paths or tile keys, symlinks, encrypted or unsupported compression, malformed
+ZIP records, unsafe PNGs, quota violations, and noncanonical XYZ paths. Tiles
+are validated and read back one at a time; the complete archive is not loaded
+into JavaScript memory.
+
+Installation refuses to overwrite an existing pack. A verified pack from an
+earlier activation failure can be reselected with the exact same ZIP and
+metadata. Tiles are published first, `manifest.pmp` is published last, and only
+then is a CRC-protected redundant active-map-set slot updated and read back. An
+interruption therefore leaves the previous map set usable. Unrelated SD-card
+files are untouched; cleanup removes only receipt-owned installer paths.
+
+## Packs and map sets
+
+A **pack** is an independent installation, update, removal, provenance, and
+attribution unit. A **map set** is an ordered collection of compatible packs
+that Pyxis uses together. Geographic packs do not require manual switching.
+
+For example, `regional-overview-z0-z9` and `local-detail-z0-z16` can both
+belong to the `osm-bright` map set. Pyxis checks the local-detail pack first and
+then the regional-overview pack for every requested XYZ key. The detail pack
+supplies its z10-z16 area while the overview pack supplies broader z0-z9
+coverage. Outside the detail area at z10-z16, the key is uncovered. If a
+higher-priority pack declares a tile but its file is missing, Pyxis safely tries
+the next compatible pack.
+
+The browser currently imports Coalition/MUI OSM Bright data into the bounded
+`osm-bright` map set. Newly installed packs take priority over earlier packs
+where their exact row-span coverage overlaps. Different styles or providers
+must use a different map set rather than being blended implicitly.
 
 ## Input requirements
 
@@ -12,10 +55,10 @@ The input must contain only canonical XYZ paths:
 
 - `z`, `x`, and `y` are canonical unsigned decimal integers: `0`, not `00` or `+0`.
 - Zoom is 0 through 22; X and Y are each in `0..2^z-1`.
-- Every PNG must be a valid, fully decodable, non-interlaced 256×256 PNG. Critical-chunk ordering, CRCs, palette state, deflate termination, exact scanline length, and row filters are validated; interlaced PNGs are intentionally unsupported.
+- Every PNG must be a valid, fully decodable, non-interlaced 256×256 PNG with at most 8 bits per sample. Critical-chunk ordering, supported ancillary semantics, CRCs, palette state, bounded deflate termination, exact scanline length, and row filters are validated; interlaced and 16-bit PNGs are intentionally unsupported by the browser importer.
 - Symlinks and unexpected files or directory levels are rejected.
-- Zoom levels must be contiguous. At each zoom, tiles must form a complete X/Y rectangle.
-- A rectangle crossing the antimeridian is accepted only with an explicit `--antimeridian-zoom Z`. Its X coordinates must form exactly two intervals, one beginning at X=0 and one ending at `2^Z-1`. The importer never guesses that a gap means an antimeridian crossing.
+- Zoom levels must be contiguous. Complete rectangles use the compact version-1 manifest; sparse state or polygon coverage uses exact bounded row spans in version 2.
+- A complete rectangle crossing the antimeridian can use `--antimeridian-zoom Z` for the compact version-1 representation. With explicit `--sparse`, disjoint coverage is represented exactly as row spans rather than guessed to be an antimeridian rectangle.
 
 The importer requires non-empty printable-ASCII display name, attribution, source, and license fields. These values are stored in the manifest; they do not grant rights or replace compliance with the provider's terms.
 
@@ -32,6 +75,10 @@ python3 tools/maps/build_map_pack.py ./my-xyz /media/$USER/SDCARD \
   --license "CC-BY-4.0"
 ```
 
+For an intentionally sparse state or polygon export, explicitly add `--sparse`.
+The default CLI mode continues to reject incomplete rectangles so an accidental
+missing tile cannot silently become declared sparse coverage.
+
 For explicitly known antimeridian coverage, repeat the option for each affected zoom:
 
 ```sh
@@ -47,7 +94,7 @@ The pack ID must match `[a-z0-9_-]{1,31}`. The destination is:
 
 The output root is normally the mounted SD-card root. The importer refuses to replace an existing pack.
 
-## Select the active pack
+## Legacy single-pack selection from the CLI
 
 With the SD card still mounted on the host and not in use by Pyxis, write the
 pack ID to the bounded selection marker without a trailing newline:
@@ -59,6 +106,8 @@ sync /media/$USER/SDCARD
 
 Safely unmount the card before inserting it into the T-Deck. Pyxis validates
 the marker, manifest, declared coverage, and canonical tile path before use.
+This marker selects one legacy pack only; it does not build a composited map
+set. The browser's redundant map-set records take precedence when present.
 Opening the map refreshes the selection. A missing or malformed pack is shown
 as unavailable; firmware never formats, repairs, deletes, or writes an
 immutable pack.
@@ -73,7 +122,19 @@ Defaults bound an import to 100,000 tiles and 8 GiB of tile bytes. Set stricter 
 
 All input is validated before publication. On Linux, the importer pins source and output directories with descriptor-relative, no-follow operations; rejects changed files and directory identities; copies under the caller's quotas; writes the deterministic manifest in a private sibling directory; flushes files and directories; and independently validates the copied tree. Publication requires Linux `renameat2(RENAME_NOREPLACE)` and fails closed when atomic no-replace is unavailable. A pre-commit failure removes its temporary directory. If the post-rename parent-directory sync fails, the CLI reports exit status 3 and explicitly says the pack is published but durability is uncertain.
 
-The manifest is the firmware's `PMPK` version 1 wire format: a 16-byte little-endian header, five length-prefixed printable-ASCII strings, zoom/count fields, fixed 26-byte per-zoom extents, and a final IEEE CRC-32. The Python serializer is fixture-tested byte-for-byte against the committed 153-byte C++ sample.
+The firmware accepts two bounded `PMPK` wire formats. Version 1 retains fixed
+26-byte per-zoom rectangular extents. Version 2 stores up to 512 canonical,
+sorted 13-byte `(zoom, y, x-minimum, x-maximum)` row spans and verifies that
+their exact tile total matches the manifest. Both use a 16-byte little-endian
+header, five bounded printable-ASCII strings, and a final IEEE CRC-32.
+
+The browser enables packs through redundant bounded `active-pack.0` and
+`active-pack.1` records with generations and CRC-32. Map-set record version 2
+stores the map-set ID, shared attribution, up to eight ordered pack IDs, and up
+to 512 total canonical row spans. Firmware selects the newest valid record,
+resolves each tile in pack-priority order, and ignores a torn or malformed peer.
+Legacy 48-byte version-1 records and the plain `active-pack` marker remain
+backward-compatible single-pack fallbacks.
 
 ## Network policy
 
@@ -81,4 +142,5 @@ Pack creation is deliberately local-files-only. The importer contains no network
 
 The production map screen is also SD-only. It does not initiate DNS, HTTP, or
 TLS and has no online-download setting. Its lookup order is the decoded PSRAM
-cache, the selected immutable pack, and then the bounded legacy SD tile cache.
+cache, the enabled immutable packs in deterministic priority order, and then the
+bounded legacy SD tile cache.

--- a/lib/tdeck_ui/Hardware/TDeck/MapTilePack.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/MapTilePack.cpp
@@ -5,18 +5,101 @@
 
 #include <cstdio>
 #include <cstring>
+#if defined(ARDUINO_ARCH_ESP32)
+#include <esp_heap_caps.h>
+#endif
 
 namespace Hardware {
 namespace TDeck {
+namespace {
+
+std::uint16_t selectionU16(const std::uint8_t* input) {
+    return static_cast<std::uint16_t>(input[0]) |
+           static_cast<std::uint16_t>(static_cast<std::uint16_t>(input[1]) << 8U);
+}
+
+std::uint32_t selectionU32(const std::uint8_t* input) {
+    return static_cast<std::uint32_t>(input[0]) |
+           (static_cast<std::uint32_t>(input[1]) << 8U) |
+           (static_cast<std::uint32_t>(input[2]) << 16U) |
+           (static_cast<std::uint32_t>(input[3]) << 24U);
+}
+
+std::uint32_t selectionCrc32(const std::uint8_t* input, std::size_t length) {
+    std::uint32_t crc = UINT32_C(0xffffffff);
+    for (std::size_t index = 0U; index < length; ++index) {
+        crc ^= input[index];
+        for (std::uint8_t bit = 0U; bit < 8U; ++bit) {
+            crc = (crc >> 1U) ^ ((crc & 1U) != 0U ? UINT32_C(0xedb88320) : 0U);
+        }
+    }
+    return ~crc;
+}
+
+bool decodeSelection(const std::uint8_t* input, std::size_t length,
+                     char* pack_id, std::uint32_t& generation) {
+    static const std::uint8_t magic[4] = {'P', 'M', 'A', 'S'};
+    if (input == NULL || pack_id == NULL || length != MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE ||
+        std::memcmp(input, magic, sizeof(magic)) != 0 || input[4] != 1U || input[5] != 0U ||
+        selectionU16(input + 6U) != MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE ||
+        selectionU32(input + 44U) != selectionCrc32(input, 44U)) {
+        return false;
+    }
+    generation = selectionU32(input + 8U);
+    const std::size_t id_length = input[12];
+    if (generation == 0U || id_length == 0U ||
+        id_length >= Pyxis::MapPackManifest::PACK_ID_CAPACITY) return false;
+    for (std::size_t index = 13U + id_length; index < 44U; ++index) {
+        if (input[index] != 0U) return false;
+    }
+    std::memcpy(pack_id, input + 13U, id_length);
+    pack_id[id_length] = '\0';
+    return MapTilePack::isValidPackId(pack_id);
+}
+
+bool readSelectionString(const std::uint8_t* input, std::size_t end, std::size_t& position,
+                         char* output, std::size_t capacity, bool identifier) {
+    if (input == NULL || output == NULL || capacity < 2U || position >= end) return false;
+    const std::size_t length = input[position++];
+    if (length == 0U || length >= capacity || position + length > end) return false;
+    for (std::size_t index = 0U; index < length; ++index) {
+        const std::uint8_t value = input[position + index];
+        if (value < 0x20U || value > 0x7eU) return false;
+        if (identifier && !((value >= 'a' && value <= 'z') ||
+                            (value >= '0' && value <= '9') || value == '_' || value == '-')) {
+            return false;
+        }
+    }
+    std::memcpy(output, input + position, length);
+    output[length] = '\0';
+    position += length;
+    return true;
+}
+
+}  // namespace
 
 const char MapTilePack::ACTIVE_PACK_PATH[] = "/pyxis-map/active-pack";
+const char MapTilePack::ACTIVE_PACK_SLOT_0_PATH[] = "/pyxis-map/active-pack.0";
+const char MapTilePack::ACTIVE_PACK_SLOT_1_PATH[] = "/pyxis-map/active-pack.1";
 
 MapTilePack::MapTilePack(MapTileStorage& storage)
-    : storage_(storage), manifest_(), status_(MapTilePackStatus::UNINITIALIZED),
-      stream_open_(false), stream_remaining_(0U), manifest_buffer_() {}
+    : storage_(storage), manifest_(), active_packs_(), active_pack_count_(0U),
+      map_set_active_(false), selection_generation_(0U),
+      status_(MapTilePackStatus::UNINITIALIZED),
+      stream_open_(false), stream_remaining_(0U), selection_buffers_(),
+      active_selection_buffer_(0U) {
+#if defined(ARDUINO_ARCH_ESP32)
+    selection_buffers_ = static_cast<std::uint8_t*>(heap_caps_malloc(
+        2U * ACTIVE_SELECTION_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+#endif
+}
 
 MapTilePack::~MapTilePack() {
     endGet();
+#if defined(ARDUINO_ARCH_ESP32)
+    if (selection_buffers_ != NULL) heap_caps_free(selection_buffers_);
+    selection_buffers_ = NULL;
+#endif
 }
 
 bool MapTilePack::isValidPackId(const char* pack_id) {
@@ -37,6 +120,95 @@ bool MapTilePack::isValidKey(const TileKey& key) {
     if (key.zoom > Pyxis::MapPackManifest::MAX_ZOOM) return false;
     const std::uint32_t edge = UINT32_C(1) << key.zoom;
     return key.x < edge && key.y < edge;
+}
+
+std::uint8_t* MapTilePack::selectionBuffer(std::uint8_t index) {
+    if (index > 1U) return NULL;
+#if defined(ARDUINO_ARCH_ESP32)
+    return selection_buffers_ == NULL ? NULL : selection_buffers_ +
+        static_cast<std::size_t>(index) * ACTIVE_SELECTION_SIZE;
+#else
+    return selection_buffers_[index];
+#endif
+}
+
+bool MapTilePack::parseMapSetSelection(const std::uint8_t* input, std::size_t length,
+                                       std::uint32_t& generation,
+                                       Pyxis::MapPackManifest& metadata,
+                                       ActivePackView* packs, std::uint8_t& pack_count) {
+    static const std::uint8_t magic[4] = {'P', 'M', 'A', 'S'};
+    if (input == NULL || packs == NULL || length < 16U || length > ACTIVE_SELECTION_SIZE ||
+        std::memcmp(input, magic, sizeof(magic)) != 0 || input[4] != 2U || input[5] != 0U ||
+        selectionU16(input + 6U) != length ||
+        selectionU32(input + length - 4U) != selectionCrc32(input, length - 4U)) return false;
+    generation = selectionU32(input + 8U);
+    if (generation == 0U) return false;
+    metadata = Pyxis::MapPackManifest();
+    std::size_t position = 12U;
+    if (!readSelectionString(input, length - 4U, position, metadata.pack_id,
+                             sizeof(metadata.pack_id), true)) return false;
+    std::strncpy(metadata.name, metadata.pack_id, sizeof(metadata.name) - 1U);
+    if (!readSelectionString(input, length - 4U, position, metadata.attribution,
+                             sizeof(metadata.attribution), false) || position >= length - 4U) return false;
+    std::strncpy(metadata.source, "active map set", sizeof(metadata.source) - 1U);
+    pack_count = input[position++];
+    if (pack_count == 0U || pack_count > MAX_ACTIVE_PACKS) return false;
+    std::uint16_t total_spans = 0U;
+    for (std::uint8_t pack_index = 0U; pack_index < pack_count; ++pack_index) {
+        ActivePackView& pack = packs[pack_index];
+        if (!readSelectionString(input, length - 4U, position, pack.pack_id,
+                                 sizeof(pack.pack_id), true)) return false;
+        for (std::uint8_t previous_pack = 0U; previous_pack < pack_index; ++previous_pack) {
+            if (std::strcmp(pack.pack_id, packs[previous_pack].pack_id) == 0) return false;
+        }
+        if (position + 2U > length - 4U) return false;
+        pack.span_count = selectionU16(input + position);
+        position += 2U;
+        if (pack.span_count == 0U || pack.span_count > MAX_ACTIVE_ROW_SPANS ||
+            total_spans > MAX_ACTIVE_ROW_SPANS - pack.span_count ||
+            position + static_cast<std::size_t>(pack.span_count) * 13U > length - 4U) return false;
+        pack.span_bytes = input + position;
+        std::uint8_t previous_zoom = 0U;
+        std::uint32_t previous_y = 0U;
+        std::uint32_t previous_x_maximum = 0U;
+        bool have_previous = false;
+        for (std::uint16_t span_index = 0U; span_index < pack.span_count; ++span_index) {
+            const std::uint8_t* span = input + position;
+            const std::uint8_t zoom = span[0];
+            const std::uint32_t y = selectionU32(span + 1U);
+            const std::uint32_t x_minimum = selectionU32(span + 5U);
+            const std::uint32_t x_maximum = selectionU32(span + 9U);
+            if (zoom > Pyxis::MapPackManifest::MAX_ZOOM) return false;
+            const std::uint32_t edge = UINT32_C(1) << zoom;
+            if (y >= edge || x_minimum > x_maximum || x_maximum >= edge ||
+                (have_previous && (zoom < previous_zoom ||
+                 (zoom == previous_zoom && y < previous_y) ||
+                 (zoom == previous_zoom && y == previous_y &&
+                  x_minimum <= previous_x_maximum + 1U)))) return false;
+            previous_zoom = zoom;
+            previous_y = y;
+            previous_x_maximum = x_maximum;
+            have_previous = true;
+            position += 13U;
+        }
+        total_spans = static_cast<std::uint16_t>(total_spans + pack.span_count);
+    }
+    return position == length - 4U;
+}
+
+bool MapTilePack::spanCovers(const ActivePackView& pack, const TileKey& key) {
+    for (std::uint16_t index = 0U; index < pack.span_count; ++index) {
+        const std::uint8_t* span = pack.span_bytes + static_cast<std::size_t>(index) * 13U;
+        const std::uint8_t zoom = span[0];
+        if (zoom > key.zoom) return false;
+        if (zoom != key.zoom) continue;
+        const std::uint32_t y = selectionU32(span + 1U);
+        if (y > key.y) return false;
+        if (y == key.y && key.x >= selectionU32(span + 5U) && key.x <= selectionU32(span + 9U)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 MapTilePackResult MapTilePack::makePath(const char* pack_id, const TileKey* key,
@@ -122,46 +294,122 @@ MapTilePackResult MapTilePack::failInitialize(MapTilePackResult result,
 MapTilePackResult MapTilePack::initialize() {
     endGet();
     const bool had_selection = hasSelection();
+    if (selectionBuffer(0U) == NULL) {
+        return failInitialize(MapTilePackResult::INSUFFICIENT_MEMORY,
+                              MapTilePackStatus::INSUFFICIENT_MEMORY, had_selection);
+    }
     if (!storage_.isAvailable()) {
         return failInitialize(MapTilePackResult::STORAGE_UNAVAILABLE,
                               MapTilePackStatus::STORAGE_UNAVAILABLE, had_selection);
     }
 
-    std::uint8_t marker[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
-    std::size_t marker_length = 0U;
-    MapTilePackResult result = loadFile(ACTIVE_PACK_PATH, marker, sizeof(marker) - 1U,
-                                        marker_length, MapTilePackResult::NO_SELECTION,
-                                        MapTilePackResult::INVALID_PACK_ID);
-    if (result == MapTilePackResult::NO_SELECTION) {
-        manifest_ = Pyxis::MapPackManifest();
-        status_ = MapTilePackStatus::NO_SELECTION;
-        return result;
+    const std::uint8_t candidate_buffer = static_cast<std::uint8_t>(active_selection_buffer_ ^ 1U);
+    const char* slot_paths[2] = {ACTIVE_PACK_SLOT_0_PATH, ACTIVE_PACK_SLOT_1_PATH};
+    std::uint32_t slot_generations[2] = {0U, 0U};
+    std::uint32_t slot_checksums[2] = {0U, 0U};
+    bool slot_valid[2] = {false, false};
+    MapTilePackResult result = MapTilePackResult::NO_SELECTION;
+    for (std::size_t slot = 0U; slot < 2U; ++slot) {
+        std::size_t record_length = 0U;
+        result = loadFile(slot_paths[slot], selectionBuffer(candidate_buffer), ACTIVE_SELECTION_SIZE,
+                          record_length, MapTilePackResult::NO_SELECTION,
+                          MapTilePackResult::INVALID_PACK_ID);
+        if (result == MapTilePackResult::OK) {
+            char legacy_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
+            Pyxis::MapPackManifest map_set_metadata = {};
+            ActivePackView map_set_packs[MAX_ACTIVE_PACKS] = {};
+            std::uint8_t map_set_pack_count = 0U;
+            if (decodeSelection(selectionBuffer(candidate_buffer), record_length,
+                                legacy_id, slot_generations[slot]) ||
+                parseMapSetSelection(selectionBuffer(candidate_buffer), record_length,
+                                     slot_generations[slot], map_set_metadata,
+                                     map_set_packs, map_set_pack_count)) {
+                slot_valid[slot] = true;
+                slot_checksums[slot] = selectionU32(selectionBuffer(candidate_buffer) + record_length - 4U);
+            }
+        } else if (result != MapTilePackResult::NO_SELECTION &&
+                   result != MapTilePackResult::INVALID_PACK_ID) {
+            const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
+                ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
+            return failInitialize(result, state, had_selection);
+        }
     }
-    if (result != MapTilePackResult::OK) {
-        const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
-            ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
-        return failInitialize(result, state, had_selection);
-    }
-    if (marker_length == 0U) {
-        manifest_ = Pyxis::MapPackManifest();
-        status_ = MapTilePackStatus::NO_SELECTION;
-        return MapTilePackResult::NO_SELECTION;
-    }
-    marker[marker_length] = 0U;
-    const char* pack_id = reinterpret_cast<const char*>(marker);
-    if (std::memchr(marker, 0, marker_length) != NULL || !isValidPackId(pack_id)) {
+    if (slot_valid[0] && slot_valid[1] && slot_generations[0] == slot_generations[1] &&
+        slot_checksums[0] != slot_checksums[1]) {
         return failInitialize(MapTilePackResult::INVALID_PACK_ID,
                               MapTilePackStatus::INVALID_SELECTION, had_selection);
     }
 
+    char selected_pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
+    std::uint32_t selected_generation = 0U;
+    if (slot_valid[0] || slot_valid[1]) {
+        const std::size_t chosen = !slot_valid[1] ||
+            (slot_valid[0] && slot_generations[0] >= slot_generations[1]) ? 0U : 1U;
+        std::size_t record_length = 0U;
+        result = loadFile(slot_paths[chosen], selectionBuffer(candidate_buffer), ACTIVE_SELECTION_SIZE,
+                          record_length, MapTilePackResult::NO_SELECTION,
+                          MapTilePackResult::INVALID_PACK_ID);
+        if (result != MapTilePackResult::OK) {
+            return failInitialize(result, MapTilePackStatus::INVALID_SELECTION, had_selection);
+        }
+        std::uint32_t generation = 0U;
+        Pyxis::MapPackManifest map_set_metadata = {};
+        ActivePackView map_set_packs[MAX_ACTIVE_PACKS] = {};
+        std::uint8_t map_set_pack_count = 0U;
+        if (parseMapSetSelection(selectionBuffer(candidate_buffer), record_length, generation,
+                                 map_set_metadata, map_set_packs, map_set_pack_count)) {
+            manifest_ = map_set_metadata;
+            std::memcpy(active_packs_, map_set_packs,
+                        static_cast<std::size_t>(map_set_pack_count) * sizeof(ActivePackView));
+            active_pack_count_ = map_set_pack_count;
+            map_set_active_ = true;
+            selection_generation_ = generation;
+            active_selection_buffer_ = candidate_buffer;
+            status_ = MapTilePackStatus::READY;
+            return MapTilePackResult::OK;
+        }
+        if (!decodeSelection(selectionBuffer(candidate_buffer), record_length,
+                             selected_pack_id, selected_generation)) {
+            return failInitialize(MapTilePackResult::INVALID_PACK_ID,
+                                  MapTilePackStatus::INVALID_SELECTION, had_selection);
+        }
+    } else {
+        std::uint8_t marker[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+        std::size_t marker_length = 0U;
+        result = loadFile(ACTIVE_PACK_PATH, marker, sizeof(marker) - 1U,
+                          marker_length, MapTilePackResult::NO_SELECTION,
+                          MapTilePackResult::INVALID_PACK_ID);
+        if (result == MapTilePackResult::NO_SELECTION ||
+            (result == MapTilePackResult::OK && marker_length == 0U)) {
+            manifest_ = Pyxis::MapPackManifest();
+            active_pack_count_ = 0U;
+            map_set_active_ = false;
+            selection_generation_ = 0U;
+            status_ = MapTilePackStatus::NO_SELECTION;
+            return MapTilePackResult::NO_SELECTION;
+        }
+        if (result != MapTilePackResult::OK) {
+            const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
+                ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
+            return failInitialize(result, state, had_selection);
+        }
+        marker[marker_length] = 0U;
+        if (std::memchr(marker, 0, marker_length) != NULL ||
+            !isValidPackId(reinterpret_cast<const char*>(marker))) {
+            return failInitialize(MapTilePackResult::INVALID_PACK_ID,
+                                  MapTilePackStatus::INVALID_SELECTION, had_selection);
+        }
+        std::strcpy(selected_pack_id, reinterpret_cast<const char*>(marker));
+    }
+
     char manifest_path[PATH_CAPACITY];
-    result = manifestPath(pack_id, manifest_path, sizeof(manifest_path));
+    result = manifestPath(selected_pack_id, manifest_path, sizeof(manifest_path));
     if (result != MapTilePackResult::OK) {
         return failInitialize(result, MapTilePackStatus::INVALID_SELECTION, had_selection);
     }
     std::size_t manifest_length = 0U;
-    result = loadFile(manifest_path, manifest_buffer_, sizeof(manifest_buffer_), manifest_length,
-                      MapTilePackResult::MANIFEST_MISSING,
+    result = loadFile(manifest_path, selectionBuffer(candidate_buffer), MANIFEST_BUFFER_CAPACITY,
+                      manifest_length, MapTilePackResult::MANIFEST_MISSING,
                       MapTilePackResult::MANIFEST_TOO_LARGE);
     if (result != MapTilePackResult::OK) {
         const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
@@ -170,17 +418,21 @@ MapTilePackResult MapTilePack::initialize() {
     }
 
     Pyxis::MapPackManifest candidate = {};
-    if (Pyxis::MapPackManifest::parse(manifest_buffer_, manifest_length, candidate) !=
+    if (Pyxis::MapPackManifest::parse(selectionBuffer(candidate_buffer), manifest_length, candidate) !=
         Pyxis::ManifestResult::OK) {
         return failInitialize(MapTilePackResult::INVALID_MANIFEST,
                               MapTilePackStatus::INVALID_SELECTION, had_selection);
     }
-    if (std::strcmp(pack_id, candidate.pack_id) != 0) {
+    if (std::strcmp(selected_pack_id, candidate.pack_id) != 0) {
         return failInitialize(MapTilePackResult::PACK_ID_MISMATCH,
                               MapTilePackStatus::INVALID_SELECTION, had_selection);
     }
 
     manifest_ = candidate;
+    active_pack_count_ = 0U;
+    map_set_active_ = false;
+    selection_generation_ = selected_generation;
+    active_selection_buffer_ = candidate_buffer;
     status_ = MapTilePackStatus::READY;
     return MapTilePackResult::OK;
 }
@@ -189,9 +441,31 @@ MapTilePackResult MapTilePack::beginGet(const TileKey& key, std::uint32_t& size)
     if (stream_open_) return MapTilePackResult::BUSY;
     if (!hasSelection()) return MapTilePackResult::NOT_INITIALIZED;
     if (!isValidKey(key)) return MapTilePackResult::INVALID_KEY;
-    if (!manifest_.covers(key)) return MapTilePackResult::UNCOVERED;
     if (!storage_.isAvailable()) return MapTilePackResult::STORAGE_UNAVAILABLE;
 
+    if (map_set_active_) {
+        bool covered = false;
+        for (std::uint8_t index = 0U; index < active_pack_count_; ++index) {
+            if (!spanCovers(active_packs_[index], key)) continue;
+            covered = true;
+            char path[PATH_CAPACITY];
+            MapTilePackResult result = tilePath(active_packs_[index].pack_id, key, path, sizeof(path));
+            if (result != MapTilePackResult::OK) return result;
+            std::uint32_t candidate_size = 0U;
+            const TileStoreResult begin = storage_.beginRead(path, candidate_size);
+            if (begin == TileStoreResult::MISS) continue;
+            if (begin == TileStoreResult::STORAGE_UNAVAILABLE) return MapTilePackResult::STORAGE_UNAVAILABLE;
+            if (begin == TileStoreResult::BUSY) return MapTilePackResult::BUSY;
+            if (begin != TileStoreResult::OK) return MapTilePackResult::IO_ERROR;
+            stream_open_ = true;
+            stream_remaining_ = candidate_size;
+            size = candidate_size;
+            return MapTilePackResult::OK;
+        }
+        return covered ? MapTilePackResult::TILE_MISSING : MapTilePackResult::UNCOVERED;
+    }
+
+    if (!manifest_.covers(key)) return MapTilePackResult::UNCOVERED;
     char path[PATH_CAPACITY];
     MapTilePackResult result = tilePath(manifest_.pack_id, key, path, sizeof(path));
     if (result != MapTilePackResult::OK) return result;

--- a/lib/tdeck_ui/Hardware/TDeck/MapTilePack.h
+++ b/lib/tdeck_ui/Hardware/TDeck/MapTilePack.h
@@ -18,6 +18,7 @@ enum class MapTilePackResult : std::uint8_t {
     NO_SELECTION,
     INVALID_PACK_ID,
     STORAGE_UNAVAILABLE,
+    INSUFFICIENT_MEMORY,
     MANIFEST_MISSING,
     MANIFEST_TOO_LARGE,
     INVALID_MANIFEST,
@@ -38,11 +39,13 @@ enum class MapTilePackStatus : std::uint8_t {
     NO_SELECTION,
     READY,
     INVALID_SELECTION,
-    STORAGE_UNAVAILABLE
+    STORAGE_UNAVAILABLE,
+    INSUFFICIENT_MEMORY
 };
 
 /**
- * Allocation-free, read-only access to one SD-selected map pack.
+ * Bounded, read-only access to an enabled map set. Production selection
+ * buffers are allocated once in PSRAM; tile lookup itself is allocation-free.
  *
  * initialize() reads the bounded active marker and manifest transactionally:
  * an already usable selection remains active if a replacement is malformed or
@@ -52,6 +55,12 @@ enum class MapTilePackStatus : std::uint8_t {
 class MapTilePack {
 public:
     static const char ACTIVE_PACK_PATH[];
+    static const char ACTIVE_PACK_SLOT_0_PATH[];
+    static const char ACTIVE_PACK_SLOT_1_PATH[];
+    static const std::size_t LEGACY_ACTIVE_SELECTION_SIZE = 48U;
+    static const std::size_t ACTIVE_SELECTION_SIZE = 7105U;
+    static const std::size_t MAX_ACTIVE_PACKS = 8U;
+    static const std::size_t MAX_ACTIVE_ROW_SPANS = 512U;
     static const std::size_t PATH_CAPACITY = 80U;
     static const std::size_t MANIFEST_BUFFER_CAPACITY = Pyxis::MapPackManifest::MAX_SERIALIZED_SIZE;
 
@@ -63,6 +72,7 @@ public:
     MapTilePackStatus status() const { return status_; }
     bool hasSelection() const { return status_ == MapTilePackStatus::READY; }
     const Pyxis::MapPackManifest& metadata() const { return manifest_; }
+    std::uint32_t selectionGeneration() const { return selection_generation_; }
 
     static bool isValidPackId(const char* pack_id);
     static MapTilePackResult manifestPath(const char* pack_id, char* output, std::size_t capacity);
@@ -74,15 +84,44 @@ public:
                                    std::size_t& count);
     void endGet();
 
-    static std::size_t ramBytes() { return sizeof(MapTilePack); }
+    static std::size_t ramBytes() {
+#if defined(ARDUINO_ARCH_ESP32)
+        return sizeof(MapTilePack) + 2U * ACTIVE_SELECTION_SIZE;
+#else
+        return sizeof(MapTilePack);
+#endif
+    }
+    static std::size_t internalRamBytes() { return sizeof(MapTilePack); }
+    static std::size_t psramBytes() {
+#if defined(ARDUINO_ARCH_ESP32)
+        return 2U * ACTIVE_SELECTION_SIZE;
+#else
+        return 0U;
+#endif
+    }
 
 private:
+    struct ActivePackView {
+        char pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+        std::uint16_t span_count;
+        const std::uint8_t* span_bytes;
+    };
+
     MapTileStorage& storage_;
     Pyxis::MapPackManifest manifest_;
+    ActivePackView active_packs_[MAX_ACTIVE_PACKS];
+    std::uint8_t active_pack_count_;
+    bool map_set_active_;
+    std::uint32_t selection_generation_;
     MapTilePackStatus status_;
     bool stream_open_;
     std::uint32_t stream_remaining_;
-    std::uint8_t manifest_buffer_[MANIFEST_BUFFER_CAPACITY];
+#if defined(ARDUINO_ARCH_ESP32)
+    std::uint8_t* selection_buffers_;
+#else
+    std::uint8_t selection_buffers_[2][ACTIVE_SELECTION_SIZE];
+#endif
+    std::uint8_t active_selection_buffer_;
 
     MapTilePack(const MapTilePack&);
     MapTilePack& operator=(const MapTilePack&);
@@ -93,6 +132,12 @@ private:
                                std::size_t& length, MapTilePackResult missing_result,
                                MapTilePackResult oversized_result);
     static bool isValidKey(const TileKey& key);
+    std::uint8_t* selectionBuffer(std::uint8_t index);
+    static bool parseMapSetSelection(const std::uint8_t* input, std::size_t length,
+                                     std::uint32_t& generation,
+                                     Pyxis::MapPackManifest& metadata,
+                                     ActivePackView* packs, std::uint8_t& pack_count);
+    static bool spanCovers(const ActivePackView& pack, const TileKey& key);
     static MapTilePackResult makePath(const char* pack_id, const TileKey* key,
                                       bool manifest, char* output, std::size_t capacity);
 };

--- a/lib/tdeck_ui/UI/LXMF/MapPackManifest.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapPackManifest.cpp
@@ -12,6 +12,7 @@ namespace {
 const std::size_t HEADER_SIZE = 16U;
 const std::size_t CRC_SIZE = 4U;
 const std::size_t EXTENT_SIZE = 26U;
+const std::size_t ROW_SPAN_SIZE = 13U;
 const std::uint8_t MAGIC[4] = {'P', 'M', 'P', 'K'};
 
 void putU16(std::uint8_t* output, std::uint16_t value) {
@@ -128,6 +129,78 @@ ManifestResult validate(const MapPackManifest& manifest) {
     return ManifestResult::OK;
 }
 
+RowSpan readRowSpan(const std::uint8_t* input) {
+    RowSpan span = {};
+    span.zoom = input[0];
+    span.y = getU32(input + 1U);
+    span.x_minimum = getU32(input + 5U);
+    span.x_maximum = getU32(input + 9U);
+    return span;
+}
+
+void writeRowSpan(std::uint8_t* output, const RowSpan& span) {
+    output[0] = span.zoom;
+    putU32(output + 1U, span.y);
+    putU32(output + 5U, span.x_minimum);
+    putU32(output + 9U, span.x_maximum);
+}
+
+ManifestResult validateSparse(const MapPackManifest& manifest,
+                              const RowSpan* spans, std::size_t span_count) {
+    std::size_t ignored = 0U;
+    if (checkedStringLength(manifest.pack_id, sizeof(manifest.pack_id), true, ignored) != ManifestResult::OK ||
+        checkedStringLength(manifest.name, sizeof(manifest.name), false, ignored) != ManifestResult::OK ||
+        checkedStringLength(manifest.attribution, sizeof(manifest.attribution), false, ignored) != ManifestResult::OK ||
+        checkedStringLength(manifest.source, sizeof(manifest.source), false, ignored) != ManifestResult::OK ||
+        checkedStringLength(manifest.license, sizeof(manifest.license), false, ignored) != ManifestResult::OK) {
+        return ManifestResult::INVALID_STRING;
+    }
+    if (manifest.min_zoom > manifest.max_zoom || manifest.max_zoom > MapPackManifest::MAX_ZOOM) {
+        return ManifestResult::INVALID_ZOOM;
+    }
+    if (spans == 0 || span_count == 0U || span_count > MapPackManifest::MAX_ROW_SPANS) {
+        return ManifestResult::INVALID_EXTENT;
+    }
+    std::uint32_t zoom_mask = 0U;
+    std::uint64_t total = 0U;
+    RowSpan previous = {};
+    for (std::size_t index = 0U; index < span_count; ++index) {
+        const RowSpan& span = spans[index];
+        if (span.zoom < manifest.min_zoom || span.zoom > manifest.max_zoom) {
+            return ManifestResult::INVALID_EXTENT;
+        }
+        const std::uint32_t world_maximum = (UINT32_C(1) << span.zoom) - 1U;
+        if (span.y > world_maximum || span.x_minimum > span.x_maximum ||
+            span.x_maximum > world_maximum) {
+            return ManifestResult::INVALID_EXTENT;
+        }
+        if (index != 0U &&
+            (span.zoom < previous.zoom ||
+             (span.zoom == previous.zoom && span.y < previous.y) ||
+             (span.zoom == previous.zoom && span.y == previous.y &&
+              span.x_minimum <= previous.x_maximum + 1U))) {
+            return ManifestResult::INVALID_EXTENT;
+        }
+        zoom_mask |= UINT32_C(1) << span.zoom;
+        const std::uint64_t count = static_cast<std::uint64_t>(span.x_maximum) -
+                                    span.x_minimum + 1U;
+        if (total > std::numeric_limits<std::uint32_t>::max() - count) {
+            return ManifestResult::INVALID_TILE_COUNT;
+        }
+        total += count;
+        previous = span;
+    }
+    std::uint32_t expected_mask = 0U;
+    for (std::uint8_t zoom = manifest.min_zoom; zoom <= manifest.max_zoom; ++zoom) {
+        expected_mask |= UINT32_C(1) << zoom;
+    }
+    if (zoom_mask != expected_mask) return ManifestResult::INVALID_ZOOM;
+    if (manifest.tile_count == 0U || total != manifest.tile_count) {
+        return ManifestResult::INVALID_TILE_COUNT;
+    }
+    return ManifestResult::OK;
+}
+
 void writeString(std::uint8_t* output, std::size_t& position,
                  const char* text, std::size_t length) {
     output[position++] = static_cast<std::uint8_t>(length);
@@ -179,7 +252,7 @@ ManifestResult MapPackManifest::serialize(const MapPackManifest& manifest,
 
     std::uint8_t temporary[MAX_SERIALIZED_SIZE] = {};
     std::memcpy(temporary, MAGIC, sizeof(MAGIC));
-    temporary[4] = FORMAT_VERSION;
+    temporary[4] = LEGACY_FORMAT_VERSION;
     temporary[5] = 0U;
     putU16(temporary + 6U, static_cast<std::uint16_t>(HEADER_SIZE));
     putU32(temporary + 8U, static_cast<std::uint32_t>(required));
@@ -212,12 +285,61 @@ ManifestResult MapPackManifest::serialize(const MapPackManifest& manifest,
     return ManifestResult::OK;
 }
 
+ManifestResult MapPackManifest::serializeSparse(const MapPackManifest& manifest,
+                                                const RowSpan* spans,
+                                                std::size_t span_count,
+                                                std::uint8_t* output,
+                                                std::size_t capacity,
+                                                std::size_t& written) {
+    const ManifestResult validity = validateSparse(manifest, spans, span_count);
+    if (validity != ManifestResult::OK) return validity;
+    std::size_t lengths[5] = {0U, 0U, 0U, 0U, 0U};
+    (void)checkedStringLength(manifest.pack_id, sizeof(manifest.pack_id), true, lengths[0]);
+    (void)checkedStringLength(manifest.name, sizeof(manifest.name), false, lengths[1]);
+    (void)checkedStringLength(manifest.attribution, sizeof(manifest.attribution), false, lengths[2]);
+    (void)checkedStringLength(manifest.source, sizeof(manifest.source), false, lengths[3]);
+    (void)checkedStringLength(manifest.license, sizeof(manifest.license), false, lengths[4]);
+    std::size_t required = HEADER_SIZE + CRC_SIZE + 8U + ROW_SPAN_SIZE * span_count;
+    for (std::size_t index = 0U; index < 5U; ++index) required += 1U + lengths[index];
+    if (output == 0 || capacity < required) return ManifestResult::INSUFFICIENT_CAPACITY;
+
+    std::uint8_t temporary[MAX_SERIALIZED_SIZE] = {};
+    std::memcpy(temporary, MAGIC, sizeof(MAGIC));
+    temporary[4] = FORMAT_VERSION;
+    temporary[5] = 0U;
+    putU16(temporary + 6U, static_cast<std::uint16_t>(HEADER_SIZE));
+    putU32(temporary + 8U, static_cast<std::uint32_t>(required));
+    putU32(temporary + 12U, 0U);
+    std::size_t position = HEADER_SIZE;
+    writeString(temporary, position, manifest.pack_id, lengths[0]);
+    writeString(temporary, position, manifest.name, lengths[1]);
+    writeString(temporary, position, manifest.attribution, lengths[2]);
+    writeString(temporary, position, manifest.source, lengths[3]);
+    writeString(temporary, position, manifest.license, lengths[4]);
+    temporary[position++] = manifest.min_zoom;
+    temporary[position++] = manifest.max_zoom;
+    putU16(temporary + position, static_cast<std::uint16_t>(span_count)); position += 2U;
+    putU32(temporary + position, manifest.tile_count); position += 4U;
+    for (std::size_t index = 0U; index < span_count; ++index) {
+        writeRowSpan(temporary + position, spans[index]);
+        position += ROW_SPAN_SIZE;
+    }
+    putU32(temporary + position, crc32(temporary, position)); position += CRC_SIZE;
+    if (position != required) return ManifestResult::BAD_LENGTH;
+    std::memcpy(output, temporary, required);
+    written = required;
+    return ManifestResult::OK;
+}
+
 ManifestResult MapPackManifest::parse(const std::uint8_t* input,
                                       std::size_t length,
                                       MapPackManifest& output) {
     if (input == 0 || length < HEADER_SIZE + CRC_SIZE) return ManifestResult::BAD_LENGTH;
     if (std::memcmp(input, MAGIC, sizeof(MAGIC)) != 0) return ManifestResult::BAD_MAGIC;
-    if (input[4] != FORMAT_VERSION) return ManifestResult::UNSUPPORTED_VERSION;
+    const std::uint8_t version = input[4];
+    if (version != LEGACY_FORMAT_VERSION && version != FORMAT_VERSION) {
+        return ManifestResult::UNSUPPORTED_VERSION;
+    }
     if (input[5] != 0U || getU16(input + 6U) != HEADER_SIZE || getU32(input + 12U) != 0U) {
         return ManifestResult::BAD_HEADER;
     }
@@ -237,28 +359,81 @@ ManifestResult MapPackManifest::parse(const std::uint8_t* input,
     if (result != ManifestResult::OK) return result;
     result = readString(input, payload_end, position, candidate.license, sizeof(candidate.license), false);
     if (result != ManifestResult::OK) return result;
-    if (payload_end - position < 7U) return ManifestResult::BAD_LENGTH;
-    candidate.min_zoom = input[position++];
-    candidate.max_zoom = input[position++];
-    candidate.extent_count = input[position++];
-    candidate.tile_count = getU32(input + position); position += 4U;
-    if (candidate.extent_count > MAX_ZOOM_LEVELS ||
-        static_cast<std::size_t>(candidate.extent_count) > (payload_end - position) / EXTENT_SIZE) {
-        return ManifestResult::INVALID_EXTENT;
-    }
-    for (std::size_t index = 0U; index < candidate.extent_count; ++index) {
-        ZoomExtent& extent = candidate.extents[index];
-        extent.zoom = input[position++];
-        extent.interval_count = input[position++];
-        extent.y_minimum = getU32(input + position); position += 4U;
-        extent.y_maximum = getU32(input + position); position += 4U;
-        for (std::size_t interval = 0U; interval < 2U; ++interval) {
-            extent.x[interval].minimum = getU32(input + position); position += 4U;
-            extent.x[interval].maximum = getU32(input + position); position += 4U;
+    candidate.format_version = version;
+    if (version == LEGACY_FORMAT_VERSION) {
+        if (payload_end - position < 7U) return ManifestResult::BAD_LENGTH;
+        candidate.min_zoom = input[position++];
+        candidate.max_zoom = input[position++];
+        candidate.extent_count = input[position++];
+        candidate.tile_count = getU32(input + position); position += 4U;
+        if (candidate.extent_count > MAX_ZOOM_LEVELS ||
+            static_cast<std::size_t>(candidate.extent_count) > (payload_end - position) / EXTENT_SIZE) {
+            return ManifestResult::INVALID_EXTENT;
         }
+        for (std::size_t index = 0U; index < candidate.extent_count; ++index) {
+            ZoomExtent& extent = candidate.extents[index];
+            extent.zoom = input[position++];
+            extent.interval_count = input[position++];
+            extent.y_minimum = getU32(input + position); position += 4U;
+            extent.y_maximum = getU32(input + position); position += 4U;
+            for (std::size_t interval = 0U; interval < 2U; ++interval) {
+                extent.x[interval].minimum = getU32(input + position); position += 4U;
+                extent.x[interval].maximum = getU32(input + position); position += 4U;
+            }
+        }
+        if (position != payload_end) return ManifestResult::BAD_LENGTH;
+        result = validate(candidate);
+    } else {
+        if (payload_end - position < 8U) return ManifestResult::BAD_LENGTH;
+        candidate.min_zoom = input[position++];
+        candidate.max_zoom = input[position++];
+        candidate.row_span_count = getU16(input + position); position += 2U;
+        candidate.tile_count = getU32(input + position); position += 4U;
+        if (candidate.row_span_count == 0U || candidate.row_span_count > MAX_ROW_SPANS ||
+            static_cast<std::size_t>(candidate.row_span_count) >
+                (payload_end - position) / ROW_SPAN_SIZE) {
+            return ManifestResult::INVALID_EXTENT;
+        }
+        candidate.row_span_bytes = input + position;
+        if (candidate.min_zoom > candidate.max_zoom || candidate.max_zoom > MAX_ZOOM) {
+            return ManifestResult::INVALID_ZOOM;
+        }
+        std::uint32_t zoom_mask = 0U;
+        std::uint64_t total = 0U;
+        RowSpan previous = {};
+        for (std::size_t index = 0U; index < candidate.row_span_count; ++index) {
+            const RowSpan span = readRowSpan(input + position);
+            const std::uint32_t world_maximum = span.zoom <= MAX_ZOOM
+                ? (UINT32_C(1) << span.zoom) - 1U : 0U;
+            if (span.zoom < candidate.min_zoom || span.zoom > candidate.max_zoom ||
+                span.y > world_maximum || span.x_minimum > span.x_maximum ||
+                span.x_maximum > world_maximum ||
+                (index != 0U &&
+                 (span.zoom < previous.zoom ||
+                  (span.zoom == previous.zoom && span.y < previous.y) ||
+                  (span.zoom == previous.zoom && span.y == previous.y &&
+                   span.x_minimum <= previous.x_maximum + 1U)))) {
+                return ManifestResult::INVALID_EXTENT;
+            }
+            const std::uint64_t count = static_cast<std::uint64_t>(span.x_maximum) -
+                                        span.x_minimum + 1U;
+            if (total > std::numeric_limits<std::uint32_t>::max() - count) {
+                return ManifestResult::INVALID_TILE_COUNT;
+            }
+            total += count;
+            zoom_mask |= UINT32_C(1) << span.zoom;
+            previous = span;
+            position += ROW_SPAN_SIZE;
+        }
+        if (position != payload_end) return ManifestResult::BAD_LENGTH;
+        std::uint32_t expected_mask = 0U;
+        for (std::uint8_t zoom = candidate.min_zoom; zoom <= candidate.max_zoom; ++zoom) {
+            expected_mask |= UINT32_C(1) << zoom;
+        }
+        result = zoom_mask != expected_mask ? ManifestResult::INVALID_ZOOM :
+            (candidate.tile_count == 0U || total != candidate.tile_count
+                ? ManifestResult::INVALID_TILE_COUNT : ManifestResult::OK);
     }
-    if (position != payload_end) return ManifestResult::BAD_LENGTH;
-    result = validate(candidate);
     if (result != ManifestResult::OK) return result;
     output = candidate;
     return ManifestResult::OK;
@@ -269,6 +444,16 @@ bool MapPackManifest::covers(const Hardware::TDeck::TileKey& key) const {
     const std::uint32_t world_size = UINT32_C(1) << key.zoom;
     if (key.x >= world_size || key.y >= world_size ||
         key.zoom < min_zoom || key.zoom > max_zoom) return false;
+    if (format_version == FORMAT_VERSION) {
+        if (row_span_bytes == 0 || row_span_count == 0U || row_span_count > MAX_ROW_SPANS) return false;
+        for (std::size_t index = 0U; index < row_span_count; ++index) {
+            const RowSpan span = readRowSpan(row_span_bytes + index * ROW_SPAN_SIZE);
+            if (span.zoom > key.zoom || (span.zoom == key.zoom && span.y > key.y)) return false;
+            if (span.zoom == key.zoom && span.y == key.y &&
+                key.x >= span.x_minimum && key.x <= span.x_maximum) return true;
+        }
+        return false;
+    }
     const std::size_t index = static_cast<std::size_t>(key.zoom - min_zoom);
     if (index >= extent_count) return false;
     const ZoomExtent& extent = extents[index];

--- a/lib/tdeck_ui/UI/LXMF/MapPackManifest.h
+++ b/lib/tdeck_ui/UI/LXMF/MapPackManifest.h
@@ -38,6 +38,13 @@ struct ZoomExtent {
     std::uint32_t y_maximum;
 };
 
+struct RowSpan {
+    std::uint8_t zoom;
+    std::uint32_t y;
+    std::uint32_t x_minimum;
+    std::uint32_t x_maximum;
+};
+
 /**
  * Portable, allocation-free description of one complete rectangular extent at
  * every declared XYZ zoom. Two canonical X intervals describe a rectangle that
@@ -49,7 +56,8 @@ struct ZoomExtent {
  * padding or native enum representations.
  */
 struct MapPackManifest {
-    static const std::uint8_t FORMAT_VERSION = 1U;
+    static const std::uint8_t LEGACY_FORMAT_VERSION = 1U;
+    static const std::uint8_t FORMAT_VERSION = 2U;
     static const std::uint8_t MAX_ZOOM = 22U;
     static const std::size_t MAX_ZOOM_LEVELS = 23U;
     static const std::size_t PACK_ID_CAPACITY = 32U;
@@ -57,7 +65,8 @@ struct MapPackManifest {
     static const std::size_t ATTRIBUTION_CAPACITY = 128U;
     static const std::size_t SOURCE_CAPACITY = 128U;
     static const std::size_t LICENSE_CAPACITY = 64U;
-    static const std::size_t MAX_SERIALIZED_SIZE = 1041U;
+    static const std::size_t MAX_ROW_SPANS = 512U;
+    static const std::size_t MAX_SERIALIZED_SIZE = 7100U;
 
     char pack_id[PACK_ID_CAPACITY];
     char name[NAME_CAPACITY];
@@ -69,11 +78,22 @@ struct MapPackManifest {
     std::uint8_t extent_count;
     std::uint32_t tile_count;
     ZoomExtent extents[MAX_ZOOM_LEVELS];
+    std::uint8_t format_version;
+    std::uint16_t row_span_count;
+    // Version-two manifests keep a validated view into the parse input. The
+    // input buffer must outlive this object (MapTilePack owns that buffer).
+    const std::uint8_t* row_span_bytes;
 
     static ManifestResult serialize(const MapPackManifest& manifest,
                                     std::uint8_t* output,
                                     std::size_t capacity,
                                     std::size_t& written);
+    static ManifestResult serializeSparse(const MapPackManifest& manifest,
+                                          const RowSpan* spans,
+                                          std::size_t span_count,
+                                          std::uint8_t* output,
+                                          std::size_t capacity,
+                                          std::size_t& written);
     static ManifestResult parse(const std::uint8_t* input,
                                 std::size_t length,
                                 MapPackManifest& output);

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -385,6 +385,7 @@ void MapScreen::workerLoop() {
             pack_refresh_epoch_.load(std::memory_order_acquire);
         if (pack_refresh_epoch != handled_pack_refresh_epoch) {
             const bool had_selection = pack_.hasSelection();
+            const std::uint32_t previous_generation = pack_.selectionGeneration();
             char previous_pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
             if (had_selection) {
                 std::memcpy(previous_pack_id, pack_.metadata().pack_id,
@@ -394,7 +395,8 @@ void MapScreen::workerLoop() {
             const bool has_selection = pack_.hasSelection();
             if (had_selection != has_selection ||
                 (had_selection && has_selection &&
-                 std::strcmp(previous_pack_id, pack_.metadata().pack_id) != 0)) {
+                 (std::strcmp(previous_pack_id, pack_.metadata().pack_id) != 0 ||
+                  previous_generation != pack_.selectionGeneration()))) {
                 decoded_tile_cache_.clear();
             }
             publishPackAttribution();

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -1,0 +1,42 @@
+"""Contracts for local-only MUI ZIP installation onto a selected SD card."""
+
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FLASHER = ROOT / "docs/flasher/index.html"
+INSTALLER = ROOT / "docs/flasher/js/map-installer.js"
+NODE_TEST = ROOT / "tests/web/test_map_installer.mjs"
+
+
+def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
+    source = FLASHER.read_text(encoding="utf-8")
+    assert 'id="map-archive"' in source
+    assert 'accept=".zip,application/zip"' in source
+    assert 'id="map-pack-name"' in source
+    assert 'id="map-install-btn"' in source
+    assert 'Install and Enable' in source
+    assert "mapSetId: 'osm-bright'" in source
+    assert 'newest pack takes priority' in source
+    assert "showDirectoryPicker" in source
+    assert "./js/map-installer.js" in source
+    assert "Coalition MUI OSM Bright user download" in source
+    assert "Map data (c) OpenStreetMap contributors" in source
+
+
+def test_map_installer_has_no_tile_network_fetch_path() -> None:
+    source = INSTALLER.read_text(encoding="utf-8").lower()
+    for forbidden in ("fetch(", "xmlhttprequest", "websocket", "http://", "https://"):
+        assert forbidden not in source
+
+
+def test_map_installer_javascript_behavior() -> None:
+    result = subprocess.run(
+        ["node", "--test", str(NODE_TEST)],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -20,6 +20,8 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert "mapSetId: 'osm-bright'" in source
     assert 'newest pack takes priority' in source
     assert "showDirectoryPicker" in source
+    assert "navigator.locks?.request" in source
+    assert "cross-tab locking required for safe map installation" in source
     assert "./js/map-installer.js" in source
     assert "Coalition MUI OSM Bright user download" in source
     assert "Map data (c) OpenStreetMap contributors" in source

--- a/tests/native/test_map_pack_manifest.cpp
+++ b/tests/native/test_map_pack_manifest.cpp
@@ -10,6 +10,7 @@
 using Hardware::TDeck::TileKey;
 using Pyxis::MapPackManifest;
 using Pyxis::ManifestResult;
+using Pyxis::RowSpan;
 using Pyxis::ZoomExtent;
 
 namespace {
@@ -135,7 +136,7 @@ void testMagicVersionHeaderAndLengthRejected() {
         std::vector<std::uint8_t> bad = valid; bad[index] ^= 1U;
         CHECK(MapPackManifest::parse(&bad[0], bad.size(), output) == ManifestResult::BAD_MAGIC);
     }
-    std::vector<std::uint8_t> bad = valid; bad[4] = 2U; refreshCrc(bad);
+    std::vector<std::uint8_t> bad = valid; bad[4] = 3U; refreshCrc(bad);
     CHECK(MapPackManifest::parse(&bad[0], bad.size(), output) == ManifestResult::UNSUPPORTED_VERSION);
     bad = valid; bad[6] = 15U; refreshCrc(bad);
     CHECK(MapPackManifest::parse(&bad[0], bad.size(), output) == ManifestResult::BAD_HEADER);
@@ -296,10 +297,71 @@ void testMaximumSerializedSizeRoundTrip() {
         extent.y_maximum = 0U;
     }
     const std::vector<std::uint8_t> bytes = encode(manifest);
-    CHECK(bytes.size() == MapPackManifest::MAX_SERIALIZED_SIZE);
+    CHECK(bytes.size() <= MapPackManifest::MAX_SERIALIZED_SIZE);
     MapPackManifest parsed = {};
     CHECK(MapPackManifest::parse(&bytes[0], bytes.size(), parsed) == ManifestResult::OK);
     CHECK(parsed.tile_count == MapPackManifest::MAX_ZOOM_LEVELS);
+
+    RowSpan spans[MapPackManifest::MAX_ROW_SPANS];
+    manifest.min_zoom = 22U; manifest.max_zoom = 22U; manifest.extent_count = 0U;
+    manifest.tile_count = static_cast<std::uint32_t>(MapPackManifest::MAX_ROW_SPANS);
+    for (std::size_t index = 0U; index < MapPackManifest::MAX_ROW_SPANS; ++index) {
+        spans[index].zoom = 22U;
+        spans[index].y = static_cast<std::uint32_t>(index);
+        spans[index].x_minimum = 0U;
+        spans[index].x_maximum = 0U;
+    }
+    std::uint8_t sparse[MapPackManifest::MAX_SERIALIZED_SIZE];
+    std::size_t sparse_size = 0U;
+    CHECK(MapPackManifest::serializeSparse(manifest, spans, MapPackManifest::MAX_ROW_SPANS,
+                                           sparse, sizeof(sparse), sparse_size) == ManifestResult::OK);
+    CHECK(sparse_size == MapPackManifest::MAX_SERIALIZED_SIZE);
+    CHECK(MapPackManifest::parse(sparse, sparse_size, parsed) == ManifestResult::OK);
+    CHECK(parsed.row_span_count == MapPackManifest::MAX_ROW_SPANS);
+}
+
+void testSparseRowSpanRoundTripAndExactCoverage() {
+    beginTest();
+    MapPackManifest manifest = sample();
+    manifest.min_zoom = 7U;
+    manifest.max_zoom = 7U;
+    manifest.extent_count = 0U;
+    manifest.tile_count = 5U;
+    const RowSpan spans[] = {
+        {7U, 48U, 35U, 36U},
+        {7U, 49U, 34U, 36U},
+    };
+    std::uint8_t storage[MapPackManifest::MAX_SERIALIZED_SIZE] = {};
+    std::size_t written = 0U;
+    CHECK(MapPackManifest::serializeSparse(manifest, spans, 2U, storage,
+                                           sizeof(storage), written) == ManifestResult::OK);
+    MapPackManifest parsed = {};
+    CHECK(MapPackManifest::parse(storage, written, parsed) == ManifestResult::OK);
+    CHECK(parsed.format_version == 2U);
+    CHECK(parsed.row_span_count == 2U);
+    CHECK(parsed.tile_count == 5U);
+    CHECK(parsed.covers(TileKey{7U, 35U, 48U}));
+    CHECK(parsed.covers(TileKey{7U, 34U, 49U}));
+    CHECK(parsed.covers(TileKey{7U, 36U, 49U}));
+    CHECK(!parsed.covers(TileKey{7U, 34U, 48U}));
+    CHECK(!parsed.covers(TileKey{7U, 37U, 49U}));
+}
+
+void testSparseRowSpansMustBeCanonicalAndBounded() {
+    beginTest();
+    MapPackManifest manifest = sample();
+    manifest.min_zoom = 7U;
+    manifest.max_zoom = 7U;
+    manifest.extent_count = 0U;
+    manifest.tile_count = 2U;
+    std::uint8_t storage[MapPackManifest::MAX_SERIALIZED_SIZE] = {};
+    std::size_t written = 0U;
+    const RowSpan adjacent[] = {{7U, 48U, 35U, 35U}, {7U, 48U, 36U, 36U}};
+    CHECK(MapPackManifest::serializeSparse(manifest, adjacent, 2U, storage,
+                                           sizeof(storage), written) == ManifestResult::INVALID_EXTENT);
+    const RowSpan reversed[] = {{7U, 49U, 35U, 35U}, {7U, 48U, 35U, 35U}};
+    CHECK(MapPackManifest::serializeSparse(manifest, reversed, 2U, storage,
+                                           sizeof(storage), written) == ManifestResult::INVALID_EXTENT);
 }
 }  // namespace
 
@@ -317,6 +379,8 @@ int main() {
     testMalformedPayloadWithValidCrcRejected();
     testDeterministicStressRoundTrips();
     testMaximumSerializedSizeRoundTrip();
+    testSparseRowSpanRoundTripAndExactCoverage();
+    testSparseRowSpansMustBeCanonicalAndBounded();
     std::cout << "map pack manifest: " << tests_run << " tests passed\n";
     return 0;
 }

--- a/tests/native/test_map_pack_manifest.py
+++ b/tests/native/test_map_pack_manifest.py
@@ -31,4 +31,4 @@ def test_map_pack_manifest(tmp_path: Path, sanitize: bool) -> None:
         env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60, env=env)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert ran.stdout == "map pack manifest: 13 tests passed\n"
+    assert ran.stdout == "map pack manifest: 15 tests passed\n"

--- a/tests/native/test_map_tile_pack.cpp
+++ b/tests/native/test_map_tile_pack.cpp
@@ -14,6 +14,7 @@ using Hardware::TDeck::MapTileStorage;
 using Hardware::TDeck::TileKey;
 using Hardware::TDeck::TileStoreResult;
 using Pyxis::MapPackManifest;
+using Pyxis::RowSpan;
 
 namespace {
 std::size_t allocations = 0U;
@@ -44,7 +45,7 @@ void operator delete[](void* memory) noexcept { std::free(memory); }
 namespace {
 struct File {
     char path[MapTilePack::PATH_CAPACITY];
-    std::uint8_t bytes[MapPackManifest::MAX_SERIALIZED_SIZE];
+    std::uint8_t bytes[MapTilePack::ACTIVE_SELECTION_SIZE];
     std::size_t size;
     std::uint32_t declared_size;
 };
@@ -146,6 +147,91 @@ void addSelection(FakeStorage& storage, const char* marker_id, const MapPackMani
     char path[MapTilePack::PATH_CAPACITY];
     CHECK(MapTilePack::manifestPath(marker_id, path, sizeof(path)) == MapTilePackResult::OK);
     storage.add(path, bytes, written);
+}
+
+std::uint32_t testCrc32(const std::uint8_t* input, std::size_t length) {
+    std::uint32_t crc = UINT32_C(0xffffffff);
+    for (std::size_t index = 0U; index < length; ++index) {
+        crc ^= input[index];
+        for (std::uint8_t bit = 0U; bit < 8U; ++bit) {
+            crc = (crc >> 1U) ^ ((crc & 1U) != 0U ? UINT32_C(0xedb88320) : 0U);
+        }
+    }
+    return ~crc;
+}
+
+void testPutU32(std::uint8_t* output, std::uint32_t value) {
+    output[0] = static_cast<std::uint8_t>(value);
+    output[1] = static_cast<std::uint8_t>(value >> 8U);
+    output[2] = static_cast<std::uint8_t>(value >> 16U);
+    output[3] = static_cast<std::uint8_t>(value >> 24U);
+}
+
+void testPutU16(std::uint8_t* output, std::uint16_t value) {
+    output[0] = static_cast<std::uint8_t>(value);
+    output[1] = static_cast<std::uint8_t>(value >> 8U);
+}
+
+std::uint8_t hexValue(char value) {
+    if (value >= '0' && value <= '9') return static_cast<std::uint8_t>(value - '0');
+    return static_cast<std::uint8_t>(10 + value - 'a');
+}
+
+void addManifest(FakeStorage& storage, const char* id) {
+    std::uint8_t bytes[MapPackManifest::MAX_SERIALIZED_SIZE];
+    std::size_t written = 0U;
+    CHECK(MapPackManifest::serialize(manifestFor(id), bytes, sizeof(bytes), written) == Pyxis::ManifestResult::OK);
+    char path[MapTilePack::PATH_CAPACITY];
+    CHECK(MapTilePack::manifestPath(id, path, sizeof(path)) == MapTilePackResult::OK);
+    storage.add(path, bytes, written);
+}
+
+void addSlot(FakeStorage& storage, const char* path, const char* id, std::uint32_t generation,
+             bool corrupt = false) {
+    std::uint8_t record[MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE] = {};
+    record[0] = 'P'; record[1] = 'M'; record[2] = 'A'; record[3] = 'S'; record[4] = 1U;
+    record[6] = static_cast<std::uint8_t>(MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE);
+    testPutU32(record + 8U, generation);
+    const std::size_t length = std::strlen(id); CHECK(length > 0U && length < 32U);
+    record[12] = static_cast<std::uint8_t>(length); std::memcpy(record + 13U, id, length);
+    testPutU32(record + 44U, testCrc32(record, 44U));
+    if (corrupt) record[47] ^= 1U;
+    storage.add(path, record, sizeof(record));
+}
+
+void addMapSetSlot(FakeStorage& storage, const char* path, std::uint32_t generation) {
+    std::uint8_t record[256] = {};
+    record[0] = 'P'; record[1] = 'M'; record[2] = 'A'; record[3] = 'S'; record[4] = 2U;
+    testPutU32(record + 8U, generation);
+    std::size_t position = 12U;
+    const char* map_set = "osm-bright";
+    const char* attribution = "Map data attribution";
+    record[position++] = static_cast<std::uint8_t>(std::strlen(map_set));
+    std::memcpy(record + position, map_set, std::strlen(map_set)); position += std::strlen(map_set);
+    record[position++] = static_cast<std::uint8_t>(std::strlen(attribution));
+    std::memcpy(record + position, attribution, std::strlen(attribution)); position += std::strlen(attribution);
+    record[position++] = 2U;
+    const char* ids[2] = {"detail", "state"};
+    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {4U, 5U, 5U, 5U}};
+    const RowSpan state[] = {{2U, 1U, 1U, 2U}};
+    const RowSpan* spans[2] = {detail, state};
+    const std::uint16_t counts[2] = {2U, 1U};
+    for (std::size_t pack = 0U; pack < 2U; ++pack) {
+        const std::size_t id_length = std::strlen(ids[pack]);
+        record[position++] = static_cast<std::uint8_t>(id_length);
+        std::memcpy(record + position, ids[pack], id_length); position += id_length;
+        testPutU16(record + position, counts[pack]); position += 2U;
+        for (std::uint16_t index = 0U; index < counts[pack]; ++index) {
+            record[position++] = spans[pack][index].zoom;
+            testPutU32(record + position, spans[pack][index].y); position += 4U;
+            testPutU32(record + position, spans[pack][index].x_minimum); position += 4U;
+            testPutU32(record + position, spans[pack][index].x_maximum); position += 4U;
+        }
+    }
+    const std::size_t total_length = position + 4U;
+    testPutU16(record + 6U, static_cast<std::uint16_t>(total_length));
+    testPutU32(record + position, testCrc32(record, position));
+    storage.add(path, record, total_length);
 }
 
 void testNoSelection() {
@@ -300,6 +386,67 @@ void testTileDeclaredLengthCapsWritesAndProbesEof() {
     count = 99U; CHECK(empty_pack.readGetChunk(output, sizeof(output), count) == MapTilePackResult::OK);
     CHECK(count == 0U); CHECK(empty_storage.open_file == NULL);
 }
+void testActiveSelectionSlotsPreferNewestValidAndRejectConflict() {
+    beginTest();
+    FakeStorage storage;
+    addSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, "one", 1U);
+    addSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, "two", 2U);
+    addManifest(storage, "one"); addManifest(storage, "two");
+    MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
+    CHECK(std::strcmp(pack.metadata().pack_id, "two") == 0);
+    CHECK(pack.selectionGeneration() == 2U);
+
+    FakeStorage fallback;
+    addSlot(fallback, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, "one", 1U);
+    addSlot(fallback, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, "two", 2U, true);
+    addManifest(fallback, "one");
+    MapTilePack fallback_pack(fallback); CHECK(fallback_pack.initialize() == MapTilePackResult::OK);
+    CHECK(std::strcmp(fallback_pack.metadata().pack_id, "one") == 0);
+
+    FakeStorage conflict;
+    addSlot(conflict, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, "one", 7U);
+    addSlot(conflict, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, "two", 7U);
+    MapTilePack conflict_pack(conflict);
+    CHECK(conflict_pack.initialize() == MapTilePackResult::INVALID_PACK_ID);
+}
+void testActiveMapSetComposesPacksByPriorityAndCoverage() {
+    beginTest();
+    FakeStorage storage;
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    const char* golden = "504d415302006900010000000a6f736d2d627269676874144d61702064617461206174747269627574696f6e020664657461696c020002010000000100000001000000040500000005000000050000000573746174650100020100000001000000020000009de230d6";
+    File* selection = storage.find(MapTilePack::ACTIVE_PACK_SLOT_0_PATH); CHECK(selection != NULL);
+    CHECK(selection->size * 2U == std::strlen(golden));
+    for (std::size_t index = 0U; index < selection->size; ++index) {
+        CHECK(selection->bytes[index] == static_cast<std::uint8_t>((hexValue(golden[index * 2U]) << 4U) | hexValue(golden[index * 2U + 1U])));
+    }
+    const std::uint8_t detail = 1U, state_overlap = 2U, state_wide = 3U, detail_high = 4U;
+    storage.add("/pyxis-map/packs/detail/tiles/2/1/1.png", &detail, 1U);
+    storage.add("/pyxis-map/packs/detail/tiles/4/5/5.png", &detail_high, 1U);
+    storage.add("/pyxis-map/packs/state/tiles/2/1/1.png", &state_overlap, 1U);
+    storage.add("/pyxis-map/packs/state/tiles/2/2/1.png", &state_wide, 1U);
+    MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
+    CHECK(std::strcmp(pack.metadata().pack_id, "osm-bright") == 0);
+    CHECK(pack.selectionGeneration() == 1U);
+    CHECK(std::strcmp(pack.metadata().attribution, "Map data attribution") == 0);
+    const TileKey keys[] = {{2U,1U,1U},{2U,2U,1U},{4U,5U,5U}};
+    const std::uint8_t expected[] = {detail,state_wide,detail_high};
+    for (std::size_t index = 0U; index < 3U; ++index) {
+        std::uint32_t size = 0U; CHECK(pack.beginGet(keys[index], size) == MapTilePackResult::OK); CHECK(size == 1U);
+        std::uint8_t output = 0U; std::size_t count = 0U;
+        CHECK(pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK); CHECK(count == 1U); CHECK(output == expected[index]);
+    }
+    std::uint32_t size = 0U;
+    CHECK(pack.beginGet(TileKey{3U,1U,1U}, size) == MapTilePackResult::UNCOVERED);
+
+    FakeStorage fallback;
+    addMapSetSlot(fallback, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    fallback.add("/pyxis-map/packs/state/tiles/2/1/1.png", &state_overlap, 1U);
+    MapTilePack fallback_pack(fallback); CHECK(fallback_pack.initialize() == MapTilePackResult::OK);
+    CHECK(fallback_pack.beginGet(TileKey{2U,1U,1U}, size) == MapTilePackResult::OK);
+    std::uint8_t output = 0U; std::size_t count = 0U;
+    CHECK(fallback_pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK);
+    CHECK(output == state_overlap);
+}
 void testCoreDoesNotAllocate() {
     beginTest(); FakeStorage storage; addSelection(storage, "one", manifestFor("one")); const std::uint8_t tile[] = {7U};
     storage.add("/pyxis-map/packs/one/tiles/2/1/1.png", tile, sizeof(tile)); const std::size_t before = allocations;
@@ -315,7 +462,9 @@ int main() {
     testStorageUnavailable(); testChunkReadAndAutomaticEnd(); testReadErrorClosesAndArgumentsAreBounded();
     testPrematureEndCloses(); testReinitializeSelectionChange(); testFailedReinitializeIsTransactional();
     testReinitializeAndDestructorCloseStreams(); testDeclaredLengthsAndEmbeddedNulFailClosed();
-    testTileDeclaredLengthCapsWritesAndProbesEof(); testCoreDoesNotAllocate();
+    testTileDeclaredLengthCapsWritesAndProbesEof(); testActiveSelectionSlotsPreferNewestValidAndRejectConflict();
+    testActiveMapSetComposesPacksByPriorityAndCoverage();
+    testCoreDoesNotAllocate();
     std::cout << "map tile pack: " << tests_run << " tests passed\n";
     return 0;
 }

--- a/tests/native/test_map_tile_pack.py
+++ b/tests/native/test_map_tile_pack.py
@@ -32,4 +32,4 @@ def test_map_tile_pack(tmp_path: Path, sanitize: bool) -> None:
         env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60, env=env)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert ran.stdout == "map tile pack: 18 tests passed\n"
+    assert ran.stdout == "map tile pack: 20 tests passed\n"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -138,24 +138,35 @@ def test_manifest_matches_committed_153_byte_cpp_fixture() -> None:
     assert actual == fixture
 
 
-def test_incomplete_rectangle_is_rejected(tmp_path: Path) -> None:
+def test_sparse_xyz_tree_builds_version_two_exact_row_spans(tmp_path: Path) -> None:
     tool = load_tool()
     source = tmp_path / "xyz"
     for x, y in ((1, 1), (1, 2), (2, 1)):
         put_tile(source, 2, x, y)
-    with pytest.raises(tool.PackError, match="incomplete rectangle"):
-        tool.build_map_pack(source, tmp_path / "sd", **metadata())
+    built = tool.build_map_pack(source, tmp_path / "sd", sparse=True, **metadata())
+    parsed = tool.validate_pack(built)
+    assert parsed["format_version"] == 2
+    assert parsed["tile_count"] == 3
+    assert parsed["row_spans"] == [
+        tool.RowSpan(2, 1, 1, 2),
+        tool.RowSpan(2, 2, 1, 1),
+    ]
 
 
-def test_antimeridian_split_requires_explicit_zoom(tmp_path: Path) -> None:
+def test_disjoint_rows_require_explicit_sparse_or_antimeridian_mode(tmp_path: Path) -> None:
     tool = load_tool()
     source = tmp_path / "xyz"
     for x in (0, 1, 6, 7):
         for y in (3, 4):
             put_tile(source, 3, x, y)
     with pytest.raises(tool.PackError, match="incomplete rectangle"):
-        tool.build_map_pack(source, tmp_path / "sd-a", **metadata())
+        tool.build_map_pack(source, tmp_path / "default", **metadata())
+    sparse = tool.build_map_pack(source, tmp_path / "sd-a", sparse=True, **metadata())
+    sparse_manifest = tool.validate_pack(sparse)
+    assert sparse_manifest["format_version"] == 2
+    assert len(sparse_manifest["row_spans"]) == 4
     built = tool.build_map_pack(source, tmp_path / "sd-b", antimeridian_zooms={3}, **metadata())
+    assert tool.validate_pack(built)["format_version"] == 1
     assert tool.validate_pack(built)["extents"][0].intervals == ((0, 1), (6, 7))
 
 

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -239,7 +239,7 @@ test('rejects traversal, duplicate keys, unsupported compression, and malformed 
   await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', trailingDeflate]])), /trailing|zlib|deflate/i);
 });
 
-test('removes only its receipt-owned unpublished pack after an interrupted write', async () => {
+test('removes only its receipt-owned contents after an interrupted write', async () => {
   const archive = storedZip([
     ['2/1/1.png', PNG],
     ['2/1/2.png', PNG],
@@ -252,7 +252,16 @@ test('removes only its receipt-owned unpublished pack after an interrupted write
     onProgress(progress) { if (progress.phase === 'write') throw new Error('cancelled'); },
   }), /cancelled/);
   const packs = root.children.get('pyxis-map').children.get('packs');
-  assert.equal(packs.children.has('interrupted'), false);
+  const interrupted = packs.children.get('interrupted');
+  assert.ok(interrupted);
+  assert.deepEqual([...interrupted.children.keys()], []);
+  const retried = await installMuiZip({
+    archive,
+    rootDirectory:root,
+    metadata:{...metadata, packId:'interrupted', name:'Interrupted'},
+  });
+  assert.equal(retried.resumed, false);
+  assert.ok(interrupted.children.has('manifest.pmp'));
 });
 
 test('cleanup preserves an unrelated file that appears in the destination', async () => {
@@ -311,6 +320,37 @@ test('concurrent installs on one selected root are serialized', async () => {
   const newest = slots.sort((left, right) => right.generation - left.generation)[0];
   assert.equal(newest.generation, 2);
   assert.deepEqual(new Set(newest.packs.map(pack => pack.packId)), new Set(['first-pack', 'second-pack']));
+});
+
+test('an empty directory created during destination creation is never removed', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create:true});
+  class EmptyRaceDirectory extends MemoryDirectoryHandle {
+    async getDirectoryHandle(name, options = {}) {
+      if (name === metadata.packId && options.create && !this.raced) {
+        this.raced = true;
+        const injected = new MemoryDirectoryHandle(name, this.log);
+        this.children.set(name, injected);
+        return injected;
+      }
+      return super.getDirectoryHandle(name, options);
+    }
+  }
+  const packs = new EmptyRaceDirectory('packs', root.log);
+  pyxis.children.set('packs', packs);
+  await assert.rejects(
+    installMuiZip({
+      archive,
+      rootDirectory:root,
+      metadata,
+      onProgress: progress => { if (progress.phase === 'write') throw new Error('forced interruption'); },
+    }),
+    /forced interruption/i,
+  );
+  const raced = packs.children.get(metadata.packId);
+  assert.ok(raced, 'concurrently created empty directory must remain');
+  assert.deepEqual([...raced.children.keys()], []);
 });
 
 test('destination-creation race preserves a pre-existing pack directory', async () => {

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -141,6 +141,32 @@ class MemoryDirectoryHandle {
   }
 }
 
+class DirectoryHandleAlias {
+  constructor(target) { this.target = target; this.name = target.name; this.kind = 'directory'; }
+  async getDirectoryHandle(...args) { return this.target.getDirectoryHandle(...args); }
+  async getFileHandle(...args) { return this.target.getFileHandle(...args); }
+  async *entries() { yield* this.target.entries(); }
+  async removeEntry(...args) { return this.target.removeEntry(...args); }
+  async isSameEntry(other) { return this.target === (other?.target || other); }
+}
+
+class MemoryLockManager {
+  constructor() { this.tails = new Map(); }
+  async request(name, _options, operation) {
+    const previous = this.tails.get(name) || Promise.resolve();
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    const tail = previous.then(() => gate);
+    this.tails.set(name, tail);
+    await previous;
+    try { return await operation(); }
+    finally {
+      release();
+      if (this.tails.get(name) === tail) this.tails.delete(name);
+    }
+  }
+}
+
 async function child(root, path) {
   let current = root;
   for (const part of path.split('/')) current = current.children.get(part);
@@ -320,6 +346,35 @@ test('concurrent installs on one selected root are serialized', async () => {
   const newest = slots.sort((left, right) => right.generation - left.generation)[0];
   assert.equal(newest.generation, 2);
   assert.deepEqual(new Set(newest.packs.map(pack => pack.packId)), new Set(['first-pack', 'second-pack']));
+});
+
+test('distinct handles for one selected root are serialized across tabs', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle('sd-card');
+  const firstHandle = new DirectoryHandleAlias(root);
+  const secondHandle = new DirectoryHandleAlias(root);
+  const previousNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable:true,
+    value:{locks:new MemoryLockManager()},
+  });
+  try {
+    await Promise.all([
+      installMuiZip({archive, rootDirectory:firstHandle, metadata:{...metadata, packId:'tab-one', name:'Tab One'}}),
+      installMuiZip({archive, rootDirectory:secondHandle, metadata:{...metadata, packId:'tab-two', name:'Tab Two'}}),
+    ]);
+  } finally {
+    if (previousNavigator) Object.defineProperty(globalThis, 'navigator', previousNavigator);
+    else delete globalThis.navigator;
+  }
+  const pyxis = root.children.get('pyxis-map');
+  const slots = ['active-pack.0', 'active-pack.1']
+    .map(name => pyxis.children.get(name))
+    .filter(Boolean)
+    .map(handle => decodeActiveSelection(handle.bytes));
+  const newest = slots.sort((left, right) => right.generation - left.generation)[0];
+  assert.equal(newest.generation, 2);
+  assert.deepEqual(new Set(newest.packs.map(pack => pack.packId)), new Set(['tab-one', 'tab-two']));
 });
 
 test('an empty directory created during destination creation is never removed', async () => {

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -1,0 +1,356 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  decodeActiveSelection,
+  encodeActiveMapSet,
+  inspectMuiZip,
+  installMuiZip,
+  parseSparseManifest,
+} from '../../docs/flasher/js/map-installer.js';
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAA1UlEQVR4nO3BMQEAAADCoPVP7WULoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAGwEtAAHMpTgHAAAAAElFTkSuQmCC',
+  'base64',
+);
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+  }
+  return (~crc) >>> 0;
+}
+
+function pngWithChunkBeforeIdat(png, type, payload) {
+  let position = 8;
+  while (png.toString('ascii', position + 4, position + 8) !== 'IDAT') {
+    position += 12 + png.readUInt32BE(position);
+  }
+  const name = Buffer.from(type, 'ascii');
+  const data = Buffer.from(payload);
+  const chunk = Buffer.alloc(12 + data.length);
+  chunk.writeUInt32BE(data.length, 0); name.copy(chunk, 4); data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(Buffer.concat([name, data])), 8 + data.length);
+  return Buffer.concat([png.subarray(0, position), chunk, png.subarray(position)]);
+}
+
+function rewriteFirstIdat(png, transform) {
+  let position = 8;
+  while (png.toString('ascii', position + 4, position + 8) !== 'IDAT') position += 12 + png.readUInt32BE(position);
+  const oldLength = png.readUInt32BE(position);
+  const payload = Buffer.from(transform(png.subarray(position + 8, position + 8 + oldLength)));
+  const type = Buffer.from('IDAT');
+  const chunk = Buffer.alloc(12 + payload.length);
+  chunk.writeUInt32BE(payload.length, 0); type.copy(chunk, 4); payload.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(Buffer.concat([type, payload])), 8 + payload.length);
+  return Buffer.concat([png.subarray(0, position), chunk, png.subarray(position + 12 + oldLength)]);
+}
+
+function storedZip(entries) {
+  const local = [];
+  const central = [];
+  let offset = 0;
+  for (const [name, payload] of entries) {
+    const filename = Buffer.from(name, 'utf8');
+    const data = Buffer.from(payload);
+    const checksum = crc32(data);
+    const header = Buffer.alloc(30);
+    header.writeUInt32LE(0x04034b50, 0);
+    header.writeUInt16LE(20, 4);
+    header.writeUInt16LE(0, 6);
+    header.writeUInt16LE(0, 8);
+    header.writeUInt32LE(checksum, 14);
+    header.writeUInt32LE(data.length, 18);
+    header.writeUInt32LE(data.length, 22);
+    header.writeUInt16LE(filename.length, 26);
+    local.push(header, filename, data);
+
+    const record = Buffer.alloc(46);
+    record.writeUInt32LE(0x02014b50, 0);
+    record.writeUInt16LE(20, 4);
+    record.writeUInt16LE(20, 6);
+    record.writeUInt16LE(0, 8);
+    record.writeUInt16LE(0, 10);
+    record.writeUInt32LE(checksum, 16);
+    record.writeUInt32LE(data.length, 20);
+    record.writeUInt32LE(data.length, 24);
+    record.writeUInt16LE(filename.length, 28);
+    record.writeUInt32LE(offset, 42);
+    central.push(record, filename);
+    offset += header.length + filename.length + data.length;
+  }
+  const centralBytes = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralBytes.length, 12);
+  end.writeUInt32LE(offset, 16);
+  return new Blob([...local, centralBytes, end], {type: 'application/zip'});
+}
+
+class MemoryFileHandle {
+  constructor(name, log) { this.name = name; this.kind = 'file'; this.bytes = new Uint8Array(); this.log = log; }
+  async createWritable() {
+    const handle = this;
+    let pending = new Uint8Array();
+    return {
+      async write(value) { pending = new Uint8Array(value instanceof Blob ? await value.arrayBuffer() : value); },
+      async close() { handle.bytes = pending; handle.log.push(`write:${handle.name}`); },
+      async abort() {},
+    };
+  }
+  async getFile() { return new Blob([this.bytes]); }
+}
+
+class MemoryDirectoryHandle {
+  constructor(name = '', log = []) { this.name = name; this.kind = 'directory'; this.log = log; this.children = new Map(); }
+  async getDirectoryHandle(name, options = {}) {
+    const current = this.children.get(name);
+    if (current) {
+      if (current.kind !== 'directory') throw new DOMException('type', 'TypeMismatchError');
+      return current;
+    }
+    if (!options.create) throw new DOMException('missing', 'NotFoundError');
+    const child = new MemoryDirectoryHandle(name, this.log);
+    this.children.set(name, child);
+    return child;
+  }
+  async getFileHandle(name, options = {}) {
+    const current = this.children.get(name);
+    if (current) {
+      if (current.kind !== 'file') throw new DOMException('type', 'TypeMismatchError');
+      return current;
+    }
+    if (!options.create) throw new DOMException('missing', 'NotFoundError');
+    const child = new MemoryFileHandle(name, this.log);
+    this.children.set(name, child);
+    return child;
+  }
+  async *entries() { for (const entry of this.children.entries()) yield entry; }
+  async isSameEntry(other) { return this === other; }
+  async removeEntry(name, options = {}) {
+    const current = this.children.get(name);
+    if (!current) throw new DOMException('missing', 'NotFoundError');
+    if (current.kind === 'directory' && current.children.size && !options.recursive) throw new DOMException('not empty', 'InvalidModificationError');
+    this.children.delete(name);
+  }
+}
+
+async function child(root, path) {
+  let current = root;
+  for (const part of path.split('/')) current = current.children.get(part);
+  return current;
+}
+
+const metadata = {
+  packId: 'overview',
+  mapSetId: 'osm-bright',
+  name: 'Overview',
+  attribution: 'Map data (c) OpenStreetMap contributors',
+  source: 'Coalition MUI OSM Bright user download',
+  license: 'ODbL-1.0',
+};
+
+test('active map-set wire format matches the cross-language golden record', () => {
+  const record = encodeActiveMapSet({generation:1,mapSetId:'osm-bright',attribution:'Map data attribution',packs:[
+    {packId:'detail',rowSpans:[{zoom:2,y:1,xMinimum:1,xMaximum:1},{zoom:4,y:5,xMinimum:5,xMaximum:5}]},
+    {packId:'state',rowSpans:[{zoom:2,y:1,xMinimum:1,xMaximum:2}]},
+  ]});
+  assert.equal(Buffer.from(record).toString('hex'), '504d415302006900010000000a6f736d2d627269676874144d61702064617461206174747269627574696f6e020664657461696c020002010000000100000001000000040500000005000000050000000573746174650100020100000001000000020000009de230d6');
+  assert.deepEqual(decodeActiveSelection(record).packs.map(pack => pack.packId), ['detail','state']);
+});
+
+test('inspects and transactionally installs a sparse stored MUI XYZ ZIP', async () => {
+  const archive = storedZip([
+    ['2/1/1.png', PNG],
+    ['2/1/2.png', PNG],
+    ['2/2/1.png', PNG],
+  ]);
+  const report = await inspectMuiZip(archive);
+  assert.equal(report.tileCount, 3);
+  assert.equal(report.minZoom, 2);
+  assert.equal(report.maxZoom, 2);
+  assert.deepEqual(report.rowSpans, [
+    {zoom: 2, y: 1, xMinimum: 1, xMaximum: 2},
+    {zoom: 2, y: 2, xMinimum: 1, xMaximum: 1},
+  ]);
+
+  const root = new MemoryDirectoryHandle();
+  const result = await installMuiZip({archive, rootDirectory: root, metadata});
+  assert.equal(result.tileCount, 3);
+  const pack = await child(root, 'pyxis-map/packs/overview');
+  const manifest = pack.children.get('manifest.pmp').bytes;
+  assert.equal(Buffer.from(manifest.subarray(0, 4)).toString('ascii'), 'PMPK');
+  assert.equal(manifest[4], 2);
+  const parsed = parseSparseManifest(manifest);
+  assert.equal(parsed.tileCount, 3);
+  assert.equal(parsed.rowSpans.length, 2);
+  const selection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.0')).bytes);
+  assert.equal(selection.version, 2);
+  assert.equal(selection.mapSetId, 'osm-bright');
+  assert.deepEqual(selection.packs.map(pack => pack.packId), ['overview']);
+  assert.equal(selection.generation, 1);
+  const firstManifestWrite = root.log.indexOf('write:manifest.pmp');
+  assert(firstManifestWrite > root.log.lastIndexOf('write:1.png'));
+  assert(root.log.indexOf('write:active-pack.0') > firstManifestWrite);
+
+  const second = await installMuiZip({
+    archive, rootDirectory:root,
+    metadata:{...metadata, packId:'overview-two', name:'Overview Two'},
+  });
+  assert.equal(second.selectionFile, 'active-pack.1');
+  const secondSelection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.1')).bytes);
+  assert.equal(secondSelection.generation, 2);
+  assert.deepEqual(secondSelection.packs.map(pack => pack.packId), ['overview-two','overview']);
+  const third = await installMuiZip({
+    archive, rootDirectory:root,
+    metadata:{...metadata, packId:'overview-three', name:'Overview Three'},
+  });
+  assert.equal(third.selectionFile, 'active-pack.0');
+  const thirdSelection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.0')).bytes);
+  assert.equal(thirdSelection.generation, 3);
+  assert.deepEqual(thirdSelection.packs.map(pack => pack.packId), ['overview-three','overview-two','overview']);
+
+  const resumed = await installMuiZip({
+    archive, rootDirectory:root,
+    metadata:{...metadata, packId:'overview-two', name:'Overview Two'},
+  });
+  assert.equal(resumed.resumed, true);
+  const resumedSelection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.1')).bytes);
+  assert.equal(resumedSelection.generation, 4);
+  assert.deepEqual(resumedSelection.packs.map(pack => pack.packId), ['overview-two','overview-three','overview']);
+});
+
+test('rejects traversal, duplicate keys, unsupported compression, and malformed PNGs', async () => {
+  await assert.rejects(inspectMuiZip(storedZip([['../2/1/1.png', PNG]])), /path|traversal/i);
+  await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', PNG], ['2/1/1.png', PNG]])), /duplicate/i);
+  const malformed = Buffer.from(PNG); malformed[12] ^= 1;
+  await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', malformed]])), /PNG/i);
+  const invalidTransparency = pngWithChunkBeforeIdat(PNG, 'tRNS', [0]);
+  await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', invalidTransparency]])), /transparency/i);
+  const badAdler = rewriteFirstIdat(PNG, payload => {const changed=Buffer.from(payload);changed[changed.length-1]^=1;return changed;});
+  await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', badAdler]])), /checksum|zlib|deflate/i);
+  const trailingDeflate = rewriteFirstIdat(PNG, payload => Buffer.concat([payload.subarray(0,-4),Buffer.from([0]),payload.subarray(-4)]));
+  await assert.rejects(inspectMuiZip(storedZip([['2/1/1.png', trailingDeflate]])), /trailing|zlib|deflate/i);
+});
+
+test('removes only its receipt-owned unpublished pack after an interrupted write', async () => {
+  const archive = storedZip([
+    ['2/1/1.png', PNG],
+    ['2/1/2.png', PNG],
+  ]);
+  const root = new MemoryDirectoryHandle();
+  await assert.rejects(installMuiZip({
+    archive,
+    rootDirectory:root,
+    metadata:{...metadata, packId:'interrupted', name:'Interrupted'},
+    onProgress(progress) { if (progress.phase === 'write') throw new Error('cancelled'); },
+  }), /cancelled/);
+  const packs = root.children.get('pyxis-map').children.get('packs');
+  assert.equal(packs.children.has('interrupted'), false);
+});
+
+test('cleanup preserves an unrelated file that appears in the destination', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  await assert.rejects(installMuiZip({
+    archive,
+    rootDirectory:root,
+    metadata:{...metadata, packId:'raced', name:'Raced'},
+    onProgress(progress) {
+      if (progress.phase !== 'write') return;
+      const pack = root.children.get('pyxis-map').children.get('packs').children.get('raced');
+      const foreign = new MemoryFileHandle('foreign.txt', root.log);
+      foreign.bytes = new Uint8Array([9]); pack.children.set('foreign.txt', foreign);
+      throw new Error('interrupted');
+    },
+  }), /could not be safely removed/i);
+  const pack = await child(root, 'pyxis-map/packs/raced');
+  assert.deepEqual([...pack.children.get('foreign.txt').bytes], [9]);
+});
+
+test('receipt cleanup failure preserves a fully published pack', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  let injected = false;
+  await assert.rejects(installMuiZip({
+    archive, rootDirectory:root, metadata:{...metadata,packId:'published',name:'Published'},
+    onProgress(progress) {
+      if (injected || progress.phase !== 'write') return;
+      injected = true;
+      const pack = root.children.get('pyxis-map').children.get('packs').children.get('published');
+      const remove = pack.removeEntry.bind(pack);
+      pack.removeEntry = async (name, options) => {
+        if (name.startsWith('.pyxis-install-owner-')) { pack.removeEntry = remove; throw new Error('injected receipt failure'); }
+        return remove(name, options);
+      };
+    },
+  }), /installed and verified.*receipt/i);
+  const pack = await child(root, 'pyxis-map/packs/published');
+  assert.ok(pack.children.has('manifest.pmp'));
+  assert.deepEqual([...pack.children.get('tiles').children.get('2').children.get('1').children.get('1.png').bytes], [...PNG]);
+});
+
+test('concurrent installs on one selected root are serialized', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  await Promise.all([
+    installMuiZip({archive, rootDirectory:root, metadata:{...metadata, packId:'first-pack', name:'First Pack'}}),
+    installMuiZip({archive, rootDirectory:root, metadata:{...metadata, packId:'second-pack', name:'Second Pack'}}),
+  ]);
+  const pyxis = root.children.get('pyxis-map');
+  const slots = ['active-pack.0', 'active-pack.1']
+    .map(name => pyxis.children.get(name))
+    .filter(Boolean)
+    .map(handle => decodeActiveSelection(handle.bytes));
+  const newest = slots.sort((left, right) => right.generation - left.generation)[0];
+  assert.equal(newest.generation, 2);
+  assert.deepEqual(new Set(newest.packs.map(pack => pack.packId)), new Set(['first-pack', 'second-pack']));
+});
+
+test('destination-creation race preserves a pre-existing pack directory', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create:true});
+  class RacingPacksDirectory extends MemoryDirectoryHandle {
+    async getDirectoryHandle(name, options = {}) {
+      if (name === metadata.packId && options.create && !this.raced) {
+        this.raced = true;
+        const injected = new MemoryDirectoryHandle(name, this.log);
+        const manifest = new MemoryFileHandle('manifest.pmp', this.log);
+        manifest.bytes = new Uint8Array([9, 8, 7]);
+        injected.children.set('manifest.pmp', manifest);
+        this.children.set(name, injected);
+        return injected;
+      }
+      return super.getDirectoryHandle(name, options);
+    }
+  }
+  const packs = new RacingPacksDirectory('packs', root.log);
+  pyxis.children.set('packs', packs);
+  await assert.rejects(
+    installMuiZip({archive, rootDirectory:root, metadata}),
+    /destination.*changed|created concurrently|not empty/i,
+  );
+  const raced = packs.children.get(metadata.packId);
+  assert.deepEqual([...raced.children.get('manifest.pmp').bytes], [9, 8, 7]);
+  assert.equal(raced.children.has('tiles'), false);
+});
+
+test('map-set capacity is checked before a ninth pack is published', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create:true});
+  const slot = await pyxis.getFileHandle('active-pack.0', {create:true});
+  const writable = await slot.createWritable();
+  await writable.write(encodeActiveMapSet({generation:8,mapSetId:'osm-bright',attribution:metadata.attribution,packs:
+    Array.from({length:8}, (_,index) => ({packId:`pack-${index}`,rowSpans:[{zoom:2,y:1,xMinimum:1,xMaximum:1}]}))}));
+  await writable.close();
+  await assert.rejects(installMuiZip({archive,rootDirectory:root,metadata:{...metadata,packId:'pack-nine',name:'Pack Nine'}}), /active map set/i);
+  assert.equal(pyxis.children.has('packs'), false);
+});

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -24,8 +24,11 @@ import zlib
 
 MAGIC = b"PMPK"
 FORMAT_VERSION = 1
+SPARSE_FORMAT_VERSION = 2
 HEADER_SIZE = 16
 EXTENT_SIZE = 26
+ROW_SPAN_SIZE = 13
+MAX_ROW_SPANS = 512
 MAX_ZOOM = 22
 DEFAULT_MAX_TILES = 100_000
 DEFAULT_MAX_BYTES = 8 * 1024 * 1024 * 1024
@@ -33,7 +36,7 @@ MAX_VISITED_ENTRIES_BASE = 64
 PACK_ID_RE = re.compile(r"[a-z0-9_-]{1,31}\Z")
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _STRING_LIMITS = {"pack_id": 31, "name": 63, "attribution": 127, "source": 127, "license": 63}
-MAX_MANIFEST_BYTES = HEADER_SIZE + 4 + 7 + sum(1 + size for size in _STRING_LIMITS.values()) + 23 * EXTENT_SIZE
+MAX_MANIFEST_BYTES = 7100
 _DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
 _FILE_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC
 
@@ -68,6 +71,14 @@ class ZoomExtent:
     intervals: tuple[tuple[int, int], ...]
     y_minimum: int
     y_maximum: int
+
+
+@dataclass(frozen=True)
+class RowSpan:
+    zoom: int
+    y: int
+    x_minimum: int
+    x_maximum: int
 
 
 @dataclass(frozen=True)
@@ -470,6 +481,74 @@ def calculate_extents(tiles: Iterable[Tile], antimeridian_zooms: set[int]) -> li
     return extents
 
 
+def calculate_row_spans(tiles: Iterable[Tile]) -> list[RowSpan]:
+    by_row: dict[tuple[int, int], set[int]] = {}
+    zooms: set[int] = set()
+    for tile in tiles:
+        by_row.setdefault((tile.zoom, tile.y), set()).add(tile.x)
+        zooms.add(tile.zoom)
+    ordered_zooms = sorted(zooms)
+    if not ordered_zooms or ordered_zooms != list(range(ordered_zooms[0], ordered_zooms[-1] + 1)):
+        raise PackError("zoom levels must be contiguous")
+    spans: list[RowSpan] = []
+    for (zoom, y), xs in sorted(by_row.items()):
+        for minimum, maximum in _runs(xs):
+            spans.append(RowSpan(zoom, y, minimum, maximum))
+            if len(spans) > MAX_ROW_SPANS:
+                raise PackError(f"sparse coverage exceeds row-span limit of {MAX_ROW_SPANS}")
+    return spans
+
+
+def _validate_row_spans(row_spans: list[RowSpan], tile_count: int) -> None:
+    if not row_spans or len(row_spans) > MAX_ROW_SPANS:
+        raise PackError("manifest row-span count is invalid")
+    zooms: set[int] = set()
+    total = 0
+    previous: RowSpan | None = None
+    for span in row_spans:
+        if span.zoom < 0 or span.zoom > MAX_ZOOM:
+            raise PackError("invalid manifest row span")
+        world_maximum = (1 << span.zoom) - 1
+        if span.y < 0 or span.y > world_maximum or span.x_minimum < 0 \
+                or span.x_minimum > span.x_maximum or span.x_maximum > world_maximum:
+            raise PackError("invalid manifest row span")
+        if previous is not None and ((span.zoom, span.y) < (previous.zoom, previous.y) or
+                ((span.zoom, span.y) == (previous.zoom, previous.y) and
+                 span.x_minimum <= previous.x_maximum + 1)):
+            raise PackError("manifest row spans are not canonical")
+        total += span.x_maximum - span.x_minimum + 1
+        if total > 0xFFFFFFFF:
+            raise PackError("manifest tile count overflows uint32")
+        zooms.add(span.zoom)
+        previous = span
+    ordered_zooms = sorted(zooms)
+    if ordered_zooms != list(range(ordered_zooms[0], ordered_zooms[-1] + 1)):
+        raise PackError("manifest row spans must cover contiguous zooms")
+    if tile_count <= 0 or tile_count != total:
+        raise PackError("invalid manifest tile count")
+
+
+def serialize_sparse_manifest(*, pack_id: str, name: str, attribution: str, source: str,
+                              license: str, row_spans: list[RowSpan], tile_count: int) -> bytes:
+    _validate_metadata(pack_id, name, attribution, source, license)
+    _validate_row_spans(row_spans, tile_count)
+    payload = bytearray()
+    for field, value in (("pack_id", pack_id), ("name", name), ("attribution", attribution),
+                         ("source", source), ("license", license)):
+        encoded = _checked_text(field, value)
+        payload.append(len(encoded))
+        payload.extend(encoded)
+    payload.extend((row_spans[0].zoom, row_spans[-1].zoom))
+    payload.extend(struct.pack("<HI", len(row_spans), tile_count))
+    for span in row_spans:
+        payload.extend(struct.pack("<BIII", span.zoom, span.y, span.x_minimum, span.x_maximum))
+    length = HEADER_SIZE + len(payload) + 4
+    result = bytearray(struct.pack("<4sBBHII", MAGIC, SPARSE_FORMAT_VERSION, 0, HEADER_SIZE, length, 0))
+    result.extend(payload)
+    result.extend(struct.pack("<I", zlib.crc32(result)))
+    return bytes(result)
+
+
 def _validate_manifest_values(extents: list[ZoomExtent], tile_count: int) -> None:
     if not extents or len(extents) > MAX_ZOOM + 1:
         raise PackError("manifest extent count is invalid")
@@ -528,7 +607,8 @@ def parse_manifest(data: bytes) -> dict[str, object]:
     if len(data) < 20 or len(data) > MAX_MANIFEST_BYTES:
         raise PackError("manifest is truncated or oversized")
     magic, version, reserved, header_size, length, reserved_word = struct.unpack("<4sBBHII", data[:16])
-    if (magic, version, reserved, header_size, length, reserved_word) != (MAGIC, 1, 0, 16, len(data), 0):
+    if magic != MAGIC or version not in (FORMAT_VERSION, SPARSE_FORMAT_VERSION) or \
+            (reserved, header_size, length, reserved_word) != (0, 16, len(data), 0):
         raise PackError("invalid manifest header")
     if zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
         raise PackError("invalid manifest CRC")
@@ -550,27 +630,48 @@ def parse_manifest(data: bytes) -> dict[str, object]:
         if field == "pack_id" and not PACK_ID_RE.fullmatch(value):
             raise PackError("invalid manifest pack ID")
         values[field] = value
-    if position + 7 > len(data) - 4:
-        raise PackError("manifest fields are truncated")
-    minimum, maximum, count = data[position:position + 3]
-    position += 3
-    tile_count = struct.unpack("<I", data[position:position + 4])[0]
-    position += 4
-    if count > MAX_ZOOM + 1 or count > (len(data) - 4 - position) // EXTENT_SIZE:
-        raise PackError("invalid manifest extent count")
-    extents: list[ZoomExtent] = []
-    for _ in range(count):
-        zoom, interval_count = data[position:position + 2]
-        y_minimum, y_maximum, x0, x1, x2, x3 = struct.unpack("<IIIIII", data[position + 2:position + 26])
-        position += EXTENT_SIZE
-        if interval_count not in (1, 2) or (interval_count == 1 and (x2 != 0 or x3 != 0)):
-            raise PackError("invalid manifest extent")
-        intervals = ((x0, x1),) if interval_count == 1 else ((x0, x1), (x2, x3))
-        extents.append(ZoomExtent(zoom, intervals, y_minimum, y_maximum))
-    if position != len(data) - 4 or not extents or minimum != extents[0].zoom or maximum != extents[-1].zoom:
-        raise PackError("invalid manifest length or zoom range")
-    _validate_manifest_values(extents, tile_count)
-    values.update(min_zoom=minimum, max_zoom=maximum, tile_count=tile_count, extents=extents)
+    if version == FORMAT_VERSION:
+        if position + 7 > len(data) - 4:
+            raise PackError("manifest fields are truncated")
+        minimum, maximum, count = data[position:position + 3]
+        position += 3
+        tile_count = struct.unpack("<I", data[position:position + 4])[0]
+        position += 4
+        if count > MAX_ZOOM + 1 or count > (len(data) - 4 - position) // EXTENT_SIZE:
+            raise PackError("invalid manifest extent count")
+        extents: list[ZoomExtent] = []
+        for _ in range(count):
+            zoom, interval_count = data[position:position + 2]
+            y_minimum, y_maximum, x0, x1, x2, x3 = struct.unpack("<IIIIII", data[position + 2:position + 26])
+            position += EXTENT_SIZE
+            if interval_count not in (1, 2) or (interval_count == 1 and (x2 != 0 or x3 != 0)):
+                raise PackError("invalid manifest extent")
+            intervals = ((x0, x1),) if interval_count == 1 else ((x0, x1), (x2, x3))
+            extents.append(ZoomExtent(zoom, intervals, y_minimum, y_maximum))
+        if position != len(data) - 4 or not extents or minimum != extents[0].zoom or maximum != extents[-1].zoom:
+            raise PackError("invalid manifest length or zoom range")
+        _validate_manifest_values(extents, tile_count)
+        values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
+                      tile_count=tile_count, extents=extents, row_spans=[])
+    else:
+        if position + 8 > len(data) - 4:
+            raise PackError("manifest sparse fields are truncated")
+        minimum, maximum = data[position:position + 2]
+        position += 2
+        count, tile_count = struct.unpack("<HI", data[position:position + 6])
+        position += 6
+        if count == 0 or count > MAX_ROW_SPANS or count > (len(data) - 4 - position) // ROW_SPAN_SIZE:
+            raise PackError("invalid manifest row-span count")
+        row_spans: list[RowSpan] = []
+        for _ in range(count):
+            zoom, y, x_minimum, x_maximum = struct.unpack("<BIII", data[position:position + ROW_SPAN_SIZE])
+            position += ROW_SPAN_SIZE
+            row_spans.append(RowSpan(zoom, y, x_minimum, x_maximum))
+        if position != len(data) - 4 or minimum != row_spans[0].zoom or maximum != row_spans[-1].zoom:
+            raise PackError("invalid manifest length or zoom range")
+        _validate_row_spans(row_spans, tile_count)
+        values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
+                      tile_count=tile_count, extents=[], row_spans=row_spans)
     return values
 
 
@@ -659,10 +760,17 @@ def _validate_pack_fd(pack_fd: int, label: Path, max_bytes: int) -> dict[str, ob
         tiles = _discover_tiles_fd(tiles_fd, label / "tiles", tile_count, max_bytes)
     finally:
         os.close(tiles_fd)
-    expected_extents = cast(list[ZoomExtent], parsed["extents"])
-    extents = calculate_extents(tiles, {item.zoom for item in expected_extents if len(item.intervals) == 2})
-    if len(tiles) != tile_count or extents != expected_extents:
+    if len(tiles) != tile_count:
         raise PackError("emitted tile tree does not match manifest")
+    if parsed["format_version"] == FORMAT_VERSION:
+        expected_extents = cast(list[ZoomExtent], parsed["extents"])
+        extents = calculate_extents(tiles, {item.zoom for item in expected_extents if len(item.intervals) == 2})
+        if extents != expected_extents:
+            raise PackError("emitted tile tree does not match manifest")
+    else:
+        expected_spans = cast(list[RowSpan], parsed["row_spans"])
+        if calculate_row_spans(tiles) != expected_spans:
+            raise PackError("emitted tile tree does not match sparse manifest")
     return parsed
 
 
@@ -737,7 +845,8 @@ def _verify_output_chain(output_root: Path, root_fd: int, pyxis_fd: int, pyxis_i
 def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, name: str,
                    attribution: str, source: str, license: str,
                    max_tiles: int = DEFAULT_MAX_TILES, max_bytes: int = DEFAULT_MAX_BYTES,
-                   antimeridian_zooms: set[int] | None = None) -> Path:
+                   antimeridian_zooms: set[int] | None = None,
+                   sparse: bool = False) -> Path:
     if not sys.platform.startswith("linux"):
         raise PackError("secure importer supports Linux hosts only")
     _validate_metadata(pack_id, name, attribution, source, license)
@@ -753,9 +862,18 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
     committed = False
     try:
         tiles = _discover_tiles_fd(source_fd, source_directory, max_tiles, max_bytes)
-        extents = calculate_extents(tiles, antimeridian_zooms)
-        manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
-                                      license=license, extents=extents, tile_count=len(tiles))
+        try:
+            extents = calculate_extents(tiles, antimeridian_zooms)
+        except PackError as exc:
+            if not sparse or antimeridian_zooms or not str(exc).startswith("incomplete rectangle"):
+                raise
+            row_spans = calculate_row_spans(tiles)
+            manifest = serialize_sparse_manifest(pack_id=pack_id, name=name, attribution=attribution,
+                                                 source=source, license=license,
+                                                 row_spans=row_spans, tile_count=len(tiles))
+        else:
+            manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
+                                          license=license, extents=extents, tile_count=len(tiles))
         output_fd = _open_path(output_root, create=True)
         pyxis_fd, pyxis_identity = _mkdir_open(output_fd, "pyxis-map")
         packs_fd, packs_identity = _mkdir_open(pyxis_fd, "packs")
@@ -831,6 +949,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-tiles", type=int, default=DEFAULT_MAX_TILES)
     parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
     parser.add_argument("--antimeridian-zoom", action="append", type=int, default=[])
+    parser.add_argument("--sparse", action="store_true",
+                        help="explicitly admit sparse state/polygon coverage and emit PMPK v2")
     return parser
 
 
@@ -842,7 +962,8 @@ def main(argv: list[str] | None = None) -> int:
                                 attribution=arguments.attribution, source=arguments.source,
                                 license=arguments.license, max_tiles=arguments.max_tiles,
                                 max_bytes=arguments.max_bytes,
-                                antimeridian_zooms=set(arguments.antimeridian_zoom))
+                                antimeridian_zooms=set(arguments.antimeridian_zoom),
+                                sparse=arguments.sparse)
     except PublishedDurabilityError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 3


### PR DESCRIPTION
## Stack

**3 of 3**. Base: `feature/offline-maps-sd-stack`.

## Summary

- add PMP v2 exact sparse row-span coverage while preserving PMP v1 compatibility
- compose compatible offline packs into bounded map sets with deterministic priority and lower-priority tile fallback
- publish redundant CRC/generation-protected PMAS records for up to eight packs and 512 total spans
- add a local browser installer for MUI ZIP archives with verified SD writes and **Install and Enable** workflow
- keep firmware map rendering entirely offline

## Review scope

This boundary changes **19 files**, below Greptile's 100-file review limit.

Exact head: `924d24f10bb1acb8bbda362ae26f1198b6aa22dc`

Stack merge commits carry the reviewed lower-layer fixes into this exact head without changing this PR's 19-file delta.

Greptile's distinct-handle concurrency finding is fixed with same-origin Web Locks keyed by the selected SD-root name. Current Chrome, Chromium, and Edge tabs now serialize publication even when they hold different handle objects for the same root; supported browser execution fails closed when cross-tab locking is unavailable.

## Archive and publication safety

The installer rejects traversal, ambiguous names, duplicates, unsupported ZIP features, header/descriptor inconsistencies, archive gaps or overlaps, malformed PNG/zlib streams, trailing data, decompression overruns, and exceeded resource bounds. Publication uses verified writes, exact ownership receipts, directory identity checks, same-root serialization, and redundant activation slots. Interrupted cleanup never deletes a concurrently created destination directory.

Writable SD-directory access requires Chrome, Chromium, or Edge. Pyxis does not mirror or redistribute third-party map bundles.

## Verification

- `python3 -m pytest -q tests/build_scripts tests/native tests/tools`: **253 passed**
- `node --check docs/flasher/js/map-installer.js`: **passed**
- `node --test tests/web/test_map_installer.mjs`: **10 passed**
- `pio run -e tdeck`: **passed**
- `pio run -e tdeck-release`: **passed**
- `python3 tools/audit_release_build.py`: **passed**
- release firmware version: `0.3.1-80-g924d24f`
- release firmware size: `2,667,552` bytes
- release firmware SHA-256: `59e8984616f45a1c38def665c2a09b53adc94e3c563c98279e0a67f0433ece4e`
- microReticulum: `6ac0d3232cf7055d538f9c556f0f82d2d2cc753bc`
- microLXMF: `60fb7d6951bd17275da83fdd9581900d55b0a2ab`
- microStore: `c5fb69d68229e684c7fbd17692a67ae8193b84e2`

## Physical validation boundary

An earlier candidate was flashed application-only and read back byte-for-byte while preserving the partition table, NVS identity, OTA metadata, alternate app, LittleFS, coredump, and SD contents. The exact current head includes subsequent review fixes and has not been flashed. One earlier controlled restart encountered a transient 16-byte container-allocation failure before automatic recovery, so reboot acceptance is not clean. Exact-head physical boot, sparse-pack rendering, overlap/fallback, GPS navigation, and real-peer location sharing remain pending final acceptance.
