### PR TITLE
fix: refresh visible map tile status

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -629,6 +629,7 @@ void MapScreen::applyFrame() {
     lv_label_set_text(zoom_label_, zoom_text);
     lv_label_set_text(attribution_label_, pack_attribution_[0] != '\0'
         ? pack_attribution_ : "No active map pack");
+    refreshVisibleStatus();
     // Non-ready images are now detached under LVGL_LOCK, so the worker may
     // safely decode into their permanent buffers without a draw race.
     requests_released_ = true;
@@ -662,15 +663,21 @@ void MapScreen::setStatusFor(Pyxis::MapTileLoadResult result) {
     }
 }
 
+void MapScreen::refreshVisibleStatus() {
+    Pyxis::MapTileLoadResult visible_status{};
+    if (presenter_.visibleTileStatus(visible_status)) {
+        setStatusFor(visible_status);
+    } else {
+        lv_label_set_text(status_label_, "Loading tiles...");
+    }
+}
+
 bool MapScreen::applyOneCompletion() {
     if (!lockState(pdMS_TO_TICKS(100))) return false;
     Pyxis::MapTileCompletion completion{};
     const bool applied = presenter_.takeApplicableCompletion(completion);
     if (applied) {
-        Pyxis::MapTileLoadResult visible_status{};
-        if (presenter_.visibleTileStatus(visible_status)) {
-            setStatusFor(visible_status);
-        }
+        refreshVisibleStatus();
         if (completion.result == Pyxis::MapTileLoadResult::READY &&
             completion.slot_index < TILE_COUNT) {
             const std::size_t index = completion.slot_index;

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -667,7 +667,10 @@ bool MapScreen::applyOneCompletion() {
     Pyxis::MapTileCompletion completion{};
     const bool applied = presenter_.takeApplicableCompletion(completion);
     if (applied) {
-        setStatusFor(completion.result);
+        Pyxis::MapTileLoadResult visible_status{};
+        if (presenter_.visibleTileStatus(visible_status)) {
+            setStatusFor(visible_status);
+        }
         if (completion.result == Pyxis::MapTileLoadResult::READY &&
             completion.slot_index < TILE_COUNT) {
             const std::size_t index = completion.slot_index;

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.h
@@ -115,6 +115,7 @@ private:
     void unlockState();
     void setPlaceholder(std::size_t index);
     void setStatusFor(Pyxis::MapTileLoadResult result);
+    void refreshVisibleStatus();
     void pan(double dx, double dy);
 
     static MapScreen* fromEvent(lv_event_t* event);

--- a/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.cpp
@@ -334,4 +334,55 @@ bool MapScreenPresenter::takeApplicableCompletion(MapTileCompletion& output) {
     return false;
 }
 
+bool MapScreenPresenter::visibleTileStatus(MapTileLoadResult& output) const {
+    bool pending = false;
+    bool have_terminal = false;
+    unsigned severity = 0U;
+    MapTileLoadResult terminal = MapTileLoadResult::MISS;
+    for (std::size_t index = 0U; index < TILE_SLOT_COUNT; ++index) {
+        switch (slots_[index].state) {
+            case MapTileSlot::READY:
+                output = MapTileLoadResult::READY;
+                return true;
+            case MapTileSlot::PENDING:
+                pending = true;
+                break;
+            case MapTileSlot::MISS:
+                have_terminal = true;
+                break;
+            case MapTileSlot::TOO_LARGE:
+                if (severity < 1U) {
+                    severity = 1U;
+                    terminal = MapTileLoadResult::TOO_LARGE;
+                }
+                have_terminal = true;
+                break;
+            case MapTileSlot::INVALID_PNG:
+                if (severity < 2U) {
+                    severity = 2U;
+                    terminal = MapTileLoadResult::INVALID_PNG;
+                }
+                have_terminal = true;
+                break;
+            case MapTileSlot::STORAGE_UNAVAILABLE:
+                if (severity < 3U) {
+                    severity = 3U;
+                    terminal = MapTileLoadResult::STORAGE_UNAVAILABLE;
+                }
+                have_terminal = true;
+                break;
+            case MapTileSlot::IO_ERROR:
+                severity = 4U;
+                terminal = MapTileLoadResult::IO_ERROR;
+                have_terminal = true;
+                break;
+            case MapTileSlot::EMPTY:
+                break;
+        }
+    }
+    if (pending || !have_terminal) return false;
+    output = terminal;
+    return true;
+}
+
 }  // namespace Pyxis

--- a/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
@@ -93,6 +93,7 @@ public:
     bool takeRequest(MapTileRequest& output);
     bool publishCompletion(const MapTileCompletion& completion);
     bool takeApplicableCompletion(MapTileCompletion& output);
+    bool visibleTileStatus(MapTileLoadResult& output) const;
 
     const MapView::Frame& frame() const { return frame_; }
     const MapTileSlot& slot(std::size_t index) const { return slots_[index]; }

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -44,6 +44,8 @@ def test_fixed_pool_and_cache_contracts():
     assert "static_assert(MapTileStore::HARD_MAX_ENTRIES == 128" in screen_cpp
     assert "pack_.metadata().attribution" in screen_cpp
     assert '"No active map pack"' in screen_cpp
+    assert "presenter_.visibleTileStatus" in screen_cpp
+    assert "setStatusFor(completion.result)" not in screen_cpp
     assert "© OpenStreetMap contributors" not in screen_cpp
     assert "worker_exited_" in screen_h
     assert "if (!center_initialized_ && request.has_local_location" in screen_cpp

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -46,6 +46,8 @@ def test_fixed_pool_and_cache_contracts():
     assert '"No active map pack"' in screen_cpp
     assert "presenter_.visibleTileStatus" in screen_cpp
     assert "setStatusFor(completion.result)" not in screen_cpp
+    assert 'lv_label_set_text(status_label_, "Loading tiles...")' in screen_cpp
+    assert screen_cpp.count("refreshVisibleStatus();") >= 2
     assert "© OpenStreetMap contributors" not in screen_cpp
     assert "worker_exited_" in screen_h
     assert "if (!center_initialized_ && request.has_local_location" in screen_cpp

--- a/tests/native/test_map_screen_presenter.cpp
+++ b/tests/native/test_map_screen_presenter.cpp
@@ -162,6 +162,45 @@ void generationPanZoomAndRecenterBounds() {
     CHECK(std::fabs(presenter.center().longitude + 0.114) < 1e-9);
 }
 
+void visibleStatusSummarizesTheCurrentFrame() {
+    MapScreenPresenter presenter;
+    presenter.show();
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 5)) ==
+          Pyxis::MapView::Result::OK);
+
+    MapTileLoadResult visible = MapTileLoadResult::IO_ERROR;
+    CHECK(!presenter.visibleTileStatus(visible));
+
+    MapTileRequest requests[MapScreenPresenter::TILE_REQUEST_CAPACITY]{};
+    std::size_t count = 0U;
+    while (count < MapScreenPresenter::TILE_REQUEST_CAPACITY &&
+           presenter.takeRequest(requests[count])) ++count;
+    CHECK(count > 1U);
+    for (std::size_t index = 0U; index < count; ++index) {
+        const MapTileLoadResult result = index == 0U
+            ? MapTileLoadResult::READY : MapTileLoadResult::MISS;
+        CHECK(presenter.publishCompletion(completionFor(requests[index], result)));
+    }
+    MapTileCompletion completion{};
+    while (presenter.takeApplicableCompletion(completion)) {}
+    CHECK(presenter.visibleTileStatus(visible));
+    CHECK(visible == MapTileLoadResult::READY);
+
+    CHECK(presenter.zoomBy(1));
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 6)) ==
+          Pyxis::MapView::Result::OK);
+    count = 0U;
+    while (count < MapScreenPresenter::TILE_REQUEST_CAPACITY &&
+           presenter.takeRequest(requests[count])) ++count;
+    for (std::size_t index = 0U; index < count; ++index) {
+        CHECK(presenter.publishCompletion(
+            completionFor(requests[index], MapTileLoadResult::MISS)));
+    }
+    while (presenter.takeApplicableCompletion(completion)) {}
+    CHECK(presenter.visibleTileStatus(visible));
+    CHECK(visible == MapTileLoadResult::MISS);
+}
+
 void resultStatesAndQueueLimit() {
     MapScreenPresenter presenter;
     presenter.show();
@@ -227,6 +266,7 @@ int main() {
     staleCompletionsRejectedAndAcceptedOnce();
     newestFrameReusesSlotsAndPurgesOldRequests();
     generationPanZoomAndRecenterBounds();
+    visibleStatusSummarizesTheCurrentFrame();
     resultStatesAndQueueLimit();
     deterministicHundredThousandOperationStress();
     std::cout << "map screen presenter: " << passed << " passed, "


### PR DESCRIPTION
## Summary

- derive map availability from the aggregate state of the current visible tile frame
- report `Tile ready` whenever any current visible tile is ready
- show `Loading tiles...` for a newly applied frame while its current tiles are pending
- prevent missing edge tiles from overwriting successful visible-tile status
- preserve deterministic typed failure status when the viewport settles with no ready tile
- add regression and integration-contract coverage

## Root cause

The map screen previously updated its status from each individual asynchronous completion. A missing edge tile arriving after a successful visible tile could therefore leave `Tile unavailable` displayed while the covered tile was rendered correctly.

The first review also identified that retaining the previous settled status during an all-pending replacement frame could temporarily show stale `Tile ready`. The additive remediation refreshes the label when each new frame is applied and reports `Loading tiles...` until that frame has a settled aggregate result.

## Verification

Exact head: `84c03e760609292ba185388bd4db6fc147809865`

- `python3 -m pytest -q tests/build_scripts tests/native tests/tools` — 253 passed
- `pio run -e tdeck` — passed
- `pio run -e tdeck-release` — passed
- `python3 tools/audit_release_build.py --environment tdeck-release` — passed
- embedded version: `0.3.1-85-g84c03e7`
- `tdeck` firmware: 2,675,216 bytes; SHA-256 `ed660349df3beb4605205c3d9aed0ae16fb95ebd5f1868dd35815a710b7f5765`
- `tdeck-release` firmware: 2,667,776 bytes; SHA-256 `3e6ee66a28d6e620a940e74b8567d553ecf2d0870fc29b1cd3697b006e460248`
- independent exact-head review — passed with no findings
- GitHub pytest, native, `tdeck`, and `tdeck-release` checks — passed
- Greptile exact-head review — 5/5, no blocking failure

## Physical validation

Pending. This PR does not claim device installation, framebuffer confirmation, reboot persistence, or physical map-navigation acceptance.

## Scope

This PR only fixes visible-frame tile status aggregation and pending-frame status. Legacy-cache retirement and on-device map-style selection will be handled separately.
