### PR TITLE
feat: add offline map style switcher

### DIFF
--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -242,7 +242,7 @@
             margin: 1rem 0;
         }
         .map-field label { display: block; color: var(--muted); font-size: 0.875rem; margin-bottom: 0.4rem; }
-        .map-field input { width: 100%; box-sizing: border-box; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.65rem; }
+        .map-field input, .map-field select { width: 100%; box-sizing: border-box; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.65rem; }
         .map-status { margin: 0.8rem 0; color: var(--muted); overflow-wrap: anywhere; }
         .map-status.success { color: var(--success); }
         .map-status.error { color: var(--error); }
@@ -319,7 +319,7 @@
                 <li>
                     Download a compatible MUI map ZIP from
                     <a href="https://download.tiles.coalition.space/" target="_blank" rel="noopener noreferrer">Oxed's Map Tile Downloader</a>.
-                    Choose OSM Bright for current Pyxis compatibility.
+                    Choose OSM Bright, Dark Matter, Positron, or Toner.
                 </li>
                 <li>Turn the T-Deck off, remove its microSD card, and insert the card into your computer.</li>
                 <li>Choose the downloaded ZIP below, enter a map name and pack ID, and wait for local validation.</li>
@@ -333,6 +333,16 @@
                     <input id="map-archive" type="file" accept=".zip,application/zip">
                 </div>
                 <div class="map-field">
+                    <label for="map-style">Map style</label>
+                    <select id="map-style">
+                        <option value="" selected disabled>Select map style…</option>
+                        <option value="osm-bright">OSM Bright</option>
+                        <option value="dark-matter">Dark Matter</option>
+                        <option value="positron">Positron</option>
+                        <option value="toner">Toner</option>
+                    </select>
+                </div>
+                <div class="map-field">
                     <label for="map-pack-name">Map name</label>
                     <input id="map-pack-name" type="text" maxlength="63" placeholder="Offline map">
                 </div>
@@ -342,9 +352,9 @@
                 </div>
             </div>
             <p class="map-note">
-                Source profile: Coalition MUI OSM Bright user download.<br>
-                Attribution: Map data (c) OpenStreetMap contributors — ODbL-1.0.<br>
-                Compatible OSM Bright packs are enabled together. The newest pack takes priority where coverage overlaps.
+                Source profile and style are read from the selected MUI ZIP. Rootless XYZ ZIPs use the style selected above.<br>
+                Attribution: Map data (c) OpenStreetMap contributors — ODbL-1.0 data; style terms at source.<br>
+                Compatible packs of the same style are enabled together. The newest pack takes priority where coverage overlaps.
             </p>
             <div id="map-install-status" class="map-status">Choose a ZIP to validate it locally. No tiles are uploaded.</div>
             <div class="button-group">
@@ -387,7 +397,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
-        import { inspectMuiZip, installMuiZip } from './js/map-installer.js';
+        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile } from './js/map-installer.js';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');
@@ -401,6 +411,7 @@
         const customFirmwareInput = document.getElementById('custom-firmware');
         const customFirmwareStatus = document.getElementById('custom-firmware-status');
         const mapArchiveInput = document.getElementById('map-archive');
+        const mapStyleSelect = document.getElementById('map-style');
         const mapPackNameInput = document.getElementById('map-pack-name');
         const mapPackIdInput = document.getElementById('map-pack-id');
         const mapInstallStatus = document.getElementById('map-install-status');
@@ -435,10 +446,24 @@
         });
         mapPackIdInput.addEventListener('input', () => { mapPackIdInput.dataset.edited = 'true'; });
 
+        function setReadyMapStatus(report, style) {
+            setMapStatus(`Ready: ${style.label}, ${report.tileCount} tiles, zoom ${report.minZoom}-${report.maxZoom}, ${report.rowSpans.length} sparse row spans, ${report.totalBytes.toLocaleString()} bytes.`, 'success');
+        }
+
+        mapStyleSelect.addEventListener('change', () => {
+            if (validatedMapArchive && !validatedMapArchive.report.styleId) {
+                const style = resolveMuiStyleProfile(null, mapStyleSelect.value);
+                mapInstallBtn.disabled = false;
+                setReadyMapStatus(validatedMapArchive.report, style);
+            }
+        });
+
         mapArchiveInput.addEventListener('change', async function() {
             const token = ++mapSelectionToken;
             validatedMapArchive = null;
             mapInstallBtn.disabled = true;
+            mapStyleSelect.disabled = false;
+            mapStyleSelect.value = '';
             const file = this.files?.[0];
             if (!file) { setMapStatus('Choose a ZIP to validate it locally. No tiles are uploaded.'); return; }
             if (!mapPackNameInput.value) mapPackNameInput.value = file.name.replace(/\.zip$/i, '') || 'Offline map';
@@ -451,18 +476,38 @@
                     }
                 }});
                 if (token !== mapSelectionToken) return;
+                const style = report.styleId
+                    ? resolveMuiStyleProfile(report.styleId, '')
+                    : (mapStyleSelect.value ? resolveMuiStyleProfile(null, mapStyleSelect.value) : null);
+                if (report.styleId) {
+                    mapStyleSelect.value = style.id;
+                    mapStyleSelect.disabled = true;
+                }
                 validatedMapArchive = {file, report};
-                mapInstallBtn.disabled = false;
-                setMapStatus(`Ready: ${report.tileCount} tiles, zoom ${report.minZoom}-${report.maxZoom}, ${report.rowSpans.length} sparse row spans, ${report.totalBytes.toLocaleString()} bytes.`, 'success');
+                if (style) {
+                    mapInstallBtn.disabled = false;
+                    setReadyMapStatus(report, style);
+                } else {
+                    setMapStatus('Select map style to enable this validated rootless XYZ ZIP.');
+                }
             } catch (error) {
                 if (token !== mapSelectionToken) return;
                 this.value = '';
+                mapStyleSelect.disabled = false;
                 setMapStatus(error.message, 'error');
             }
         });
 
         mapInstallBtn.addEventListener('click', async () => {
             if (!validatedMapArchive) return;
+            let style;
+            try {
+                style = resolveMuiStyleProfile(validatedMapArchive.report.styleId, mapStyleSelect.value);
+            } catch (error) {
+                mapInstallBtn.disabled = true;
+                setMapStatus(error.message, 'error');
+                return;
+            }
             const name = mapPackNameInput.value.trim();
             const packId = mapPackIdInput.value.trim();
             if (!name || !/^[a-z0-9_-]{1,31}$/.test(packId)) {
@@ -486,11 +531,11 @@
                     rootDirectory,
                     metadata: {
                         packId,
-                        mapSetId: 'osm-bright',
+                        mapSetId: style.id,
                         name,
-                        attribution: 'Map data (c) OpenStreetMap contributors',
-                        source: 'Coalition MUI OSM Bright user download',
-                        license: 'ODbL-1.0',
+                        attribution: style.attribution,
+                        source: style.source,
+                        license: style.license,
                     },
                     onProgress(progress) {
                         if (progress.phase === 'write' && (progress.completed % 25 === 0 || progress.completed === progress.total)) {
@@ -498,7 +543,7 @@
                         }
                     },
                 });
-                setMapStatus(`Installed and enabled ${name} in OSM Bright: ${result.tileCount} tiles; ${result.enabledPacks.length} compatible pack(s) active. Safely eject the SD card before returning it to the T-Deck.`, 'success');
+                setMapStatus(`Installed and enabled ${name} in ${style.label}: ${result.tileCount} tiles; ${result.enabledPacks.length} compatible pack(s) active. Safely eject the SD card before returning it to the T-Deck.`, 'success');
             } catch (error) {
                 if (error?.name !== 'AbortError') setMapStatus(`Installation failed: ${error.message}`, 'error');
             } finally {

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -399,7 +399,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
-        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js';
+        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js?v=map-style-picker-2';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -242,7 +242,9 @@
             margin: 1rem 0;
         }
         .map-field label { display: block; color: var(--muted); font-size: 0.875rem; margin-bottom: 0.4rem; }
-        .map-field input, .map-field select { width: 100%; box-sizing: border-box; color: var(--text); background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 0.65rem; }
+        .map-field input, .map-field select { width: 100%; box-sizing: border-box; color: var(--text); background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.15); border-radius: 6px; padding: 0.65rem; }
+        .map-field select { color-scheme: dark; }
+        .map-field select option { color: var(--text); background: var(--card); }
         .map-status { margin: 0.8rem 0; color: var(--muted); overflow-wrap: anywhere; }
         .map-status.success { color: var(--success); }
         .map-status.error { color: var(--error); }
@@ -397,7 +399,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
-        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile } from './js/map-installer.js';
+        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');
@@ -466,8 +468,10 @@
             mapStyleSelect.value = '';
             const file = this.files?.[0];
             if (!file) { setMapStatus('Choose a ZIP to validate it locally. No tiles are uploaded.'); return; }
-            if (!mapPackNameInput.value) mapPackNameInput.value = file.name.replace(/\.zip$/i, '') || 'Offline map';
-            if (!mapPackIdInput.value) mapPackIdInput.value = slugifyMapName(mapPackNameInput.value);
+            const suggestion = suggestMapIdentity(file.name);
+            mapPackNameInput.value = suggestion.name;
+            mapPackIdInput.value = suggestion.packId;
+            delete mapPackIdInput.dataset.edited;
             setMapStatus(`Validating ${file.name} locally...`);
             try {
                 const report = await inspectMuiZip(file, {onProgress(progress) {

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -57,6 +57,34 @@ async function withInstallLock(rootDirectory, operation) {
 
 export class MapInstallerError extends Error {}
 function fail(message) { throw new MapInstallerError(message); }
+
+const MUI_STYLE_PROFILES = Object.freeze({
+  'osm-bright': Object.freeze({label:'OSM Bright',attribution:'(c) OpenMapTiles (c) OpenStreetMap contributors',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause'}),
+  'dark-matter': Object.freeze({label:'Dark Matter',attribution:'(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)'}),
+  'positron': Object.freeze({label:'Positron',attribution:'(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)'}),
+  'toner': Object.freeze({label:'Toner',attribution:'(c) MapTiler (c) OpenStreetMap contributors',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)'}),
+});
+
+export function getMuiStyleProfile(styleId) {
+  const profile = MUI_STYLE_PROFILES[styleId];
+  if (!profile) fail(`Unsupported MUI map style: ${styleId || 'unknown'}`);
+  return {
+    id: styleId,
+    label: profile.label,
+    attribution: profile.attribution,
+    source: `Oxed's Map Tile Downloader (${profile.label})`,
+    license: profile.license,
+  };
+}
+
+export function resolveMuiStyleProfile(detectedStyleId, selectedStyleId) {
+  if (detectedStyleId !== null && detectedStyleId !== undefined) {
+    return getMuiStyleProfile(detectedStyleId);
+  }
+  if (!selectedStyleId) fail('Select map style before installing this rootless XYZ ZIP');
+  return getMuiStyleProfile(selectedStyleId);
+}
+
 function u16(view, offset) { return view.getUint16(offset, true); }
 function u32(view, offset) { return view.getUint32(offset, true); }
 function putU16(view, offset, value) { view.setUint16(offset, value, true); }
@@ -432,8 +460,9 @@ export async function inspectMuiZip(archive, {onProgress = () => {}} = {}) {
   entries.sort((a,b) => a.zoom-b.zoom || a.x-b.x || a.y-b.y);
   const zooms = [...new Set(entries.map(entry => entry.zoom))].sort((a,b) => a-b);
   if (zooms.some((zoom,index) => zoom !== zooms[0] + index)) fail('ZIP zoom levels must be contiguous');
+  const styleId = prefix ? prefix.slice('maps/'.length, -1) : null;
   return {entries, rowSpans:makeRowSpans(entries), tileCount:entries.length,
-          totalBytes, minZoom:zooms[0], maxZoom:zooms.at(-1), prefix};
+          totalBytes, minZoom:zooms[0], maxZoom:zooms.at(-1), prefix, styleId};
 }
 
 export function serializeSparseManifest(metadata, rowSpans, tileCount) {
@@ -545,6 +574,7 @@ async function verifyNamedDirectory(parent,name,expected,allowedEntries){
 }
 async function writeVerified(parent,name,bytes){ const handle=await parent.getFileHandle(name,{create:true}); const writable=await handle.createWritable({keepExistingData:false}); try{await writable.write(bytes);await writable.close();}catch(error){try{await writable.abort();}catch{} throw error;} const actual=new Uint8Array(await (await handle.getFile()).arrayBuffer()); if(actual.length!==bytes.length) fail(`SD read-back mismatch: ${name}`); for(let index=0;index<bytes.length;index++) if(actual[index]!==bytes[index]) fail(`SD read-back mismatch: ${name}`); return handle; }
 async function readSelection(pyxis,name){ let handle; try{handle=await pyxis.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;} const bytes=new Uint8Array(await(await handle.getFile()).arrayBuffer()); try{return decodeActiveSelection(bytes);}catch{return null;} }
+async function readStyleSelection(mapSets,name){let handle;try{handle=await mapSets.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;}const bytes=new Uint8Array(await(await handle.getFile()).arrayBuffer());try{return decodeActiveSelection(bytes);}catch{fail(`Installed style record is invalid: ${name}`);}}
 async function fileBytes(parent,name){const handle=await parent.getFileHandle(name);return new Uint8Array(await(await handle.getFile()).arrayBuffer());}
 function equalBytes(left,right){if(left.length!==right.length)return false;for(let index=0;index<left.length;index++)if(left[index]!==right[index])return false;return true;}
 async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
@@ -568,22 +598,28 @@ async function prepareActiveMapSet(pyxis,metadata,rowSpans){
   if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
   const valid=slots.filter(Boolean);const highest=Math.max(0,...valid.map(slot=>slot.generation));if(highest===0xffffffff)fail('Active selection generation is exhausted');
   const current=valid.sort((left,right)=>right.generation-left.generation)[0];
+  const mapSets=await getDirectory(pyxis,'map-sets');const styleName=`${metadata.mapSetId}.pmas`;
+  const installed=await readStyleSelection(mapSets,styleName);
+  if(installed&&(installed.version!==2||installed.mapSetId!==metadata.mapSetId||installed.attribution!==metadata.attribution))fail('Installed style record does not match selected map set');
+  const composition=installed||(current?.version===2&&current.mapSetId===metadata.mapSetId?current:null);
   let packs=[];
-  if(current?.version===2&&current.mapSetId===metadata.mapSetId){
-    if(current.attribution!==metadata.attribution)fail('Installed map set attribution does not match');
-    packs=current.packs.filter(pack=>pack.packId!==metadata.packId);
+  if(composition){
+    if(composition.attribution!==metadata.attribution)fail('Installed map set attribution does not match');
+    packs=composition.packs.filter(pack=>pack.packId!==metadata.packId);
   }
   packs.unshift({packId:metadata.packId,rowSpans});
   const target=!slots[0]?'active-pack.0':!slots[1]?'active-pack.1':slots[0].generation<=slots[1].generation?'active-pack.0':'active-pack.1';
   const record=encodeActiveMapSet({generation:highest+1,mapSetId:metadata.mapSetId,attribution:metadata.attribution,packs});
-  return {target,record,packs};
+  return {target,record,packs,mapSets,styleName};
 }
 
 async function activateMapSet(pyxis,metadata,rowSpans){
-  const {target,record}=await prepareActiveMapSet(pyxis,metadata,rowSpans);
+  const {target,record,mapSets,styleName}=await prepareActiveMapSet(pyxis,metadata,rowSpans);
+  await writeVerified(mapSets,styleName,record);const installed=decodeActiveSelection(await fileBytes(mapSets,styleName));
+  if(installed.version!==2||installed.mapSetId!==metadata.mapSetId||installed.packs[0].packId!==metadata.packId)fail('Style map-set verification failed');
   await writeVerified(pyxis,target,record);const selected=decodeActiveSelection(await fileBytes(pyxis,target));
   if(selected.version!==2||selected.mapSetId!==metadata.mapSetId||selected.packs[0].packId!==metadata.packId)fail('Active map-set verification failed');
-  return {selectionFile:target,enabledPacks:selected.packs.map(pack=>pack.packId)};
+  return {selectionFile:target,styleFile:styleName,enabledPacks:selected.packs.map(pack=>pack.packId)};
 }
 
 async function verifyExistingPack(pack,archive,report,manifest){
@@ -593,8 +629,10 @@ async function verifyExistingPack(pack,archive,report,manifest){
 }
 
 async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()=>{}}){
-  validateMetadata(metadata);if(!/^[a-z0-9_-]{1,31}$/.test(metadata.mapSetId||''))fail('Map set ID is invalid');if(!rootDirectory||rootDirectory.kind!=='directory')fail('Choose an SD-card directory');
-  const report=await inspectMuiZip(archive,{onProgress});const manifest=serializeSparseManifest(metadata,report.rowSpans,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
+  validateMetadata(metadata);if(!/^[a-z0-9_-]{1,31}$/.test(metadata.mapSetId||''))fail('Map set ID is invalid');const profile=getMuiStyleProfile(metadata.mapSetId);if(metadata.attribution!==profile.attribution||metadata.source!==profile.source||metadata.license!==profile.license)fail('Required style attribution or provenance was changed');if(!rootDirectory||rootDirectory.kind!=='directory')fail('Choose an SD-card directory');
+  const report=await inspectMuiZip(archive,{onProgress});
+  if(report.styleId&&report.styleId!==metadata.mapSetId)fail('MUI ZIP style does not match the selected map set');
+  const manifest=serializeSparseManifest(metadata,report.rowSpans,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
   await prepareActiveMapSet(pyxis,metadata,report.rowSpans);const packs=await getDirectory(pyxis,'packs');
   let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
   if(existing){

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -85,6 +85,16 @@ export function resolveMuiStyleProfile(detectedStyleId, selectedStyleId) {
   return getMuiStyleProfile(selectedStyleId);
 }
 
+export function suggestMapIdentity(filename) {
+  const base = String(filename || '').replace(/\.zip$/i, '').trim().slice(0, 63);
+  const name = base || 'Offline map';
+  const packId = name.toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 31) || 'offline-map';
+  return {name, packId};
+}
+
 function u16(view, offset) { return view.getUint16(offset, true); }
 function u32(view, offset) { return view.getUint32(offset, true); }
 function putU16(view, offset, value) { view.setUint16(offset, value, true); }

--- a/docs/offline-map-packs.md
+++ b/docs/offline-map-packs.md
@@ -6,7 +6,7 @@ Pyxis can read prebuilt raster map packs from an SD card. Importers accept only 
 
 Open the Pyxis web flasher in current Chrome or Edge and use **Install Offline Maps**:
 
-1. Download an OSM Bright MUI ZIP from [Oxed's Map Tile Downloader](https://download.tiles.coalition.space/).
+1. Download an OSM Bright, Dark Matter, Positron, or Toner MUI ZIP from [Oxed's Map Tile Downloader](https://download.tiles.coalition.space/).
 2. Turn the T-Deck off, remove its SD card, and mount the card on the computer.
 3. Choose the ZIP, enter a map name and pack ID, and wait for local validation.
 4. Click **Install and Enable**, then choose the SD-card root.
@@ -40,10 +40,25 @@ coverage. Outside the detail area at z10-z16, the key is uncovered. If a
 higher-priority pack declares a tile but its file is missing, Pyxis safely tries
 the next compatible pack.
 
-The browser currently imports Coalition/MUI OSM Bright data into the bounded
-`osm-bright` map set. Newly installed packs take priority over earlier packs
-where their exact row-span coverage overlaps. Different styles or providers
-must use a different map set rather than being blended implicitly.
+The browser detects Coalition/MUI OSM Bright, Dark Matter, Positron, and Toner
+ZIP roots and places each style into a separate bounded map set. For rootless
+XYZ ZIPs, the user must select the correct style. Newly installed packs take
+priority over earlier packs of the same style where their exact row-span
+coverage overlaps; different styles are never blended implicitly.
+
+Each successful install publishes a bounded style snapshot at
+`/pyxis-map/map-sets/<style>.pmas` before updating the redundant active slots.
+When two or more valid snapshots are installed, use the style control in the
+Maps toolbar to cycle them. Pyxis probes only the four documented paths and
+never scans the SD card. Activation is committed and read back before the map
+reloads; a failed switch leaves the previous valid active slot available.
+
+The generated PMAS attribution follows the upstream style licenses as well as
+OpenStreetMap data: [OSM Bright](https://github.com/openmaptiles/osm-bright-gl-style),
+[Dark Matter](https://github.com/openmaptiles/dark-matter-gl-style),
+[Positron](https://github.com/openmaptiles/positron-gl-style), and
+[Toner](https://github.com/openmaptiles/maptiler-toner-gl-style). Do not remove
+or replace the attribution metadata when repackaging tiles.
 
 ## Input requirements
 

--- a/lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#include "Hardware/TDeck/ActiveMapSetCodec.h"
+
+#include <cstring>
+
+namespace Hardware {
+namespace TDeck {
+namespace {
+
+bool readString(const std::uint8_t* input, std::size_t end, std::size_t& position,
+                char* output, std::size_t capacity, bool identifier) {
+    if (position >= end || capacity < 2U) return false;
+    const std::size_t length = input[position++];
+    if (length == 0U || length >= capacity || length > end - position) return false;
+    for (std::size_t index = 0U; index < length; ++index) {
+        const std::uint8_t value = input[position + index];
+        if (value < 0x20U || value > 0x7eU) return false;
+        if (identifier && !((value >= static_cast<std::uint8_t>('a') &&
+                             value <= static_cast<std::uint8_t>('z')) ||
+                            (value >= static_cast<std::uint8_t>('0') &&
+                             value <= static_cast<std::uint8_t>('9')) ||
+                            value == static_cast<std::uint8_t>('_') ||
+                            value == static_cast<std::uint8_t>('-'))) return false;
+    }
+    std::memcpy(output, input + position, length);
+    output[length] = '\0';
+    position += length;
+    return true;
+}
+
+}  // namespace
+
+std::uint16_t ActiveMapSetCodec::readU16(const std::uint8_t* input) {
+    return static_cast<std::uint16_t>(input[0]) |
+        static_cast<std::uint16_t>(static_cast<std::uint16_t>(input[1]) << 8U);
+}
+
+std::uint32_t ActiveMapSetCodec::readU32(const std::uint8_t* input) {
+    return static_cast<std::uint32_t>(input[0]) |
+        (static_cast<std::uint32_t>(input[1]) << 8U) |
+        (static_cast<std::uint32_t>(input[2]) << 16U) |
+        (static_cast<std::uint32_t>(input[3]) << 24U);
+}
+
+void ActiveMapSetCodec::writeU32(std::uint8_t* output, std::uint32_t value) {
+    output[0] = static_cast<std::uint8_t>(value);
+    output[1] = static_cast<std::uint8_t>(value >> 8U);
+    output[2] = static_cast<std::uint8_t>(value >> 16U);
+    output[3] = static_cast<std::uint8_t>(value >> 24U);
+}
+
+std::uint32_t ActiveMapSetCodec::crc32(const std::uint8_t* input, std::size_t length) {
+    std::uint32_t crc = UINT32_C(0xffffffff);
+    for (std::size_t index = 0U; index < length; ++index) {
+        crc ^= input[index];
+        for (std::uint8_t bit = 0U; bit < 8U; ++bit) {
+            crc = (crc >> 1U) ^ ((crc & 1U) != 0U ? UINT32_C(0xedb88320) : 0U);
+        }
+    }
+    return ~crc;
+}
+
+bool ActiveMapSetCodec::decode(const std::uint8_t* input, std::size_t length,
+                               ActiveMapSetView& output) {
+    static const std::uint8_t magic[4] = {'P', 'M', 'A', 'S'};
+    if (input == NULL || length < 16U || length > MAX_SERIALIZED_SIZE ||
+        std::memcmp(input, magic, sizeof(magic)) != 0 || input[4] != 2U || input[5] != 0U ||
+        readU16(input + 6U) != length || readU32(input + length - 4U) != crc32(input, length - 4U)) {
+        return false;
+    }
+
+    ActiveMapSetView candidate = {};
+    candidate.generation = readU32(input + 8U);
+    if (candidate.generation == 0U) return false;
+    const std::size_t end = length - 4U;
+    std::size_t position = 12U;
+    if (!readString(input, end, position, candidate.map_set_id,
+                    sizeof(candidate.map_set_id), true) ||
+        !readString(input, end, position, candidate.attribution,
+                    sizeof(candidate.attribution), false) || position >= end) return false;
+    candidate.pack_count = input[position++];
+    if (candidate.pack_count == 0U || candidate.pack_count > MAX_PACKS) return false;
+
+    std::uint16_t total_spans = 0U;
+    for (std::uint8_t pack_index = 0U; pack_index < candidate.pack_count; ++pack_index) {
+        ActiveMapSetPackView& pack = candidate.packs[pack_index];
+        if (!readString(input, end, position, pack.pack_id, sizeof(pack.pack_id), true)) return false;
+        for (std::uint8_t previous = 0U; previous < pack_index; ++previous) {
+            if (std::strcmp(pack.pack_id, candidate.packs[previous].pack_id) == 0) return false;
+        }
+        if (position > end || end - position < 2U) return false;
+        pack.span_count = readU16(input + position); position += 2U;
+        if (pack.span_count == 0U || pack.span_count > MAX_ROW_SPANS ||
+            total_spans > MAX_ROW_SPANS - pack.span_count) return false;
+        const std::size_t span_bytes = static_cast<std::size_t>(pack.span_count) * ROW_SPAN_SIZE;
+        if (position > end || span_bytes > end - position) return false;
+        pack.span_bytes = input + position;
+
+        bool have_previous = false;
+        std::uint8_t previous_zoom = 0U;
+        std::uint32_t previous_y = 0U;
+        std::uint32_t previous_x_maximum = 0U;
+        for (std::uint16_t span_index = 0U; span_index < pack.span_count; ++span_index) {
+            const std::uint8_t* span = input + position;
+            const std::uint8_t zoom = span[0];
+            const std::uint32_t y = readU32(span + 1U);
+            const std::uint32_t x_minimum = readU32(span + 5U);
+            const std::uint32_t x_maximum = readU32(span + 9U);
+            if (zoom > Pyxis::MapPackManifest::MAX_ZOOM) return false;
+            const std::uint32_t edge = UINT32_C(1) << zoom;
+            if (y >= edge || x_minimum > x_maximum || x_maximum >= edge ||
+                (have_previous && (zoom < previous_zoom ||
+                 (zoom == previous_zoom && y < previous_y) ||
+                 (zoom == previous_zoom && y == previous_y &&
+                  x_minimum <= previous_x_maximum + 1U)))) return false;
+            previous_zoom = zoom; previous_y = y; previous_x_maximum = x_maximum;
+            have_previous = true; position += ROW_SPAN_SIZE;
+        }
+        total_spans = static_cast<std::uint16_t>(total_spans + pack.span_count);
+    }
+    if (position != end) return false;
+    candidate.total_span_count = total_spans;
+    output = candidate;
+    return true;
+}
+
+bool ActiveMapSetCodec::resequence(const std::uint8_t* input, std::size_t length,
+                                   std::uint32_t generation, std::uint8_t* output,
+                                   std::size_t capacity, std::size_t& written) {
+    written = 0U;
+    ActiveMapSetView view = {};
+    if (generation == 0U || output == NULL || capacity < length ||
+        !decode(input, length, view)) return false;
+    if (output != input) std::memcpy(output, input, length);
+    writeU32(output + 8U, generation);
+    writeU32(output + length - 4U, crc32(output, length - 4U));
+    written = length;
+    return true;
+}
+
+}  // namespace TDeck
+}  // namespace Hardware

--- a/lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.h
+++ b/lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef HARDWARE_TDECK_ACTIVE_MAP_SET_CODEC_H
+#define HARDWARE_TDECK_ACTIVE_MAP_SET_CODEC_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "UI/LXMF/MapPackManifest.h"
+
+namespace Hardware {
+namespace TDeck {
+
+struct ActiveMapSetPackView {
+    char pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+    std::uint16_t span_count;
+    const std::uint8_t* span_bytes;
+};
+
+struct ActiveMapSetView {
+    std::uint32_t generation;
+    char map_set_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+    char attribution[Pyxis::MapPackManifest::ATTRIBUTION_CAPACITY];
+    std::uint8_t pack_count;
+    std::uint16_t total_span_count;
+    ActiveMapSetPackView packs[8];
+};
+
+/** Strict, allocation-free codec for canonical PMAS version-2 records. */
+class ActiveMapSetCodec {
+public:
+    static const std::size_t MAX_SERIALIZED_SIZE = 7105U;
+    static const std::size_t MAX_PACKS = 8U;
+    static const std::size_t MAX_ROW_SPANS = 512U;
+    static const std::size_t ROW_SPAN_SIZE = 13U;
+
+    static bool decode(const std::uint8_t* input, std::size_t length, ActiveMapSetView& output);
+    static bool resequence(const std::uint8_t* input, std::size_t length,
+                           std::uint32_t generation, std::uint8_t* output,
+                           std::size_t capacity, std::size_t& written);
+    static std::uint32_t crc32(const std::uint8_t* input, std::size_t length);
+    static std::uint16_t readU16(const std::uint8_t* input);
+    static std::uint32_t readU32(const std::uint8_t* input);
+
+private:
+    static void writeU32(std::uint8_t* output, std::uint32_t value);
+};
+
+}  // namespace TDeck
+}  // namespace Hardware
+
+#endif

--- a/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.cpp
@@ -185,7 +185,9 @@ MapStyleCatalogResult MapStyleCatalog::discover() {
 }
 
 MapStyleCatalogResult MapStyleCatalog::activate(std::uint32_t expected_catalog_generation,
-                                                const char* style_id) {
+                                                const char* style_id,
+                                                BeginCommitCallback begin_commit,
+                                                void* commit_context) {
     if (expected_catalog_generation != catalog_generation_) return MapStyleCatalogResult::STALE_CATALOG;
     std::size_t style_index = 0U;
     if (!allowedIndex(style_id, style_index)) return MapStyleCatalogResult::UNKNOWN_STYLE;
@@ -251,6 +253,9 @@ MapStyleCatalogResult MapStyleCatalog::activate(std::uint32_t expected_catalog_g
             storage_.abortWrite(); return MapStyleCatalogResult::WRITE_FAILED;
         }
         offset += written;
+    }
+    if (begin_commit != NULL && !begin_commit(commit_context)) {
+        storage_.abortWrite(); return MapStyleCatalogResult::CANCELLED;
     }
     if (storage_.commitWrite() != TileStoreResult::OK) {
         storage_.abortWrite(); return MapStyleCatalogResult::WRITE_FAILED;

--- a/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.cpp
@@ -1,0 +1,277 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#include "Hardware/TDeck/MapStyleCatalog.h"
+#include "Hardware/TDeck/MapTilePack.h"
+
+#include <cstdio>
+#include <cstring>
+#if defined(ARDUINO_ARCH_ESP32)
+#include <esp_heap_caps.h>
+#endif
+
+namespace Hardware {
+namespace TDeck {
+namespace {
+
+const char* const STYLE_IDS[MapStyleCatalog::MAX_STYLES] = {
+    "osm-bright", "dark-matter", "positron", "toner"
+};
+
+}  // namespace
+
+const char MapStyleCatalog::ACTIVE_SLOT_0_PATH[] = "/pyxis-map/active-pack.0";
+const char MapStyleCatalog::ACTIVE_SLOT_1_PATH[] = "/pyxis-map/active-pack.1";
+
+MapStyleCatalog::MapStyleCatalog(MapTileStorage& storage)
+    : storage_(storage), styles_(), count_(0U), catalog_generation_(0U), buffers_() {
+#if defined(ARDUINO_ARCH_ESP32)
+    buffers_ = static_cast<std::uint8_t*>(heap_caps_malloc(
+        3U * ActiveMapSetCodec::MAX_SERIALIZED_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+#endif
+}
+
+MapStyleCatalog::~MapStyleCatalog() {
+#if defined(ARDUINO_ARCH_ESP32)
+    if (buffers_ != NULL) heap_caps_free(buffers_);
+    buffers_ = NULL;
+#endif
+}
+
+std::uint8_t* MapStyleCatalog::buffer(std::size_t index) {
+    if (index >= 3U) return NULL;
+#if defined(ARDUINO_ARCH_ESP32)
+    return buffers_ == NULL ? NULL : buffers_ + index * ActiveMapSetCodec::MAX_SERIALIZED_SIZE;
+#else
+    return buffers_[index];
+#endif
+}
+
+bool MapStyleCatalog::allowedIndex(const char* style_id, std::size_t& index) {
+    if (style_id == NULL) return false;
+    for (std::size_t candidate = 0U; candidate < MAX_STYLES; ++candidate) {
+        if (std::strcmp(style_id, STYLE_IDS[candidate]) == 0) {
+            index = candidate; return true;
+        }
+    }
+    return false;
+}
+
+void MapStyleCatalog::stylePath(std::size_t index, char* output, std::size_t capacity) {
+    if (output == NULL || capacity == 0U || index >= MAX_STYLES) return;
+    const int result = std::snprintf(output, capacity, "/pyxis-map/map-sets/%s.pmas", STYLE_IDS[index]);
+    if (result < 0 || static_cast<std::size_t>(result) >= capacity) output[0] = '\0';
+}
+
+MapStyleCatalog::FileState MapStyleCatalog::readRecord(const char* path, std::uint8_t* output,
+                                                        std::size_t& length,
+                                                        ActiveMapSetView& view) {
+    length = 0U;
+    if (output == NULL) return FileState::INDETERMINATE;
+    std::uint32_t declared_size = 0U;
+    const TileStoreResult begin = storage_.beginRead(path, declared_size);
+    if (begin == TileStoreResult::MISS) return FileState::MISSING;
+    if (begin != TileStoreResult::OK) return FileState::INDETERMINATE;
+    if (declared_size > ActiveMapSetCodec::MAX_SERIALIZED_SIZE) {
+        storage_.endRead(); return FileState::INVALID;
+    }
+    std::size_t total = 0U;
+    while (total < declared_size) {
+        std::size_t count = 0U;
+        const TileStoreResult result = storage_.readChunk(
+            output + total, static_cast<std::size_t>(declared_size) - total, count);
+        if (result != TileStoreResult::OK || count == 0U ||
+            count > static_cast<std::size_t>(declared_size) - total) {
+            storage_.endRead(); return FileState::INDETERMINATE;
+        }
+        total += count;
+    }
+    std::uint8_t trailing = 0U;
+    std::size_t trailing_count = 0U;
+    const TileStoreResult eof = storage_.readChunk(&trailing, 1U, trailing_count);
+    storage_.endRead();
+    if (eof != TileStoreResult::OK || trailing_count != 0U) return FileState::INDETERMINATE;
+    length = total;
+    return ActiveMapSetCodec::decode(output, total, view) ? FileState::PRESENT : FileState::INVALID;
+}
+
+bool MapStyleCatalog::sameRecord(const SlotState& first, const std::uint8_t* first_bytes,
+                                 const SlotState& second, const std::uint8_t* second_bytes) {
+    return first.length == second.length &&
+        std::memcmp(first_bytes, second_bytes, first.length) == 0;
+}
+
+MapStyleCatalogResult MapStyleCatalog::readActiveSlots(SlotState (&slots)[2]) {
+    const char* paths[2] = {ACTIVE_SLOT_0_PATH, ACTIVE_SLOT_1_PATH};
+    for (std::size_t index = 0U; index < 2U; ++index) {
+        slots[index].length = 0U; slots[index].view = ActiveMapSetView();
+        slots[index].state = readRecord(paths[index], buffer(index + 1U),
+                                        slots[index].length, slots[index].view);
+        if (slots[index].state == FileState::INDETERMINATE) {
+            return MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE;
+        }
+    }
+    if (slots[0].state == FileState::PRESENT && slots[1].state == FileState::PRESENT &&
+        slots[0].view.generation == slots[1].view.generation &&
+        !sameRecord(slots[0], buffer(1U), slots[1], buffer(2U))) {
+        return MapStyleCatalogResult::ACTIVE_CONFLICT;
+    }
+    return MapStyleCatalogResult::OK;
+}
+
+void MapStyleCatalog::copySummary(MapStyleSummary& output, const ActiveMapSetView& view,
+                                  bool active, bool synthesized) {
+    output = MapStyleSummary();
+    std::strcpy(output.id, view.map_set_id);
+    std::strcpy(output.attribution, view.attribution);
+    output.pack_count = view.pack_count;
+    output.span_count = view.total_span_count;
+    output.active = active;
+    output.synthesized = synthesized;
+}
+
+void MapStyleCatalog::advanceCatalogGeneration() {
+    ++catalog_generation_;
+    if (catalog_generation_ == 0U) ++catalog_generation_;
+}
+
+MapStyleCatalogResult MapStyleCatalog::discover() {
+    if (!storage_.isAvailable()) return MapStyleCatalogResult::STORAGE_UNAVAILABLE;
+    if (buffer(0U) == NULL) return MapStyleCatalogResult::INSUFFICIENT_MEMORY;
+
+    MapStyleSummary candidates[MAX_STYLES] = {};
+    std::size_t candidate_count = 0U;
+    for (std::size_t index = 0U; index < MAX_STYLES; ++index) {
+        char path[80] = {};
+        stylePath(index, path, sizeof(path));
+        std::size_t length = 0U; ActiveMapSetView view = {};
+        const FileState state = readRecord(path, buffer(0U), length, view);
+        if (state == FileState::INDETERMINATE) return MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE;
+        if (state == FileState::INVALID ||
+            (state == FileState::PRESENT && std::strcmp(view.map_set_id, STYLE_IDS[index]) != 0)) {
+            return MapStyleCatalogResult::INVALID_STYLE_RECORD;
+        }
+        if (state == FileState::PRESENT) copySummary(candidates[candidate_count++], view, false, false);
+    }
+
+    SlotState slots[2] = {};
+    const MapStyleCatalogResult active_result = readActiveSlots(slots);
+    if (active_result != MapStyleCatalogResult::OK) return active_result;
+    const SlotState* current = NULL;
+    if (slots[0].state == FileState::PRESENT || slots[1].state == FileState::PRESENT) {
+        current = slots[1].state != FileState::PRESENT ||
+            (slots[0].state == FileState::PRESENT &&
+             slots[0].view.generation >= slots[1].view.generation) ? &slots[0] : &slots[1];
+    }
+    if (current != NULL) {
+        std::size_t allowlist_index = 0U;
+        if (allowedIndex(current->view.map_set_id, allowlist_index)) {
+            bool found = false;
+            for (std::size_t index = 0U; index < candidate_count; ++index) {
+                if (std::strcmp(candidates[index].id, current->view.map_set_id) == 0) {
+                    candidates[index].active = true; found = true; break;
+                }
+            }
+            if (!found && candidate_count < MAX_STYLES) {
+                copySummary(candidates[candidate_count++], current->view, true, true);
+            }
+        }
+    }
+
+    std::memcpy(styles_, candidates, candidate_count * sizeof(MapStyleSummary));
+    count_ = candidate_count;
+    advanceCatalogGeneration();
+    return MapStyleCatalogResult::OK;
+}
+
+MapStyleCatalogResult MapStyleCatalog::activate(std::uint32_t expected_catalog_generation,
+                                                const char* style_id) {
+    if (expected_catalog_generation != catalog_generation_) return MapStyleCatalogResult::STALE_CATALOG;
+    std::size_t style_index = 0U;
+    if (!allowedIndex(style_id, style_index)) return MapStyleCatalogResult::UNKNOWN_STYLE;
+    bool catalogued = false;
+    for (std::size_t index = 0U; index < count_; ++index) {
+        if (std::strcmp(styles_[index].id, style_id) == 0) { catalogued = true; break; }
+    }
+    if (!catalogued) return MapStyleCatalogResult::UNKNOWN_STYLE;
+    if (!storage_.isAvailable()) return MapStyleCatalogResult::STORAGE_UNAVAILABLE;
+    if (buffer(0U) == NULL) return MapStyleCatalogResult::INSUFFICIENT_MEMORY;
+
+    char selected_path[80] = {};
+    stylePath(style_index, selected_path, sizeof(selected_path));
+    std::size_t selected_length = 0U; ActiveMapSetView selected_view = {};
+    const FileState selected_state = readRecord(selected_path, buffer(0U), selected_length, selected_view);
+    if (selected_state != FileState::PRESENT || std::strcmp(selected_view.map_set_id, style_id) != 0) {
+        return MapStyleCatalogResult::INVALID_STYLE_RECORD;
+    }
+
+    const MapTilePackResult semantic = MapTilePack::validateMapSet(
+        storage_, selected_view, buffer(1U), ActiveMapSetCodec::MAX_SERIALIZED_SIZE);
+    if (semantic != MapTilePackResult::OK) {
+        if (semantic == MapTilePackResult::STORAGE_UNAVAILABLE)
+            return MapStyleCatalogResult::STORAGE_UNAVAILABLE;
+        if (semantic == MapTilePackResult::INSUFFICIENT_MEMORY)
+            return MapStyleCatalogResult::INSUFFICIENT_MEMORY;
+        if (semantic == MapTilePackResult::IO_ERROR || semantic == MapTilePackResult::BUSY)
+            return MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE;
+        return MapStyleCatalogResult::INVALID_STYLE_RECORD;
+    }
+
+    SlotState slots[2] = {};
+    const MapStyleCatalogResult active_result = readActiveSlots(slots);
+    if (active_result != MapStyleCatalogResult::OK) return active_result;
+    std::uint32_t highest = 0U;
+    for (std::size_t index = 0U; index < 2U; ++index) {
+        if (slots[index].state == FileState::PRESENT && slots[index].view.generation > highest) {
+            highest = slots[index].view.generation;
+        }
+    }
+    if (highest == UINT32_MAX) return MapStyleCatalogResult::GENERATION_EXHAUSTED;
+
+    std::size_t target = 0U;
+    if (slots[0].state != FileState::PRESENT) target = 0U;
+    else if (slots[1].state != FileState::PRESENT) target = 1U;
+    else target = slots[0].view.generation <= slots[1].view.generation ? 0U : 1U;
+    const std::uint32_t next_generation = highest + 1U;
+    std::size_t write_length = 0U;
+    if (!ActiveMapSetCodec::resequence(buffer(0U), selected_length, next_generation,
+                                       buffer(0U), ActiveMapSetCodec::MAX_SERIALIZED_SIZE,
+                                       write_length)) return MapStyleCatalogResult::INVALID_STYLE_RECORD;
+
+    const char* target_path = target == 0U ? ACTIVE_SLOT_0_PATH : ACTIVE_SLOT_1_PATH;
+    if (storage_.beginWrite(target_path) != TileStoreResult::OK) {
+        storage_.abortWrite(); return MapStyleCatalogResult::WRITE_FAILED;
+    }
+    std::size_t offset = 0U;
+    while (offset < write_length) {
+        std::size_t written = 0U;
+        const TileStoreResult result = storage_.writeChunk(buffer(0U) + offset,
+                                                            write_length - offset, written);
+        if (result != TileStoreResult::OK || written == 0U || written > write_length - offset) {
+            storage_.abortWrite(); return MapStyleCatalogResult::WRITE_FAILED;
+        }
+        offset += written;
+    }
+    if (storage_.commitWrite() != TileStoreResult::OK) {
+        storage_.abortWrite(); return MapStyleCatalogResult::WRITE_FAILED;
+    }
+
+    std::size_t readback_length = 0U; ActiveMapSetView readback_view = {};
+    const FileState readback_state = readRecord(target_path, buffer(target + 1U),
+                                                 readback_length, readback_view);
+    if (readback_state != FileState::PRESENT || readback_length != write_length ||
+        std::memcmp(buffer(target + 1U), buffer(0U), write_length) != 0 ||
+        readback_view.generation != next_generation ||
+        std::strcmp(readback_view.map_set_id, style_id) != 0) {
+        return MapStyleCatalogResult::READBACK_MISMATCH;
+    }
+
+    for (std::size_t index = 0U; index < count_; ++index) {
+        styles_[index].active = std::strcmp(styles_[index].id, style_id) == 0;
+    }
+    advanceCatalogGeneration();
+    return MapStyleCatalogResult::OK;
+}
+
+}  // namespace TDeck
+}  // namespace Hardware

--- a/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.h
+++ b/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.h
@@ -23,6 +23,7 @@ enum class MapStyleCatalogResult : std::uint8_t {
     STALE_CATALOG,
     UNKNOWN_STYLE,
     GENERATION_EXHAUSTED,
+    CANCELLED,
     WRITE_FAILED,
     READBACK_MISMATCH
 };
@@ -39,6 +40,8 @@ struct MapStyleSummary {
 /** Fixed-allowlist PMAS discovery and redundant-slot transactional activation. */
 class MapStyleCatalog {
 public:
+    typedef bool (*BeginCommitCallback)(void* context);
+
     static const std::size_t MAX_STYLES = 4U;
     static const char ACTIVE_SLOT_0_PATH[];
     static const char ACTIVE_SLOT_1_PATH[];
@@ -48,7 +51,9 @@ public:
 
     MapStyleCatalogResult discover();
     MapStyleCatalogResult activate(std::uint32_t expected_catalog_generation,
-                                   const char* style_id);
+                                   const char* style_id,
+                                   BeginCommitCallback begin_commit = NULL,
+                                   void* commit_context = NULL);
 
     std::size_t count() const { return count_; }
     const MapStyleSummary* style(std::size_t index) const {

--- a/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.h
+++ b/lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef HARDWARE_TDECK_MAP_STYLE_CATALOG_H
+#define HARDWARE_TDECK_MAP_STYLE_CATALOG_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "Hardware/TDeck/ActiveMapSetCodec.h"
+#include "Hardware/TDeck/MapTileStore.h"
+
+namespace Hardware {
+namespace TDeck {
+
+enum class MapStyleCatalogResult : std::uint8_t {
+    OK = 0,
+    STORAGE_UNAVAILABLE,
+    INSUFFICIENT_MEMORY,
+    INVALID_STYLE_RECORD,
+    ACTIVE_IO_INDETERMINATE,
+    ACTIVE_CONFLICT,
+    STALE_CATALOG,
+    UNKNOWN_STYLE,
+    GENERATION_EXHAUSTED,
+    WRITE_FAILED,
+    READBACK_MISMATCH
+};
+
+struct MapStyleSummary {
+    char id[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+    char attribution[Pyxis::MapPackManifest::ATTRIBUTION_CAPACITY];
+    std::uint8_t pack_count;
+    std::uint16_t span_count;
+    bool active;
+    bool synthesized;
+};
+
+/** Fixed-allowlist PMAS discovery and redundant-slot transactional activation. */
+class MapStyleCatalog {
+public:
+    static const std::size_t MAX_STYLES = 4U;
+    static const char ACTIVE_SLOT_0_PATH[];
+    static const char ACTIVE_SLOT_1_PATH[];
+
+    explicit MapStyleCatalog(MapTileStorage& storage);
+    ~MapStyleCatalog();
+
+    MapStyleCatalogResult discover();
+    MapStyleCatalogResult activate(std::uint32_t expected_catalog_generation,
+                                   const char* style_id);
+
+    std::size_t count() const { return count_; }
+    const MapStyleSummary* style(std::size_t index) const {
+        return index < count_ ? &styles_[index] : NULL;
+    }
+    std::uint32_t generation() const { return catalog_generation_; }
+
+private:
+    enum class FileState : std::uint8_t { PRESENT, MISSING, INVALID, INDETERMINATE };
+    struct SlotState {
+        FileState state;
+        std::size_t length;
+        ActiveMapSetView view;
+    };
+
+    MapTileStorage& storage_;
+    MapStyleSummary styles_[MAX_STYLES];
+    std::size_t count_;
+    std::uint32_t catalog_generation_;
+#if defined(ARDUINO_ARCH_ESP32)
+    std::uint8_t* buffers_;
+#else
+    std::uint8_t buffers_[3][ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+#endif
+
+    MapStyleCatalog(const MapStyleCatalog&);
+    MapStyleCatalog& operator=(const MapStyleCatalog&);
+
+    std::uint8_t* buffer(std::size_t index);
+    FileState readRecord(const char* path, std::uint8_t* output,
+                         std::size_t& length, ActiveMapSetView& view);
+    MapStyleCatalogResult readActiveSlots(SlotState (&slots)[2]);
+    static bool allowedIndex(const char* style_id, std::size_t& index);
+    static void stylePath(std::size_t index, char* output, std::size_t capacity);
+    static bool sameRecord(const SlotState& first, const std::uint8_t* first_bytes,
+                           const SlotState& second, const std::uint8_t* second_bytes);
+    static void copySummary(MapStyleSummary& output, const ActiveMapSetView& view,
+                            bool active, bool synthesized);
+    void advanceCatalogGeneration();
+};
+
+}  // namespace TDeck
+}  // namespace Hardware
+
+#endif

--- a/lib/tdeck_ui/Hardware/TDeck/MapTilePack.cpp
+++ b/lib/tdeck_ui/Hardware/TDeck/MapTilePack.cpp
@@ -57,23 +57,34 @@ bool decodeSelection(const std::uint8_t* input, std::size_t length,
     return MapTilePack::isValidPackId(pack_id);
 }
 
-bool readSelectionString(const std::uint8_t* input, std::size_t end, std::size_t& position,
-                         char* output, std::size_t capacity, bool identifier) {
-    if (input == NULL || output == NULL || capacity < 2U || position >= end) return false;
-    const std::size_t length = input[position++];
-    if (length == 0U || length >= capacity || position + length > end) return false;
-    for (std::size_t index = 0U; index < length; ++index) {
-        const std::uint8_t value = input[position + index];
-        if (value < 0x20U || value > 0x7eU) return false;
-        if (identifier && !((value >= 'a' && value <= 'z') ||
-                            (value >= '0' && value <= '9') || value == '_' || value == '-')) {
-            return false;
-        }
+struct StylePolicy {
+    const char* id;
+    const char* attribution;
+    const char* source;
+    const char* license;
+};
+
+const StylePolicy STYLE_POLICIES[] = {
+    {"osm-bright", "(c) OpenMapTiles (c) OpenStreetMap contributors",
+     "Oxed's Map Tile Downloader (OSM Bright)",
+     "OSM ODbL; style CC-BY-4.0/BSD-3-Clause"},
+    {"dark-matter", "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+     "Oxed's Map Tile Downloader (Dark Matter)",
+     "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)"},
+    {"positron", "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+     "Oxed's Map Tile Downloader (Positron)",
+     "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)"},
+    {"toner", "(c) MapTiler (c) OpenStreetMap contributors",
+     "Oxed's Map Tile Downloader (Toner)",
+     "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)"},
+};
+
+const StylePolicy* findStylePolicy(const char* id) {
+    for (std::size_t index = 0U; index < sizeof(STYLE_POLICIES) / sizeof(STYLE_POLICIES[0]);
+         ++index) {
+        if (std::strcmp(id, STYLE_POLICIES[index].id) == 0) return &STYLE_POLICIES[index];
     }
-    std::memcpy(output, input + position, length);
-    output[length] = '\0';
-    position += length;
-    return true;
+    return NULL;
 }
 
 }  // namespace
@@ -90,7 +101,8 @@ MapTilePack::MapTilePack(MapTileStorage& storage)
       active_selection_buffer_(0U) {
 #if defined(ARDUINO_ARCH_ESP32)
     selection_buffers_ = static_cast<std::uint8_t*>(heap_caps_malloc(
-        2U * ACTIVE_SELECTION_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+        2U * ACTIVE_SELECTION_SIZE + MANIFEST_BUFFER_CAPACITY,
+        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
 #endif
 }
 
@@ -116,6 +128,12 @@ bool MapTilePack::isValidPackId(const char* pack_id) {
     return length > 0U && length < Pyxis::MapPackManifest::PACK_ID_CAPACITY;
 }
 
+bool MapTilePack::selectionRecordsEqual(const std::uint8_t* first, std::size_t first_length,
+                                        const std::uint8_t* second, std::size_t second_length) {
+    return first != NULL && second != NULL && first_length == second_length &&
+        first_length <= ACTIVE_SELECTION_SIZE && std::memcmp(first, second, first_length) == 0;
+}
+
 bool MapTilePack::isValidKey(const TileKey& key) {
     if (key.zoom > Pyxis::MapPackManifest::MAX_ZOOM) return false;
     const std::uint32_t edge = UINT32_C(1) << key.zoom;
@@ -132,68 +150,133 @@ std::uint8_t* MapTilePack::selectionBuffer(std::uint8_t index) {
 #endif
 }
 
+std::uint8_t* MapTilePack::manifestBuffer() {
+#if defined(ARDUINO_ARCH_ESP32)
+    return selection_buffers_ == NULL ? NULL : selection_buffers_ + 2U * ACTIVE_SELECTION_SIZE;
+#else
+    return manifest_buffer_;
+#endif
+}
+
+bool MapTilePack::fileMatches(const char* path, const std::uint8_t* expected,
+                              std::size_t length) {
+    if (expected == NULL || length > ACTIVE_SELECTION_SIZE) return false;
+    std::uint32_t declared_size = 0U;
+    if (storage_.beginRead(path, declared_size) != TileStoreResult::OK) return false;
+    if (declared_size != length) { storage_.endRead(); return false; }
+    std::size_t offset = 0U;
+    std::uint8_t chunk[64];
+    while (offset < length) {
+        const std::size_t wanted = (length - offset) < sizeof(chunk)
+            ? length - offset : sizeof(chunk);
+        std::size_t count = 0U;
+        const TileStoreResult result = storage_.readChunk(chunk, wanted, count);
+        if (result != TileStoreResult::OK || count == 0U || count > wanted ||
+            !selectionRecordsEqual(chunk, count, expected + offset, count)) {
+            storage_.endRead(); return false;
+        }
+        offset += count;
+    }
+    std::uint8_t trailing = 0U; std::size_t trailing_count = 0U;
+    const TileStoreResult eof = storage_.readChunk(&trailing, 1U, trailing_count);
+    storage_.endRead();
+    return eof == TileStoreResult::OK && trailing_count == 0U;
+}
+
+MapTilePackResult MapTilePack::validateMapSet(MapTileStorage& storage,
+                                              const ActiveMapSetView& view,
+                                              std::uint8_t* scratch,
+                                              std::size_t scratch_capacity) {
+    const StylePolicy* policy = findStylePolicy(view.map_set_id);
+    if (policy == NULL || scratch == NULL || scratch_capacity < MANIFEST_BUFFER_CAPACITY) {
+        return policy == NULL ? MapTilePackResult::INVALID_MANIFEST
+                              : MapTilePackResult::INSUFFICIENT_MEMORY;
+    }
+    const bool legacy_bright = std::strcmp(view.map_set_id, "osm-bright") == 0 &&
+        std::strcmp(view.attribution, "Map data (c) OpenStreetMap contributors") == 0;
+    const bool canonical = std::strcmp(view.attribution, policy->attribution) == 0;
+    if (!legacy_bright && !canonical) return MapTilePackResult::INVALID_MANIFEST;
+
+    for (std::uint8_t index = 0U; index < view.pack_count; ++index) {
+        char path[PATH_CAPACITY];
+        MapTilePackResult result = manifestPath(view.packs[index].pack_id, path, sizeof(path));
+        if (result != MapTilePackResult::OK) return result;
+        std::uint32_t declared_size = 0U;
+        const TileStoreResult begin = storage.beginRead(path, declared_size);
+        if (begin == TileStoreResult::MISS) return MapTilePackResult::MANIFEST_MISSING;
+        if (begin == TileStoreResult::STORAGE_UNAVAILABLE)
+            return MapTilePackResult::STORAGE_UNAVAILABLE;
+        if (begin == TileStoreResult::BUSY) return MapTilePackResult::BUSY;
+        if (begin != TileStoreResult::OK) return MapTilePackResult::IO_ERROR;
+        if (declared_size > scratch_capacity) {
+            storage.endRead(); return MapTilePackResult::MANIFEST_TOO_LARGE;
+        }
+        std::size_t length = 0U;
+        while (length < declared_size) {
+            std::size_t count = 0U;
+            const TileStoreResult read = storage.readChunk(
+                scratch + length, static_cast<std::size_t>(declared_size) - length, count);
+            if (read != TileStoreResult::OK || count == 0U ||
+                count > static_cast<std::size_t>(declared_size) - length) {
+                storage.endRead();
+                return read == TileStoreResult::BUSY ? MapTilePackResult::BUSY
+                                                     : MapTilePackResult::IO_ERROR;
+            }
+            length += count;
+        }
+        std::uint8_t trailing = 0U; std::size_t trailing_count = 0U;
+        const TileStoreResult eof = storage.readChunk(&trailing, 1U, trailing_count);
+        storage.endRead();
+        if (eof != TileStoreResult::OK || trailing_count != 0U) {
+            return eof == TileStoreResult::BUSY ? MapTilePackResult::BUSY
+                                                : MapTilePackResult::IO_ERROR;
+        }
+        Pyxis::MapPackManifest manifest = {};
+        if (Pyxis::MapPackManifest::parse(scratch, length, manifest) !=
+                Pyxis::ManifestResult::OK ||
+            manifest.format_version != Pyxis::MapPackManifest::FORMAT_VERSION ||
+            std::strcmp(manifest.pack_id, view.packs[index].pack_id) != 0 ||
+            std::strcmp(manifest.attribution, view.attribution) != 0 ||
+            manifest.row_span_count != view.packs[index].span_count ||
+            std::memcmp(manifest.row_span_bytes, view.packs[index].span_bytes,
+                        static_cast<std::size_t>(manifest.row_span_count) *
+                            ActiveMapSetCodec::ROW_SPAN_SIZE) != 0) {
+            return MapTilePackResult::INVALID_MANIFEST;
+        }
+        if (legacy_bright) {
+            if (std::strcmp(manifest.source, "Coalition MUI OSM Bright user download") != 0 ||
+                std::strcmp(manifest.license, "ODbL-1.0") != 0) {
+                return MapTilePackResult::INVALID_MANIFEST;
+            }
+        } else if (std::strcmp(manifest.source, policy->source) != 0 ||
+                   std::strcmp(manifest.license, policy->license) != 0) {
+            return MapTilePackResult::INVALID_MANIFEST;
+        }
+    }
+    return MapTilePackResult::OK;
+}
+
 bool MapTilePack::parseMapSetSelection(const std::uint8_t* input, std::size_t length,
                                        std::uint32_t& generation,
                                        Pyxis::MapPackManifest& metadata,
                                        ActivePackView* packs, std::uint8_t& pack_count) {
-    static const std::uint8_t magic[4] = {'P', 'M', 'A', 'S'};
-    if (input == NULL || packs == NULL || length < 16U || length > ACTIVE_SELECTION_SIZE ||
-        std::memcmp(input, magic, sizeof(magic)) != 0 || input[4] != 2U || input[5] != 0U ||
-        selectionU16(input + 6U) != length ||
-        selectionU32(input + length - 4U) != selectionCrc32(input, length - 4U)) return false;
-    generation = selectionU32(input + 8U);
-    if (generation == 0U) return false;
+    if (packs == NULL) return false;
+    ActiveMapSetView view = {};
+    if (!ActiveMapSetCodec::decode(input, length, view)) return false;
+    generation = view.generation;
     metadata = Pyxis::MapPackManifest();
-    std::size_t position = 12U;
-    if (!readSelectionString(input, length - 4U, position, metadata.pack_id,
-                             sizeof(metadata.pack_id), true)) return false;
+    std::strcpy(metadata.pack_id, view.map_set_id);
     std::strncpy(metadata.name, metadata.pack_id, sizeof(metadata.name) - 1U);
-    if (!readSelectionString(input, length - 4U, position, metadata.attribution,
-                             sizeof(metadata.attribution), false) || position >= length - 4U) return false;
+    std::strcpy(metadata.attribution, view.attribution);
     std::strncpy(metadata.source, "active map set", sizeof(metadata.source) - 1U);
-    pack_count = input[position++];
-    if (pack_count == 0U || pack_count > MAX_ACTIVE_PACKS) return false;
-    std::uint16_t total_spans = 0U;
+    pack_count = view.pack_count;
     for (std::uint8_t pack_index = 0U; pack_index < pack_count; ++pack_index) {
         ActivePackView& pack = packs[pack_index];
-        if (!readSelectionString(input, length - 4U, position, pack.pack_id,
-                                 sizeof(pack.pack_id), true)) return false;
-        for (std::uint8_t previous_pack = 0U; previous_pack < pack_index; ++previous_pack) {
-            if (std::strcmp(pack.pack_id, packs[previous_pack].pack_id) == 0) return false;
-        }
-        if (position + 2U > length - 4U) return false;
-        pack.span_count = selectionU16(input + position);
-        position += 2U;
-        if (pack.span_count == 0U || pack.span_count > MAX_ACTIVE_ROW_SPANS ||
-            total_spans > MAX_ACTIVE_ROW_SPANS - pack.span_count ||
-            position + static_cast<std::size_t>(pack.span_count) * 13U > length - 4U) return false;
-        pack.span_bytes = input + position;
-        std::uint8_t previous_zoom = 0U;
-        std::uint32_t previous_y = 0U;
-        std::uint32_t previous_x_maximum = 0U;
-        bool have_previous = false;
-        for (std::uint16_t span_index = 0U; span_index < pack.span_count; ++span_index) {
-            const std::uint8_t* span = input + position;
-            const std::uint8_t zoom = span[0];
-            const std::uint32_t y = selectionU32(span + 1U);
-            const std::uint32_t x_minimum = selectionU32(span + 5U);
-            const std::uint32_t x_maximum = selectionU32(span + 9U);
-            if (zoom > Pyxis::MapPackManifest::MAX_ZOOM) return false;
-            const std::uint32_t edge = UINT32_C(1) << zoom;
-            if (y >= edge || x_minimum > x_maximum || x_maximum >= edge ||
-                (have_previous && (zoom < previous_zoom ||
-                 (zoom == previous_zoom && y < previous_y) ||
-                 (zoom == previous_zoom && y == previous_y &&
-                  x_minimum <= previous_x_maximum + 1U)))) return false;
-            previous_zoom = zoom;
-            previous_y = y;
-            previous_x_maximum = x_maximum;
-            have_previous = true;
-            position += 13U;
-        }
-        total_spans = static_cast<std::uint16_t>(total_spans + pack.span_count);
+        std::strcpy(pack.pack_id, view.packs[pack_index].pack_id);
+        pack.span_count = view.packs[pack_index].span_count;
+        pack.span_bytes = view.packs[pack_index].span_bytes;
     }
-    return position == length - 4U;
+    return true;
 }
 
 bool MapTilePack::spanCovers(const ActivePackView& pack, const TileKey& key) {
@@ -254,6 +337,7 @@ MapTilePackResult MapTilePack::loadFile(const char* path, std::uint8_t* output,
     const TileStoreResult begin = storage_.beginRead(path, declared_size);
     if (begin == TileStoreResult::MISS) return missing_result;
     if (begin == TileStoreResult::STORAGE_UNAVAILABLE) return MapTilePackResult::STORAGE_UNAVAILABLE;
+    if (begin == TileStoreResult::BUSY) return MapTilePackResult::BUSY;
     if (begin != TileStoreResult::OK) return MapTilePackResult::IO_ERROR;
 
     if (declared_size > capacity) {
@@ -306,8 +390,9 @@ MapTilePackResult MapTilePack::initialize() {
     const std::uint8_t candidate_buffer = static_cast<std::uint8_t>(active_selection_buffer_ ^ 1U);
     const char* slot_paths[2] = {ACTIVE_PACK_SLOT_0_PATH, ACTIVE_PACK_SLOT_1_PATH};
     std::uint32_t slot_generations[2] = {0U, 0U};
-    std::uint32_t slot_checksums[2] = {0U, 0U};
+    std::size_t slot_lengths[2] = {0U, 0U};
     bool slot_valid[2] = {false, false};
+    bool redundant_record_present = false;
     MapTilePackResult result = MapTilePackResult::NO_SELECTION;
     for (std::size_t slot = 0U; slot < 2U; ++slot) {
         std::size_t record_length = 0U;
@@ -315,6 +400,7 @@ MapTilePackResult MapTilePack::initialize() {
                           record_length, MapTilePackResult::NO_SELECTION,
                           MapTilePackResult::INVALID_PACK_ID);
         if (result == MapTilePackResult::OK) {
+            redundant_record_present = true;
             char legacy_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
             Pyxis::MapPackManifest map_set_metadata = {};
             ActivePackView map_set_packs[MAX_ACTIVE_PACKS] = {};
@@ -325,82 +411,150 @@ MapTilePackResult MapTilePack::initialize() {
                                      slot_generations[slot], map_set_metadata,
                                      map_set_packs, map_set_pack_count)) {
                 slot_valid[slot] = true;
-                slot_checksums[slot] = selectionU32(selectionBuffer(candidate_buffer) + record_length - 4U);
+                slot_lengths[slot] = record_length;
             }
-        } else if (result != MapTilePackResult::NO_SELECTION &&
-                   result != MapTilePackResult::INVALID_PACK_ID) {
+        } else if (result == MapTilePackResult::INVALID_PACK_ID) {
+            redundant_record_present = true;
+        } else if (result != MapTilePackResult::NO_SELECTION) {
             const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
                 ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
             return failInitialize(result, state, had_selection);
         }
     }
-    if (slot_valid[0] && slot_valid[1] && slot_generations[0] == slot_generations[1] &&
-        slot_checksums[0] != slot_checksums[1]) {
+    if (slot_valid[0] && slot_valid[1] && slot_generations[0] == slot_generations[1]) {
+        std::size_t first_length = 0U;
+        result = loadFile(slot_paths[0], selectionBuffer(candidate_buffer), ACTIVE_SELECTION_SIZE,
+                          first_length, MapTilePackResult::NO_SELECTION,
+                          MapTilePackResult::INVALID_PACK_ID);
+        if (result != MapTilePackResult::OK || first_length != slot_lengths[0] ||
+            slot_lengths[0] != slot_lengths[1] ||
+            !fileMatches(slot_paths[1], selectionBuffer(candidate_buffer), first_length)) {
+            return failInitialize(MapTilePackResult::INVALID_PACK_ID,
+                                  MapTilePackStatus::INVALID_SELECTION, had_selection);
+        }
+    }
+
+    if (slot_valid[0] || slot_valid[1]) {
+        std::size_t order[2] = {0U, 1U};
+        if (!slot_valid[0] || (slot_valid[1] && slot_generations[1] > slot_generations[0])) {
+            order[0] = 1U; order[1] = 0U;
+        }
+        MapTilePackResult deterministic_failure = MapTilePackResult::INVALID_PACK_ID;
+        for (std::size_t attempt = 0U; attempt < 2U; ++attempt) {
+            const std::size_t chosen = order[attempt];
+            if (!slot_valid[chosen]) continue;
+            std::size_t record_length = 0U;
+            result = loadFile(slot_paths[chosen], selectionBuffer(candidate_buffer), ACTIVE_SELECTION_SIZE,
+                              record_length, MapTilePackResult::NO_SELECTION,
+                              MapTilePackResult::INVALID_PACK_ID);
+            if (result != MapTilePackResult::OK) {
+                const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
+                    ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
+                return failInitialize(result, state, had_selection);
+            }
+
+            std::uint32_t generation = 0U;
+            Pyxis::MapPackManifest map_set_metadata = {};
+            ActivePackView map_set_packs[MAX_ACTIVE_PACKS] = {};
+            std::uint8_t map_set_pack_count = 0U;
+            ActiveMapSetView map_set_view = {};
+            if (ActiveMapSetCodec::decode(selectionBuffer(candidate_buffer), record_length,
+                                          map_set_view) &&
+                parseMapSetSelection(selectionBuffer(candidate_buffer), record_length, generation,
+                                     map_set_metadata, map_set_packs, map_set_pack_count)) {
+                result = validateMapSet(storage_, map_set_view, manifestBuffer(),
+                                        MANIFEST_BUFFER_CAPACITY);
+                if (result == MapTilePackResult::OK) {
+                    manifest_ = map_set_metadata;
+                    std::memcpy(active_packs_, map_set_packs,
+                                static_cast<std::size_t>(map_set_pack_count) * sizeof(ActivePackView));
+                    active_pack_count_ = map_set_pack_count;
+                    map_set_active_ = true;
+                    selection_generation_ = generation;
+                    active_selection_buffer_ = candidate_buffer;
+                    status_ = MapTilePackStatus::READY;
+                    return MapTilePackResult::OK;
+                }
+            } else {
+                char pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
+                if (!decodeSelection(selectionBuffer(candidate_buffer), record_length,
+                                     pack_id, generation)) {
+                    result = MapTilePackResult::INVALID_PACK_ID;
+                } else {
+                    char path[PATH_CAPACITY];
+                    result = manifestPath(pack_id, path, sizeof(path));
+                    std::size_t manifest_length = 0U;
+                    if (result == MapTilePackResult::OK) {
+                        result = loadFile(path, manifestBuffer(), MANIFEST_BUFFER_CAPACITY,
+                                          manifest_length, MapTilePackResult::MANIFEST_MISSING,
+                                          MapTilePackResult::MANIFEST_TOO_LARGE);
+                    }
+                    Pyxis::MapPackManifest candidate = {};
+                    if (result == MapTilePackResult::OK &&
+                        Pyxis::MapPackManifest::parse(manifestBuffer(), manifest_length, candidate) !=
+                            Pyxis::ManifestResult::OK) {
+                        result = MapTilePackResult::INVALID_MANIFEST;
+                    }
+                    if (result == MapTilePackResult::OK &&
+                        std::strcmp(pack_id, candidate.pack_id) != 0) {
+                        result = MapTilePackResult::PACK_ID_MISMATCH;
+                    }
+                    if (result == MapTilePackResult::OK) {
+                        manifest_ = candidate;
+                        active_pack_count_ = 0U;
+                        map_set_active_ = false;
+                        selection_generation_ = generation;
+                        active_selection_buffer_ = candidate_buffer;
+                        status_ = MapTilePackStatus::READY;
+                        return MapTilePackResult::OK;
+                    }
+                }
+            }
+            if (result == MapTilePackResult::STORAGE_UNAVAILABLE ||
+                result == MapTilePackResult::IO_ERROR || result == MapTilePackResult::BUSY ||
+                result == MapTilePackResult::INSUFFICIENT_MEMORY) {
+                const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
+                    ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
+                return failInitialize(result, state, had_selection);
+            }
+            deterministic_failure = result;
+        }
+        return failInitialize(deterministic_failure, MapTilePackStatus::INVALID_SELECTION,
+                              had_selection);
+    }
+    if (redundant_record_present) {
         return failInitialize(MapTilePackResult::INVALID_PACK_ID,
                               MapTilePackStatus::INVALID_SELECTION, had_selection);
     }
 
     char selected_pack_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
     std::uint32_t selected_generation = 0U;
-    if (slot_valid[0] || slot_valid[1]) {
-        const std::size_t chosen = !slot_valid[1] ||
-            (slot_valid[0] && slot_generations[0] >= slot_generations[1]) ? 0U : 1U;
-        std::size_t record_length = 0U;
-        result = loadFile(slot_paths[chosen], selectionBuffer(candidate_buffer), ACTIVE_SELECTION_SIZE,
-                          record_length, MapTilePackResult::NO_SELECTION,
-                          MapTilePackResult::INVALID_PACK_ID);
-        if (result != MapTilePackResult::OK) {
-            return failInitialize(result, MapTilePackStatus::INVALID_SELECTION, had_selection);
-        }
-        std::uint32_t generation = 0U;
-        Pyxis::MapPackManifest map_set_metadata = {};
-        ActivePackView map_set_packs[MAX_ACTIVE_PACKS] = {};
-        std::uint8_t map_set_pack_count = 0U;
-        if (parseMapSetSelection(selectionBuffer(candidate_buffer), record_length, generation,
-                                 map_set_metadata, map_set_packs, map_set_pack_count)) {
-            manifest_ = map_set_metadata;
-            std::memcpy(active_packs_, map_set_packs,
-                        static_cast<std::size_t>(map_set_pack_count) * sizeof(ActivePackView));
-            active_pack_count_ = map_set_pack_count;
-            map_set_active_ = true;
-            selection_generation_ = generation;
-            active_selection_buffer_ = candidate_buffer;
-            status_ = MapTilePackStatus::READY;
-            return MapTilePackResult::OK;
-        }
-        if (!decodeSelection(selectionBuffer(candidate_buffer), record_length,
-                             selected_pack_id, selected_generation)) {
-            return failInitialize(MapTilePackResult::INVALID_PACK_ID,
-                                  MapTilePackStatus::INVALID_SELECTION, had_selection);
-        }
-    } else {
-        std::uint8_t marker[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
-        std::size_t marker_length = 0U;
-        result = loadFile(ACTIVE_PACK_PATH, marker, sizeof(marker) - 1U,
-                          marker_length, MapTilePackResult::NO_SELECTION,
-                          MapTilePackResult::INVALID_PACK_ID);
-        if (result == MapTilePackResult::NO_SELECTION ||
-            (result == MapTilePackResult::OK && marker_length == 0U)) {
-            manifest_ = Pyxis::MapPackManifest();
-            active_pack_count_ = 0U;
-            map_set_active_ = false;
-            selection_generation_ = 0U;
-            status_ = MapTilePackStatus::NO_SELECTION;
-            return MapTilePackResult::NO_SELECTION;
-        }
-        if (result != MapTilePackResult::OK) {
-            const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
-                ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
-            return failInitialize(result, state, had_selection);
-        }
-        marker[marker_length] = 0U;
-        if (std::memchr(marker, 0, marker_length) != NULL ||
-            !isValidPackId(reinterpret_cast<const char*>(marker))) {
-            return failInitialize(MapTilePackResult::INVALID_PACK_ID,
-                                  MapTilePackStatus::INVALID_SELECTION, had_selection);
-        }
-        std::strcpy(selected_pack_id, reinterpret_cast<const char*>(marker));
+    std::uint8_t marker[Pyxis::MapPackManifest::PACK_ID_CAPACITY];
+    std::size_t marker_length = 0U;
+    result = loadFile(ACTIVE_PACK_PATH, marker, sizeof(marker) - 1U,
+                      marker_length, MapTilePackResult::NO_SELECTION,
+                      MapTilePackResult::INVALID_PACK_ID);
+    if (result == MapTilePackResult::NO_SELECTION ||
+        (result == MapTilePackResult::OK && marker_length == 0U)) {
+        manifest_ = Pyxis::MapPackManifest();
+        active_pack_count_ = 0U;
+        map_set_active_ = false;
+        selection_generation_ = 0U;
+        status_ = MapTilePackStatus::NO_SELECTION;
+        return MapTilePackResult::NO_SELECTION;
     }
+    if (result != MapTilePackResult::OK) {
+        const MapTilePackStatus state = result == MapTilePackResult::STORAGE_UNAVAILABLE
+            ? MapTilePackStatus::STORAGE_UNAVAILABLE : MapTilePackStatus::INVALID_SELECTION;
+        return failInitialize(result, state, had_selection);
+    }
+    marker[marker_length] = 0U;
+    if (std::memchr(marker, 0, marker_length) != NULL ||
+        !isValidPackId(reinterpret_cast<const char*>(marker))) {
+        return failInitialize(MapTilePackResult::INVALID_PACK_ID,
+                              MapTilePackStatus::INVALID_SELECTION, had_selection);
+    }
+    std::strcpy(selected_pack_id, reinterpret_cast<const char*>(marker));
 
     char manifest_path[PATH_CAPACITY];
     result = manifestPath(selected_pack_id, manifest_path, sizeof(manifest_path));

--- a/lib/tdeck_ui/Hardware/TDeck/MapTilePack.h
+++ b/lib/tdeck_ui/Hardware/TDeck/MapTilePack.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "Hardware/TDeck/ActiveMapSetCodec.h"
 #include "Hardware/TDeck/MapTileStore.h"
 #include "UI/LXMF/MapPackManifest.h"
 
@@ -58,9 +59,9 @@ public:
     static const char ACTIVE_PACK_SLOT_0_PATH[];
     static const char ACTIVE_PACK_SLOT_1_PATH[];
     static const std::size_t LEGACY_ACTIVE_SELECTION_SIZE = 48U;
-    static const std::size_t ACTIVE_SELECTION_SIZE = 7105U;
-    static const std::size_t MAX_ACTIVE_PACKS = 8U;
-    static const std::size_t MAX_ACTIVE_ROW_SPANS = 512U;
+    static const std::size_t ACTIVE_SELECTION_SIZE = ActiveMapSetCodec::MAX_SERIALIZED_SIZE;
+    static const std::size_t MAX_ACTIVE_PACKS = ActiveMapSetCodec::MAX_PACKS;
+    static const std::size_t MAX_ACTIVE_ROW_SPANS = ActiveMapSetCodec::MAX_ROW_SPANS;
     static const std::size_t PATH_CAPACITY = 80U;
     static const std::size_t MANIFEST_BUFFER_CAPACITY = Pyxis::MapPackManifest::MAX_SERIALIZED_SIZE;
 
@@ -75,9 +76,15 @@ public:
     std::uint32_t selectionGeneration() const { return selection_generation_; }
 
     static bool isValidPackId(const char* pack_id);
+    static bool selectionRecordsEqual(const std::uint8_t* first, std::size_t first_length,
+                                      const std::uint8_t* second, std::size_t second_length);
     static MapTilePackResult manifestPath(const char* pack_id, char* output, std::size_t capacity);
     static MapTilePackResult tilePath(const char* pack_id, const TileKey& key,
                                       char* output, std::size_t capacity);
+    static MapTilePackResult validateMapSet(MapTileStorage& storage,
+                                            const ActiveMapSetView& view,
+                                            std::uint8_t* scratch,
+                                            std::size_t scratch_capacity);
 
     MapTilePackResult beginGet(const TileKey& key, std::uint32_t& size);
     MapTilePackResult readGetChunk(std::uint8_t* output, std::size_t capacity,
@@ -86,7 +93,7 @@ public:
 
     static std::size_t ramBytes() {
 #if defined(ARDUINO_ARCH_ESP32)
-        return sizeof(MapTilePack) + 2U * ACTIVE_SELECTION_SIZE;
+        return sizeof(MapTilePack) + 2U * ACTIVE_SELECTION_SIZE + MANIFEST_BUFFER_CAPACITY;
 #else
         return sizeof(MapTilePack);
 #endif
@@ -94,7 +101,7 @@ public:
     static std::size_t internalRamBytes() { return sizeof(MapTilePack); }
     static std::size_t psramBytes() {
 #if defined(ARDUINO_ARCH_ESP32)
-        return 2U * ACTIVE_SELECTION_SIZE;
+        return 2U * ACTIVE_SELECTION_SIZE + MANIFEST_BUFFER_CAPACITY;
 #else
         return 0U;
 #endif
@@ -120,6 +127,7 @@ private:
     std::uint8_t* selection_buffers_;
 #else
     std::uint8_t selection_buffers_[2][ACTIVE_SELECTION_SIZE];
+    std::uint8_t manifest_buffer_[MANIFEST_BUFFER_CAPACITY];
 #endif
     std::uint8_t active_selection_buffer_;
 
@@ -133,6 +141,9 @@ private:
                                MapTilePackResult oversized_result);
     static bool isValidKey(const TileKey& key);
     std::uint8_t* selectionBuffer(std::uint8_t index);
+    std::uint8_t* manifestBuffer();
+    bool fileMatches(const char* path, const std::uint8_t* expected, std::size_t length);
+
     static bool parseMapSetSelection(const std::uint8_t* input, std::size_t length,
                                      std::uint32_t& generation,
                                      Pyxis::MapPackManifest& metadata,

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -620,7 +620,9 @@ void MapScreen::updateModel(const Pyxis::MapView::Request& request) {
         presenter_.recenter(true, request.local_location)) {
         center_initialized_ = true;
     }
-    requests_released_ = false;
+    if (!presenter_.frameBuiltForCurrentEpoch()) {
+        requests_released_ = false;
+    }
     (void)presenter_.buildFrame(request);
     unlockState();
 }

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -108,8 +108,10 @@ MapScreen::MapScreen(lv_obj_t* parent)
       decoded_cache_pixels_{}, approximation_halos_{}, markers_{}, marker_labels_{},
       presenter_(), style_selector_(), storage_(), pack_(storage_),
       style_catalog_(storage_), style_request_{}, style_request_pending_(false),
+      style_request_lifecycle_epoch_(0U),
       pack_attribution_{},
-      screen_visible_(false), pack_refresh_epoch_(0U),
+      screen_visible_(false), style_lifecycle_epoch_(0U),
+      style_lifecycle_exhausted_(false), pack_refresh_epoch_(0U),
       compressed_staging_(nullptr),
       state_mutex_(nullptr), worker_task_(nullptr),
       worker_exited_(true), worker_started_(false),
@@ -351,7 +353,9 @@ void MapScreen::publishPackAttribution() {
     unlockState();
 }
 
-void MapScreen::publishStyleCatalog() {
+void MapScreen::publishStyleCatalog(std::uint32_t activation_token,
+                                    std::uint32_t request_lifecycle_epoch,
+                                    bool activation_failed) {
     Pyxis::MapStyleSummary summaries[Pyxis::MapStyleSelector::MAX_STYLES] = {};
     char active_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
     const std::size_t count = style_catalog_.count();
@@ -367,8 +371,18 @@ void MapScreen::publishStyleCatalog() {
         }
     }
     if (!lockState(portMAX_DELAY)) return;
-    (void)style_selector_.setCatalog(style_catalog_.generation(), summaries, count,
-                                     active_id[0] == '\0' ? nullptr : active_id);
+    const bool retain_error = activation_failed &&
+        screen_visible_.load(std::memory_order_acquire) &&
+        !style_lifecycle_exhausted_ &&
+        request_lifecycle_epoch == style_lifecycle_epoch_;
+    if (activation_token == 0U) {
+        (void)style_selector_.setCatalog(style_catalog_.generation(), summaries, count,
+                                         active_id[0] == '\0' ? nullptr : active_id);
+    } else {
+        (void)style_selector_.reconcileActivation(
+            activation_token, style_catalog_.generation(), summaries, count,
+            active_id[0] == '\0' ? nullptr : active_id, retain_error);
+    }
     unlockState();
 }
 
@@ -409,12 +423,26 @@ void MapScreen::workerLoop() {
         }
 
         Pyxis::MapStyleRequest style_request{};
+        std::uint32_t style_request_lifecycle_epoch = 0U;
         bool have_style_request = false;
         if (lockState(pdMS_TO_TICKS(20))) {
-            if (style_request_pending_ && screen_visible) {
-                style_request = style_request_;
-                style_request_pending_ = false;
-                have_style_request = true;
+            if (style_request_pending_) {
+                const bool style_screen_visible =
+                    screen_visible_.load(std::memory_order_acquire);
+                if (!style_screen_visible || style_lifecycle_exhausted_ ||
+                    style_request_lifecycle_epoch_ != style_lifecycle_epoch_) {
+                    (void)style_selector_.cancelPending(style_request_.token);
+                    style_request_pending_ = false;
+                    style_request_ = Pyxis::MapStyleRequest();
+                } else if (style_selector_.activationOwnedBy(style_request_.token)) {
+                    style_request = style_request_;
+                    style_request_lifecycle_epoch = style_request_lifecycle_epoch_;
+                    style_request_pending_ = false;
+                    have_style_request = true;
+                } else {
+                    style_request_pending_ = false;
+                    style_request_ = Pyxis::MapStyleRequest();
+                }
             }
             unlockState();
         }
@@ -440,23 +468,34 @@ void MapScreen::workerLoop() {
                          sizeof(style_completion.style_id) - 1U);
             style_completion.success = success;
             if (lockState(portMAX_DELAY)) {
-                (void)style_selector_.complete(style_completion);
+                const bool same_visible_lifecycle =
+                    screen_visible_.load(std::memory_order_acquire) &&
+                    !style_lifecycle_exhausted_ &&
+                    style_request_lifecycle_epoch == style_lifecycle_epoch_;
+                const bool completed = style_selector_.complete(style_completion);
+                if (completed && !same_visible_lifecycle && !success) {
+                    (void)style_selector_.clearError();
+                }
                 if (success) {
                     presenter_.invalidateTiles();
                     requests_released_ = false;
                 }
                 unlockState();
             }
-            if (success) {
-                // activate() already advanced the durable catalog generation and
-                // updated active flags. Publish that in-memory truth before any
-                // fallible post-commit SD rediscovery so the next request cannot
-                // carry a stale generation token.
-                publishStyleCatalog();
+            // Reconcile the reservation owner's catalog on every outcome. A
+            // durable activate() may have advanced its generation even when the
+            // subsequent pack reload failed; stale-generation failures can also
+            // follow a refresh that raced the queued request. Keep the lease until
+            // both the in-memory truth and any successful rediscovery are published.
+            publishStyleCatalog(style_request.token,
+                                style_request_lifecycle_epoch, !success);
+            if (style_catalog_.discover() == Hardware::TDeck::MapStyleCatalogResult::OK) {
+                publishStyleCatalog(style_request.token,
+                                    style_request_lifecycle_epoch, !success);
             }
-            if (success && style_catalog_.discover() ==
-                               Hardware::TDeck::MapStyleCatalogResult::OK) {
-                publishStyleCatalog();
+            if (lockState(portMAX_DELAY)) {
+                (void)style_selector_.releaseActivation(style_request.token);
+                unlockState();
             }
             continue;
         }
@@ -754,7 +793,18 @@ void MapScreen::show() {
 void MapScreen::hide() {
     screen_visible_.store(false, std::memory_order_release);
     if (worker_task_) xTaskNotifyGive(worker_task_);
-    if (lockState(pdMS_TO_TICKS(100))) {
+    if (lockState(portMAX_DELAY)) {
+        if (style_lifecycle_epoch_ == UINT32_MAX) {
+            style_lifecycle_exhausted_ = true;
+        } else {
+            ++style_lifecycle_epoch_;
+        }
+        if (style_request_pending_) {
+            (void)style_selector_.cancelPending(style_request_.token);
+            style_request_pending_ = false;
+            style_request_ = Pyxis::MapStyleRequest();
+        }
+        (void)style_selector_.clearError();
         presenter_.hide();
         unlockState();
     }
@@ -818,7 +868,10 @@ void MapScreen::onStyle(lv_event_t* event) {
     MapScreen* screen = fromEvent(event);
     bool queued = false;
     if (screen && screen->lockState(pdMS_TO_TICKS(100))) {
-        if (screen->style_selector_.requestNext(screen->style_request_)) {
+        if (!screen->style_lifecycle_exhausted_ &&
+            screen->style_selector_.requestNext(screen->style_request_)) {
+            screen->style_request_lifecycle_epoch_ =
+                screen->style_lifecycle_epoch_;
             screen->style_request_pending_ = true;
             queued = true;
         }

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -438,6 +438,7 @@ void MapScreen::workerLoop() {
                     style_request = style_request_;
                     style_request_lifecycle_epoch = style_request_lifecycle_epoch_;
                     style_request_pending_ = false;
+                    style_request_ = Pyxis::MapStyleRequest();
                     have_style_request = true;
                 } else {
                     style_request_pending_ = false;
@@ -447,9 +448,28 @@ void MapScreen::workerLoop() {
             unlockState();
         }
         if (have_style_request) {
-            const Hardware::TDeck::MapStyleCatalogResult activation =
-                style_catalog_.activate(style_request.catalog_generation,
-                                        style_request.style_id);
+            Hardware::TDeck::MapStyleCatalogResult activation =
+                Hardware::TDeck::MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE;
+            bool activation_admitted = false;
+            // Linearize durable activation with hide(). If hide wins this lock,
+            // the stale request is cancelled without touching the active slots.
+            // If activation wins, hide cannot mark the screen hidden until the
+            // bounded SD commit has completed.
+            if (lockState(portMAX_DELAY)) {
+                activation_admitted =
+                    screen_visible_.load(std::memory_order_acquire) &&
+                    !style_lifecycle_exhausted_ &&
+                    style_request_lifecycle_epoch == style_lifecycle_epoch_ &&
+                    style_selector_.activationOwnedBy(style_request.token);
+                if (activation_admitted) {
+                    activation = style_catalog_.activate(
+                        style_request.catalog_generation, style_request.style_id);
+                } else {
+                    (void)style_selector_.cancelPending(style_request.token);
+                }
+                unlockState();
+            }
+            if (!activation_admitted) continue;
             bool success = activation == Hardware::TDeck::MapStyleCatalogResult::OK;
             if (success) {
                 const Hardware::TDeck::MapTilePackResult initialized = pack_.initialize();
@@ -793,9 +813,8 @@ void MapScreen::show() {
 }
 
 void MapScreen::hide() {
-    screen_visible_.store(false, std::memory_order_release);
-    if (worker_task_) xTaskNotifyGive(worker_task_);
     if (lockState(portMAX_DELAY)) {
+        screen_visible_.store(false, std::memory_order_release);
         if (style_lifecycle_epoch_ == UINT32_MAX) {
             style_lifecycle_exhausted_ = true;
         } else {
@@ -810,6 +829,7 @@ void MapScreen::hide() {
         presenter_.hide();
         unlockState();
     }
+    if (worker_task_) xTaskNotifyGive(worker_task_);
     lv_group_t* group = LVGL::LVGLInit::get_default_group();
     if (group) {
         lv_group_remove_obj(back_button_);

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -386,6 +386,24 @@ void MapScreen::publishStyleCatalog(std::uint32_t activation_token,
     unlockState();
 }
 
+bool MapScreen::beginStyleActivationCommit(void* raw_context) {
+    StyleActivationCommitContext* context =
+        static_cast<StyleActivationCommitContext*>(raw_context);
+    if (context == NULL || context->screen == NULL) return false;
+    MapScreen* screen = context->screen;
+    if (!screen->lockState(portMAX_DELAY)) return false;
+    const bool admitted =
+        screen->screen_visible_.load(std::memory_order_acquire) &&
+        !screen->style_lifecycle_exhausted_ &&
+        context->lifecycle_epoch == screen->style_lifecycle_epoch_ &&
+        screen->style_selector_.activationOwnedBy(context->token);
+    // This is the lifecycle linearization point. Release before commitWrite()
+    // so LVGL navigation never waits on SD I/O. A hide that wins this lock
+    // rejects publication; a commit admitted first represents visible intent.
+    screen->unlockState();
+    return admitted;
+}
+
 void MapScreen::workerLoop() {
     std::uint32_t handled_pack_refresh_epoch =
         pack_refresh_epoch_.load(std::memory_order_acquire);
@@ -448,28 +466,33 @@ void MapScreen::workerLoop() {
             unlockState();
         }
         if (have_style_request) {
-            Hardware::TDeck::MapStyleCatalogResult activation =
-                Hardware::TDeck::MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE;
             bool activation_admitted = false;
-            // Linearize durable activation with hide(). If hide wins this lock,
-            // the stale request is cancelled without touching the active slots.
-            // If activation wins, hide cannot mark the screen hidden until the
-            // bounded SD commit has completed.
             if (lockState(portMAX_DELAY)) {
                 activation_admitted =
                     screen_visible_.load(std::memory_order_acquire) &&
                     !style_lifecycle_exhausted_ &&
                     style_request_lifecycle_epoch == style_lifecycle_epoch_ &&
                     style_selector_.activationOwnedBy(style_request.token);
-                if (activation_admitted) {
-                    activation = style_catalog_.activate(
-                        style_request.catalog_generation, style_request.style_id);
-                } else {
+                if (!activation_admitted) {
                     (void)style_selector_.cancelPending(style_request.token);
                 }
                 unlockState();
             }
             if (!activation_admitted) continue;
+            StyleActivationCommitContext commit_context = {
+                this, style_request.token, style_request_lifecycle_epoch};
+            const Hardware::TDeck::MapStyleCatalogResult activation =
+                style_catalog_.activate(style_request.catalog_generation,
+                                        style_request.style_id,
+                                        &MapScreen::beginStyleActivationCommit,
+                                        &commit_context);
+            if (activation == Hardware::TDeck::MapStyleCatalogResult::CANCELLED) {
+                if (lockState(portMAX_DELAY)) {
+                    (void)style_selector_.cancelPending(style_request.token);
+                    unlockState();
+                }
+                continue;
+            }
             bool success = activation == Hardware::TDeck::MapStyleCatalogResult::OK;
             if (success) {
                 const Hardware::TDeck::MapTilePackResult initialized = pack_.initialize();

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -70,7 +70,7 @@ private:
 
 lv_obj_t* createToolbarButton(lv_obj_t* parent, const char* text,
                               lv_event_cb_t callback, void* context,
-                              lv_coord_t width) {
+                              lv_coord_t width, lv_obj_t** label_output = nullptr) {
     lv_obj_t* button = lv_btn_create(parent);
     lv_obj_set_size(button, width, 26);
     lv_obj_set_style_pad_all(button, 0, 0);
@@ -80,7 +80,17 @@ lv_obj_t* createToolbarButton(lv_obj_t* parent, const char* text,
     lv_obj_t* label = lv_label_create(button);
     lv_label_set_text(label, text);
     lv_obj_center(label);
+    if (label_output) *label_output = label;
     return button;
+}
+
+const char* styleLabel(const char* style_id) {
+    if (style_id == nullptr) return "Style";
+    if (std::strcmp(style_id, "osm-bright") == 0) return "Bright";
+    if (std::strcmp(style_id, "dark-matter") == 0) return "Dark";
+    if (std::strcmp(style_id, "positron") == 0) return "Positron";
+    if (std::strcmp(style_id, "toner") == 0) return "Toner";
+    return "Style";
 }
 
 }  // namespace
@@ -92,10 +102,13 @@ MapScreen::MapScreen(lv_obj_t* parent)
     : screen_(nullptr), toolbar_(nullptr), viewport_(nullptr),
       status_label_(nullptr), attribution_label_(nullptr), zoom_label_(nullptr),
       zoom_out_button_(nullptr), zoom_in_button_(nullptr),
-      recenter_button_(nullptr), pan_buttons_{}, tile_images_{},
+      recenter_button_(nullptr), style_button_(nullptr), style_label_(nullptr),
+      pan_buttons_{}, tile_images_{},
       tile_descriptors_{}, tile_pixels_{}, decoded_tile_cache_(TILE_PIXEL_COUNT),
       decoded_cache_pixels_{}, approximation_halos_{}, markers_{}, marker_labels_{},
-      presenter_(), storage_(), pack_(storage_), pack_attribution_{},
+      presenter_(), style_selector_(), storage_(), pack_(storage_),
+      style_catalog_(storage_), style_request_{}, style_request_pending_(false),
+      pack_attribution_{},
       screen_visible_(false), pack_refresh_epoch_(0U),
       compressed_staging_(nullptr),
       state_mutex_(nullptr), worker_task_(nullptr),
@@ -141,6 +154,12 @@ MapScreen::MapScreen(lv_obj_t* parent)
                                            onZoomIn, this, 36);
     recenter_button_ = createToolbarButton(toolbar_, LV_SYMBOL_GPS,
                                             onRecenter, this, 44);
+    style_button_ = createToolbarButton(toolbar_, "Style", onStyle, this, 80,
+                                        &style_label_);
+    lv_obj_add_state(style_button_, LV_STATE_DISABLED);
+    lv_obj_set_width(style_label_, 74);
+    lv_label_set_long_mode(style_label_, LV_LABEL_LONG_DOT);
+    lv_obj_set_style_text_align(style_label_, LV_TEXT_ALIGN_CENTER, 0);
 
     viewport_ = lv_obj_create(screen_);
     lv_obj_set_size(viewport_, Pyxis::MapScreenPresenter::VIEWPORT_WIDTH,
@@ -332,11 +351,35 @@ void MapScreen::publishPackAttribution() {
     unlockState();
 }
 
+void MapScreen::publishStyleCatalog() {
+    Pyxis::MapStyleSummary summaries[Pyxis::MapStyleSelector::MAX_STYLES] = {};
+    char active_id[Pyxis::MapPackManifest::PACK_ID_CAPACITY] = {};
+    const std::size_t count = style_catalog_.count();
+    for (std::size_t index = 0U; index < count; ++index) {
+        const Hardware::TDeck::MapStyleSummary* source = style_catalog_.style(index);
+        if (source == nullptr) continue;
+        std::strncpy(summaries[index].id, source->id,
+                     sizeof(summaries[index].id) - 1U);
+        std::strncpy(summaries[index].label, styleLabel(source->id),
+                     sizeof(summaries[index].label) - 1U);
+        if (source->active) {
+            std::strncpy(active_id, source->id, sizeof(active_id) - 1U);
+        }
+    }
+    if (!lockState(portMAX_DELAY)) return;
+    (void)style_selector_.setCatalog(style_catalog_.generation(), summaries, count,
+                                     active_id[0] == '\0' ? nullptr : active_id);
+    unlockState();
+}
+
 void MapScreen::workerLoop() {
     std::uint32_t handled_pack_refresh_epoch =
         pack_refresh_epoch_.load(std::memory_order_acquire);
     (void)pack_.initialize();
     publishPackAttribution();
+    if (style_catalog_.discover() == Hardware::TDeck::MapStyleCatalogResult::OK) {
+        publishStyleCatalog();
+    }
     while (!stop_requested_.load(std::memory_order_acquire)) {
         const bool screen_visible =
             screen_visible_.load(std::memory_order_acquire);
@@ -359,7 +402,63 @@ void MapScreen::workerLoop() {
                 decoded_tile_cache_.clear();
             }
             publishPackAttribution();
+            if (style_catalog_.discover() == Hardware::TDeck::MapStyleCatalogResult::OK) {
+                publishStyleCatalog();
+            }
             handled_pack_refresh_epoch = pack_refresh_epoch;
+        }
+
+        Pyxis::MapStyleRequest style_request{};
+        bool have_style_request = false;
+        if (lockState(pdMS_TO_TICKS(20))) {
+            if (style_request_pending_ && screen_visible) {
+                style_request = style_request_;
+                style_request_pending_ = false;
+                have_style_request = true;
+            }
+            unlockState();
+        }
+        if (have_style_request) {
+            const Hardware::TDeck::MapStyleCatalogResult activation =
+                style_catalog_.activate(style_request.catalog_generation,
+                                        style_request.style_id);
+            bool success = activation == Hardware::TDeck::MapStyleCatalogResult::OK;
+            if (success) {
+                const Hardware::TDeck::MapTilePackResult initialized = pack_.initialize();
+                success = initialized == Hardware::TDeck::MapTilePackResult::OK &&
+                    pack_.hasSelection() &&
+                    std::strcmp(pack_.metadata().pack_id, style_request.style_id) == 0;
+            }
+            if (success) {
+                decoded_tile_cache_.clear();
+                publishPackAttribution();
+            }
+            Pyxis::MapStyleCompletion style_completion{};
+            style_completion.token = style_request.token;
+            style_completion.catalog_generation = style_request.catalog_generation;
+            std::strncpy(style_completion.style_id, style_request.style_id,
+                         sizeof(style_completion.style_id) - 1U);
+            style_completion.success = success;
+            if (lockState(portMAX_DELAY)) {
+                (void)style_selector_.complete(style_completion);
+                if (success) {
+                    presenter_.invalidateTiles();
+                    requests_released_ = false;
+                }
+                unlockState();
+            }
+            if (success) {
+                // activate() already advanced the durable catalog generation and
+                // updated active flags. Publish that in-memory truth before any
+                // fallible post-commit SD rediscovery so the next request cannot
+                // carry a stale generation token.
+                publishStyleCatalog();
+            }
+            if (success && style_catalog_.discover() ==
+                               Hardware::TDeck::MapStyleCatalogResult::OK) {
+                publishStyleCatalog();
+            }
+            continue;
         }
 
         Pyxis::MapTileRequest request{};
@@ -549,9 +648,24 @@ void MapScreen::applyFrame() {
     std::snprintf(zoom_text, sizeof(zoom_text), "z%lu",
                   static_cast<unsigned long>(presenter_.zoom()));
     lv_label_set_text(zoom_label_, zoom_text);
+    if (style_selector_.state() == Pyxis::MapStyleSelector::State::APPLYING) {
+        lv_label_set_text(style_label_, "Switching");
+    } else {
+        lv_label_set_text(style_label_, style_selector_.activeLabel());
+    }
+    if (style_selector_.canCycle()) {
+        lv_obj_clear_state(style_button_, LV_STATE_DISABLED);
+    } else {
+        lv_obj_add_state(style_button_, LV_STATE_DISABLED);
+    }
     lv_label_set_text(attribution_label_, pack_attribution_[0] != '\0'
         ? pack_attribution_ : "No active map pack");
     refreshVisibleStatus();
+    if (style_selector_.state() == Pyxis::MapStyleSelector::State::APPLYING) {
+        lv_label_set_text(status_label_, "Switching style...");
+    } else if (style_selector_.state() == Pyxis::MapStyleSelector::State::ERROR) {
+        lv_label_set_text(status_label_, "Style switch failed");
+    }
     // Non-ready images are now detached under LVGL_LOCK, so the worker may
     // safely decode into their permanent buffers without a draw race.
     requests_released_ = true;
@@ -631,6 +745,7 @@ void MapScreen::show() {
         lv_group_add_obj(group, zoom_out_button_);
         lv_group_add_obj(group, zoom_in_button_);
         lv_group_add_obj(group, recenter_button_);
+        lv_group_add_obj(group, style_button_);
         for (std::size_t i = 0; i < 4U; ++i) lv_group_add_obj(group, pan_buttons_[i]);
         lv_group_focus_obj(back_button_);
     }
@@ -649,6 +764,7 @@ void MapScreen::hide() {
         lv_group_remove_obj(zoom_out_button_);
         lv_group_remove_obj(zoom_in_button_);
         lv_group_remove_obj(recenter_button_);
+        lv_group_remove_obj(style_button_);
         for (std::size_t i = 0; i < 4U; ++i) lv_group_remove_obj(pan_buttons_[i]);
     }
     lv_obj_add_flag(screen_, LV_OBJ_FLAG_HIDDEN);
@@ -696,6 +812,19 @@ void MapScreen::onRecenter(lv_event_t* event) {
     if (centered) screen->center_initialized_ = true;
     screen->unlockState();
     if (!centered) lv_label_set_text(screen->status_label_, "No GPS fix");
+}
+
+void MapScreen::onStyle(lv_event_t* event) {
+    MapScreen* screen = fromEvent(event);
+    bool queued = false;
+    if (screen && screen->lockState(pdMS_TO_TICKS(100))) {
+        if (screen->style_selector_.requestNext(screen->style_request_)) {
+            screen->style_request_pending_ = true;
+            queued = true;
+        }
+        screen->unlockState();
+    }
+    if (queued && screen->worker_task_) xTaskNotifyGive(screen->worker_task_);
 }
 
 void MapScreen::onPan(lv_event_t* event) {

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.h
@@ -56,6 +56,14 @@ public:
     bool applyOneCompletion();
 
 private:
+    struct StyleActivationCommitContext {
+        MapScreen* screen;
+        std::uint32_t token;
+        std::uint32_t lifecycle_epoch;
+    };
+
+    static bool beginStyleActivationCommit(void* context);
+
     lv_obj_t* screen_;
     lv_obj_t* toolbar_;
     lv_obj_t* viewport_;

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.h
@@ -85,8 +85,11 @@ private:
     Hardware::TDeck::MapStyleCatalog style_catalog_;
     Pyxis::MapStyleRequest style_request_;
     bool style_request_pending_;
+    std::uint32_t style_request_lifecycle_epoch_;
     char pack_attribution_[Pyxis::MapPackManifest::ATTRIBUTION_CAPACITY];
     std::atomic<bool> screen_visible_;
+    std::uint32_t style_lifecycle_epoch_;
+    bool style_lifecycle_exhausted_;
     std::atomic<std::uint32_t> pack_refresh_epoch_;
     std::uint8_t* compressed_staging_;
     SemaphoreHandle_t state_mutex_;
@@ -105,7 +108,9 @@ private:
     static void workerEntry(void* context);
     void workerLoop();
     void publishPackAttribution();
-    void publishStyleCatalog();
+    void publishStyleCatalog(std::uint32_t activation_token = 0U,
+                             std::uint32_t request_lifecycle_epoch = 0U,
+                             bool activation_failed = false);
     Pyxis::MapTileLoadResult loadTile(const Pyxis::MapTileRequest& request);
     Pyxis::MapTileLoadResult readTile(const Pyxis::MapTileRequest& request);
     Pyxis::MapTileLoadResult readCompressedTile(const Pyxis::MapTileRequest& request);

--- a/lib/tdeck_ui/UI/LXMF/MapScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.h
@@ -6,6 +6,7 @@
 
 #include "MapScreenPresenter.h"
 #include "DecodedTileCache.h"
+#include "MapStyleSelector.h"
 
 #ifdef ARDUINO
 
@@ -19,6 +20,7 @@
 
 #include "Hardware/TDeck/MapTileStoreSD.h"
 #include "Hardware/TDeck/MapTilePack.h"
+#include "Hardware/TDeck/MapStyleCatalog.h"
 
 namespace UI {
 namespace LXMF {
@@ -64,6 +66,8 @@ private:
     lv_obj_t* zoom_out_button_;
     lv_obj_t* zoom_in_button_;
     lv_obj_t* recenter_button_;
+    lv_obj_t* style_button_;
+    lv_obj_t* style_label_;
     lv_obj_t* pan_buttons_[4];
     lv_obj_t* tile_images_[TILE_COUNT];
     lv_img_dsc_t tile_descriptors_[TILE_COUNT];
@@ -75,8 +79,12 @@ private:
     lv_obj_t* marker_labels_[MARKER_COUNT];
 
     Pyxis::MapScreenPresenter presenter_;
+    Pyxis::MapStyleSelector style_selector_;
     Hardware::TDeck::MapTileStoreSD storage_;
     Hardware::TDeck::MapTilePack pack_;
+    Hardware::TDeck::MapStyleCatalog style_catalog_;
+    Pyxis::MapStyleRequest style_request_;
+    bool style_request_pending_;
     char pack_attribution_[Pyxis::MapPackManifest::ATTRIBUTION_CAPACITY];
     std::atomic<bool> screen_visible_;
     std::atomic<std::uint32_t> pack_refresh_epoch_;
@@ -97,6 +105,7 @@ private:
     static void workerEntry(void* context);
     void workerLoop();
     void publishPackAttribution();
+    void publishStyleCatalog();
     Pyxis::MapTileLoadResult loadTile(const Pyxis::MapTileRequest& request);
     Pyxis::MapTileLoadResult readTile(const Pyxis::MapTileRequest& request);
     Pyxis::MapTileLoadResult readCompressedTile(const Pyxis::MapTileRequest& request);
@@ -114,6 +123,7 @@ private:
     static void onZoomIn(lv_event_t* event);
     static void onZoomOut(lv_event_t* event);
     static void onRecenter(lv_event_t* event);
+    static void onStyle(lv_event_t* event);
     static void onPan(lv_event_t* event);
     static void onMapPressed(lv_event_t* event);
     static void onMapPressing(lv_event_t* event);

--- a/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.cpp
@@ -156,6 +156,12 @@ bool MapScreenPresenter::recenter(
     return true;
 }
 
+void MapScreenPresenter::invalidateTiles() {
+    startNewFrame();
+    clearSlots();
+    frame_.tile_count = 0U;
+}
+
 int MapScreenPresenter::findSlot(const Hardware::TDeck::TileKey& key) const {
     for (std::size_t index = 0; index < TILE_SLOT_COUNT; ++index) {
         if (slots_[index].state != MapTileSlot::EMPTY &&

--- a/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
@@ -88,6 +88,7 @@ public:
     bool zoomBy(int delta);
     bool recenter(bool has_fix,
                   const Telemetry::LocationTelemetry& location);
+    void invalidateTiles();
 
     MapView::Result buildFrame(const MapView::Request& request);
     bool takeRequest(MapTileRequest& output);

--- a/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
+++ b/lib/tdeck_ui/UI/LXMF/MapScreenPresenter.h
@@ -102,6 +102,7 @@ public:
     std::uint32_t zoom() const { return zoom_; }
     std::uint32_t generation() const { return generation_; }
     std::uint32_t frameEpoch() const { return frame_epoch_; }
+    bool frameBuiltForCurrentEpoch() const { return frame_built_for_epoch_; }
     std::size_t requestCount() const { return request_count_; }
     std::size_t completionCount() const { return completion_count_; }
 

--- a/lib/tdeck_ui/UI/LXMF/MapStyleSelector.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapStyleSelector.cpp
@@ -10,7 +10,7 @@ namespace Pyxis {
 MapStyleSelector::MapStyleSelector()
     : styles_(), count_(0U), active_index_(-1), pending_index_(0U),
       catalog_generation_(0U), next_token_(1U), pending_token_(0U),
-      state_(State::DISCOVERING) {}
+      activation_token_(0U), state_(State::DISCOVERING) {}
 
 std::uint32_t MapStyleSelector::advance(std::uint32_t value) {
     ++value;
@@ -35,6 +35,14 @@ bool MapStyleSelector::validString(const char* value, std::size_t capacity,
 bool MapStyleSelector::setCatalog(std::uint32_t generation,
                                   const MapStyleSummary* styles,
                                   std::size_t count, const char* active_id) {
+    if (activation_token_ != 0U) return false;
+    return applyCatalog(generation, styles, count, active_id, State::READY);
+}
+
+bool MapStyleSelector::applyCatalog(std::uint32_t generation,
+                                    const MapStyleSummary* styles,
+                                    std::size_t count, const char* active_id,
+                                    State next_state) {
     if (generation == 0U || count > MAX_STYLES ||
         (count != 0U && styles == NULL) ||
         (count == 0U && active_id != NULL)) return false;
@@ -61,7 +69,7 @@ bool MapStyleSelector::setCatalog(std::uint32_t generation,
     pending_token_ = 0U;
     catalog_generation_ = generation;
     next_token_ = advance(next_token_);
-    state_ = State::READY;
+    state_ = next_state;
     return true;
 }
 
@@ -75,12 +83,44 @@ bool MapStyleSelector::requestNext(MapStyleRequest& output) {
     output.token = pending_token_;
     output.catalog_generation = catalog_generation_;
     std::strcpy(output.style_id, styles_[pending_index_].id);
+    activation_token_ = pending_token_;
     state_ = State::APPLYING;
+    return true;
+}
+
+bool MapStyleSelector::reconcileActivation(
+    std::uint32_t expected_token, std::uint32_t generation,
+    const MapStyleSummary* styles, std::size_t count, const char* active_id,
+    bool retain_error) {
+    if (!activationOwnedBy(expected_token)) return false;
+    return applyCatalog(generation, styles, count, active_id,
+                        retain_error ? State::ERROR : State::READY);
+}
+
+bool MapStyleSelector::releaseActivation(std::uint32_t expected_token) {
+    if (activation_token_ == 0U || activation_token_ != expected_token) return false;
+    activation_token_ = 0U;
+    return true;
+}
+
+bool MapStyleSelector::cancelPending(std::uint32_t expected_token) {
+    if (!activationOwnedBy(expected_token) || state_ != State::APPLYING ||
+        pending_token_ != expected_token) return false;
+    pending_token_ = 0U;
+    activation_token_ = 0U;
+    state_ = State::READY;
+    return true;
+}
+
+bool MapStyleSelector::clearError() {
+    if (state_ != State::ERROR) return false;
+    state_ = State::READY;
     return true;
 }
 
 bool MapStyleSelector::complete(const MapStyleCompletion& completion) {
     if (state_ != State::APPLYING || completion.token != pending_token_ ||
+        completion.token != activation_token_ ||
         completion.catalog_generation != catalog_generation_ ||
         std::strcmp(completion.style_id, styles_[pending_index_].id) != 0) return false;
     pending_token_ = 0U;

--- a/lib/tdeck_ui/UI/LXMF/MapStyleSelector.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapStyleSelector.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#include "UI/LXMF/MapStyleSelector.h"
+
+#include <cstring>
+
+namespace Pyxis {
+
+MapStyleSelector::MapStyleSelector()
+    : styles_(), count_(0U), active_index_(-1), pending_index_(0U),
+      catalog_generation_(0U), next_token_(1U), pending_token_(0U),
+      state_(State::DISCOVERING) {}
+
+std::uint32_t MapStyleSelector::advance(std::uint32_t value) {
+    ++value;
+    return value == 0U ? 1U : value;
+}
+
+bool MapStyleSelector::validString(const char* value, std::size_t capacity,
+                                   bool identifier) {
+    if (value == NULL || capacity < 2U) return false;
+    std::size_t length = 0U;
+    while (length < capacity && value[length] != '\0') {
+        const unsigned char character = static_cast<unsigned char>(value[length]);
+        if (character < 0x20U || character > 0x7eU) return false;
+        if (identifier && !((character >= 'a' && character <= 'z') ||
+                            (character >= '0' && character <= '9') ||
+                            character == '-' || character == '_')) return false;
+        ++length;
+    }
+    return length > 0U && length < capacity;
+}
+
+bool MapStyleSelector::setCatalog(std::uint32_t generation,
+                                  const MapStyleSummary* styles,
+                                  std::size_t count, const char* active_id) {
+    if (generation == 0U || count > MAX_STYLES ||
+        (count != 0U && styles == NULL) ||
+        (count == 0U && active_id != NULL)) return false;
+
+    std::ptrdiff_t active = -1;
+    bool found_active = active_id == NULL;
+    for (std::size_t index = 0U; index < count; ++index) {
+        if (!validString(styles[index].id, sizeof(styles[index].id), true) ||
+            !validString(styles[index].label, sizeof(styles[index].label), false)) return false;
+        for (std::size_t previous = 0U; previous < index; ++previous) {
+            if (std::strcmp(styles[index].id, styles[previous].id) == 0) return false;
+        }
+        if (active_id != NULL && std::strcmp(styles[index].id, active_id) == 0) {
+            active = static_cast<std::ptrdiff_t>(index);
+            found_active = true;
+        }
+    }
+    if (!found_active) return false;
+
+    if (count != 0U) std::memcpy(styles_, styles, count * sizeof(MapStyleSummary));
+    count_ = count;
+    active_index_ = active;
+    pending_index_ = 0U;
+    pending_token_ = 0U;
+    catalog_generation_ = generation;
+    next_token_ = advance(next_token_);
+    state_ = State::READY;
+    return true;
+}
+
+bool MapStyleSelector::requestNext(MapStyleRequest& output) {
+    if (!canCycle()) return false;
+    pending_index_ = active_index_ < 0 ? 0U :
+        (static_cast<std::size_t>(active_index_) + 1U) % count_;
+    pending_token_ = next_token_;
+    next_token_ = advance(next_token_);
+    output = MapStyleRequest();
+    output.token = pending_token_;
+    output.catalog_generation = catalog_generation_;
+    std::strcpy(output.style_id, styles_[pending_index_].id);
+    state_ = State::APPLYING;
+    return true;
+}
+
+bool MapStyleSelector::complete(const MapStyleCompletion& completion) {
+    if (state_ != State::APPLYING || completion.token != pending_token_ ||
+        completion.catalog_generation != catalog_generation_ ||
+        std::strcmp(completion.style_id, styles_[pending_index_].id) != 0) return false;
+    pending_token_ = 0U;
+    if (!completion.success) {
+        state_ = State::ERROR;
+        return true;
+    }
+    active_index_ = static_cast<std::ptrdiff_t>(pending_index_);
+    state_ = State::READY;
+    return true;
+}
+
+const char* MapStyleSelector::activeId() const {
+    return active_index_ < 0 ? "" : styles_[static_cast<std::size_t>(active_index_)].id;
+}
+
+const char* MapStyleSelector::activeLabel() const {
+    return active_index_ < 0 ? "Style" :
+        styles_[static_cast<std::size_t>(active_index_)].label;
+}
+
+}  // namespace Pyxis

--- a/lib/tdeck_ui/UI/LXMF/MapStyleSelector.h
+++ b/lib/tdeck_ui/UI/LXMF/MapStyleSelector.h
@@ -40,14 +40,26 @@ public:
     bool setCatalog(std::uint32_t generation, const MapStyleSummary* styles,
                     std::size_t count, const char* active_id);
     bool requestNext(MapStyleRequest& output);
+    bool activationOwnedBy(std::uint32_t expected_token) const {
+        return expected_token != 0U && activation_token_ == expected_token;
+    }
+    bool reconcileActivation(std::uint32_t expected_token,
+                             std::uint32_t generation,
+                             const MapStyleSummary* styles,
+                             std::size_t count, const char* active_id,
+                             bool retain_error);
+    bool releaseActivation(std::uint32_t expected_token);
+    bool cancelPending(std::uint32_t expected_token);
+    bool clearError();
     bool complete(const MapStyleCompletion& completion);
 
     State state() const { return state_; }
     std::size_t count() const { return count_; }
     bool canCycle() const {
         return (count_ > 1U || (count_ == 1U && active_index_ < 0)) &&
-            state_ != State::APPLYING;
+            state_ != State::APPLYING && activation_token_ == 0U;
     }
+    bool activationInFlight() const { return activation_token_ != 0U; }
     const char* activeId() const;
     const char* activeLabel() const;
     std::uint32_t generation() const { return catalog_generation_; }
@@ -60,8 +72,12 @@ private:
     std::uint32_t catalog_generation_;
     std::uint32_t next_token_;
     std::uint32_t pending_token_;
+    std::uint32_t activation_token_;
     State state_;
 
+    bool applyCatalog(std::uint32_t generation, const MapStyleSummary* styles,
+                      std::size_t count, const char* active_id,
+                      State next_state);
     static bool validString(const char* value, std::size_t capacity, bool identifier);
     static std::uint32_t advance(std::uint32_t value);
 };

--- a/lib/tdeck_ui/UI/LXMF/MapStyleSelector.h
+++ b/lib/tdeck_ui/UI/LXMF/MapStyleSelector.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Pyxis contributors
+// SPDX-License-Identifier: MIT
+
+#ifndef PYXIS_UI_LXMF_MAP_STYLE_SELECTOR_H
+#define PYXIS_UI_LXMF_MAP_STYLE_SELECTOR_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "UI/LXMF/MapPackManifest.h"
+
+namespace Pyxis {
+
+struct MapStyleSummary {
+    char id[MapPackManifest::PACK_ID_CAPACITY];
+    char label[20];
+};
+
+struct MapStyleRequest {
+    std::uint32_t token;
+    std::uint32_t catalog_generation;
+    char style_id[MapPackManifest::PACK_ID_CAPACITY];
+};
+
+struct MapStyleCompletion {
+    std::uint32_t token;
+    std::uint32_t catalog_generation;
+    char style_id[MapPackManifest::PACK_ID_CAPACITY];
+    bool success;
+};
+
+/** Allocation-free UI state for one bounded map-style activation intent. */
+class MapStyleSelector {
+public:
+    static const std::size_t MAX_STYLES = 4U;
+    enum class State : std::uint8_t { DISCOVERING, READY, APPLYING, ERROR };
+
+    MapStyleSelector();
+
+    bool setCatalog(std::uint32_t generation, const MapStyleSummary* styles,
+                    std::size_t count, const char* active_id);
+    bool requestNext(MapStyleRequest& output);
+    bool complete(const MapStyleCompletion& completion);
+
+    State state() const { return state_; }
+    std::size_t count() const { return count_; }
+    bool canCycle() const {
+        return (count_ > 1U || (count_ == 1U && active_index_ < 0)) &&
+            state_ != State::APPLYING;
+    }
+    const char* activeId() const;
+    const char* activeLabel() const;
+    std::uint32_t generation() const { return catalog_generation_; }
+
+private:
+    MapStyleSummary styles_[MAX_STYLES];
+    std::size_t count_;
+    std::ptrdiff_t active_index_;
+    std::size_t pending_index_;
+    std::uint32_t catalog_generation_;
+    std::uint32_t next_token_;
+    std::uint32_t pending_token_;
+    State state_;
+
+    static bool validString(const char* value, std::size_t capacity, bool identifier);
+    static std::uint32_t advance(std::uint32_t value);
+};
+
+}  // namespace Pyxis
+
+#endif

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -160,16 +160,23 @@ def test_style_switch_is_bounded_and_worker_owned():
     assert "lv_obj_t* style_label_;" in header
     assert "Pyxis::MapStyleRequest style_request_;" in header
     assert "bool style_request_pending_;" in header
+    assert "std::uint32_t style_request_lifecycle_epoch_;" in header
+    assert "std::uint32_t style_lifecycle_epoch_;" in header
+    assert "bool style_lifecycle_exhausted_;" in header
 
     callback = function_body(source, "void MapScreen::onStyle(lv_event_t* event)")
     assert "style_selector_.requestNext" in callback
     assert "style_request_pending_ = true" in callback
+    assert "style_request_lifecycle_epoch_" in callback
+    assert "screen->style_lifecycle_epoch_;" in callback
     assert "style_catalog_.activate" not in callback
     assert "pack_.initialize" not in callback
 
     worker = function_body(source, "void MapScreen::workerLoop()")
     assert "style_catalog_.discover()" in worker
     assert "style_catalog_.activate" in worker
+    assert "style_selector_.activationOwnedBy(style_request_.token)" in worker
+    assert "style_selector_.releaseActivation(style_request.token)" in worker
     assert "pack_.initialize()" in worker
     assert "presenter_.invalidateTiles()" in worker
     activation = worker.index("style_catalog_.activate")
@@ -177,10 +184,15 @@ def test_style_switch_is_bounded_and_worker_owned():
     cache_invalidation = worker.index("decoded_tile_cache_.clear()", committed_reload)
     selector_completion = worker.index("style_selector_.complete", committed_reload)
     tile_invalidation = worker.index("presenter_.invalidateTiles()", committed_reload)
-    committed_catalog = worker.index("publishStyleCatalog();", tile_invalidation)
+    committed_catalog = worker.index("publishStyleCatalog(style_request.token", tile_invalidation)
     rediscovery = worker.index("style_catalog_.discover()", committed_reload)
     assert activation < committed_reload < cache_invalidation
     assert cache_invalidation < selector_completion < tile_invalidation < committed_catalog < rediscovery
+    assert "publishStyleCatalog(style_request.token" in worker
+    assert "style_request_lifecycle_epoch, !success" in worker
+    assert "retain_style_error" not in worker
+    release = worker.index("style_selector_.releaseActivation(style_request.token)")
+    assert rediscovery < release
     assert "success = discovery" not in worker
     assert worker.index("style_catalog_.activate") < worker.index("presenter_.takeRequest")
 
@@ -191,6 +203,18 @@ def test_style_switch_is_bounded_and_worker_owned():
         assert "pack_.initialize" not in body
     assert "lv_group_add_obj(group, style_button_)" in source
     assert "lv_group_remove_obj(style_button_)" in source
+    publisher = function_body(source, "void MapScreen::publishStyleCatalog(")
+    assert "activation_failed &&" in publisher
+    assert "screen_visible_.load" in publisher
+    assert "!style_lifecycle_exhausted_" in publisher
+    assert "request_lifecycle_epoch == style_lifecycle_epoch_" in publisher
+    assert publisher.index("lockState(portMAX_DELAY)") < publisher.index("activation_failed &&")
+    hide = function_body(source, "void MapScreen::hide()")
+    assert "lockState(portMAX_DELAY)" in hide
+    assert "style_lifecycle_exhausted_" in hide
+    assert "UINT32_MAX" in hide
+    assert "style_selector_.cancelPending(style_request_.token)" in hide
+    assert "style_selector_.clearError()" in hide
 
 
 def test_ui_manager_services_before_lock_and_hides_map_everywhere():

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -149,6 +149,50 @@ def test_sd_adapter_never_mounts_or_formats():
         assert forbidden not in source
 
 
+def test_style_switch_is_bounded_and_worker_owned():
+    source = text(UI / "MapScreen.cpp")
+    header = text(UI / "MapScreen.h")
+    assert '#include "MapStyleSelector.h"' in header
+    assert '#include "Hardware/TDeck/MapStyleCatalog.h"' in header
+    assert "Hardware::TDeck::MapStyleCatalog style_catalog_;" in header
+    assert "Pyxis::MapStyleSelector style_selector_;" in header
+    assert "lv_obj_t* style_button_;" in header
+    assert "lv_obj_t* style_label_;" in header
+    assert "Pyxis::MapStyleRequest style_request_;" in header
+    assert "bool style_request_pending_;" in header
+
+    callback = function_body(source, "void MapScreen::onStyle(lv_event_t* event)")
+    assert "style_selector_.requestNext" in callback
+    assert "style_request_pending_ = true" in callback
+    assert "style_catalog_.activate" not in callback
+    assert "pack_.initialize" not in callback
+
+    worker = function_body(source, "void MapScreen::workerLoop()")
+    assert "style_catalog_.discover()" in worker
+    assert "style_catalog_.activate" in worker
+    assert "pack_.initialize()" in worker
+    assert "presenter_.invalidateTiles()" in worker
+    activation = worker.index("style_catalog_.activate")
+    committed_reload = worker.index("pack_.initialize()", activation)
+    cache_invalidation = worker.index("decoded_tile_cache_.clear()", committed_reload)
+    selector_completion = worker.index("style_selector_.complete", committed_reload)
+    tile_invalidation = worker.index("presenter_.invalidateTiles()", committed_reload)
+    committed_catalog = worker.index("publishStyleCatalog();", tile_invalidation)
+    rediscovery = worker.index("style_catalog_.discover()", committed_reload)
+    assert activation < committed_reload < cache_invalidation
+    assert cache_invalidation < selector_completion < tile_invalidation < committed_catalog < rediscovery
+    assert "success = discovery" not in worker
+    assert worker.index("style_catalog_.activate") < worker.index("presenter_.takeRequest")
+
+    for signature in ("void MapScreen::applyFrame()",
+                      "bool MapScreen::applyOneCompletion()"):
+        body = function_body(source, signature)
+        assert "style_catalog_." not in body
+        assert "pack_.initialize" not in body
+    assert "lv_group_add_obj(group, style_button_)" in source
+    assert "lv_group_remove_obj(style_button_)" in source
+
+
 def test_ui_manager_services_before_lock_and_hides_map_everywhere():
     source = text(UI / "UIManager.cpp")
     update = function_body(source, "void UIManager::update()")

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -77,6 +77,17 @@ def test_worker_predecodes_and_render_path_has_no_io():
     assert "MAX_COMPLETIONS_PER_TICK = 1" in text(UI / "MapScreen.h")
 
 
+def test_unchanged_model_does_not_starve_released_tile_requests():
+    source = text(UI / "MapScreen.cpp")
+    presenter = text(UI / "MapScreenPresenter.h")
+    update = function_body(source, "void MapScreen::updateModel(")
+    assert "frameBuiltForCurrentEpoch" in presenter
+    guard = update.index("if (!presenter_.frameBuiltForCurrentEpoch())")
+    revoke = update.index("requests_released_ = false")
+    build = update.index("presenter_.buildFrame(request)")
+    assert guard < revoke < build
+
+
 def test_selected_pack_is_the_only_sd_tile_source():
     source = text(UI / "MapScreen.cpp")
     header = text(UI / "MapScreen.h")

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -193,11 +193,18 @@ def test_style_switch_is_bounded_and_worker_owned():
     activation = worker.index("style_catalog_.activate")
     admission_lock = worker.rindex("lockState(portMAX_DELAY)", 0, activation)
     admission_guard = worker.rindex("activation_admitted =", 0, activation)
-    admission_unlock = worker.index("unlockState();", activation)
-    assert admission_lock < admission_guard < activation < admission_unlock
+    admission_unlock = worker.rindex("unlockState();", 0, activation)
+    assert admission_lock < admission_guard < admission_unlock < activation
     assert "style_request_lifecycle_epoch == style_lifecycle_epoch_" in worker[admission_guard:activation]
     assert "style_selector_.activationOwnedBy(style_request.token)" in worker[admission_guard:activation]
-    assert "if (!activation_admitted) continue;" in worker[activation:]
+    assert "if (!activation_admitted) continue;" in worker[:activation]
+    assert "&MapScreen::beginStyleActivationCommit" in worker
+    commit_guard = function_body(source, "bool MapScreen::beginStyleActivationCommit(void* raw_context)")
+    assert "lockState(portMAX_DELAY)" in commit_guard
+    assert "screen_visible_.load" in commit_guard
+    assert "lifecycle_epoch == screen->style_lifecycle_epoch_" in commit_guard
+    assert "activationOwnedBy(context->token)" in commit_guard
+    assert commit_guard.index("screen->unlockState()") < commit_guard.index("return admitted")
     committed_reload = worker.index("pack_.initialize()", activation)
     cache_invalidation = worker.index("decoded_tile_cache_.clear()", committed_reload)
     selector_completion = worker.index("style_selector_.complete", committed_reload)

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -191,6 +191,13 @@ def test_style_switch_is_bounded_and_worker_owned():
     assert "pack_.initialize()" in worker
     assert "presenter_.invalidateTiles()" in worker
     activation = worker.index("style_catalog_.activate")
+    admission_lock = worker.rindex("lockState(portMAX_DELAY)", 0, activation)
+    admission_guard = worker.rindex("activation_admitted =", 0, activation)
+    admission_unlock = worker.index("unlockState();", activation)
+    assert admission_lock < admission_guard < activation < admission_unlock
+    assert "style_request_lifecycle_epoch == style_lifecycle_epoch_" in worker[admission_guard:activation]
+    assert "style_selector_.activationOwnedBy(style_request.token)" in worker[admission_guard:activation]
+    assert "if (!activation_admitted) continue;" in worker[activation:]
     committed_reload = worker.index("pack_.initialize()", activation)
     cache_invalidation = worker.index("decoded_tile_cache_.clear()", committed_reload)
     selector_completion = worker.index("style_selector_.complete", committed_reload)
@@ -222,6 +229,7 @@ def test_style_switch_is_bounded_and_worker_owned():
     assert publisher.index("lockState(portMAX_DELAY)") < publisher.index("activation_failed &&")
     hide = function_body(source, "void MapScreen::hide()")
     assert "lockState(portMAX_DELAY)" in hide
+    assert hide.index("lockState(portMAX_DELAY)") < hide.index("screen_visible_.store(false")
     assert "style_lifecycle_exhausted_" in hide
     assert "UINT32_MAX" in hide
     assert "style_selector_.cancelPending(style_request_.token)" in hide

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -27,7 +27,7 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert "showDirectoryPicker" in source
     assert "navigator.locks?.request" in source
     assert "cross-tab locking required for safe map installation" in source
-    assert "./js/map-installer.js" in source
+    assert "./js/map-installer.js?v=map-style-picker-2" in source
     assert "Oxed's Map Tile Downloader" in source
     assert "OpenStreetMap contributors" in source
     assert "suggestMapIdentity" in source

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -17,14 +17,24 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert 'id="map-pack-name"' in source
     assert 'id="map-install-btn"' in source
     assert 'Install and Enable' in source
-    assert "mapSetId: 'osm-bright'" in source
+    assert 'id="map-style"' in source
+    assert '<option value="" selected disabled>Select map style…</option>' in source
+    for style in ("osm-bright", "dark-matter", "positron", "toner"):
+        assert f'value="{style}"' in source
+    assert "resolveMuiStyleProfile" in source
+    assert "mapSetId: style.id" in source
     assert 'newest pack takes priority' in source
     assert "showDirectoryPicker" in source
     assert "navigator.locks?.request" in source
     assert "cross-tab locking required for safe map installation" in source
     assert "./js/map-installer.js" in source
-    assert "Coalition MUI OSM Bright user download" in source
-    assert "Map data (c) OpenStreetMap contributors" in source
+    assert "Oxed's Map Tile Downloader" in source
+    assert "OpenStreetMap contributors" in source
+
+    click_start = source.index("mapInstallBtn.addEventListener('click'")
+    picker = source.index("const rootDirectory = await window.showDirectoryPicker", click_start)
+    click_before_picker = source[click_start:picker]
+    assert "resolveMuiStyleProfile" in click_before_picker
 
 
 def test_map_installer_explains_the_complete_sd_card_workflow() -> None:

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -30,6 +30,12 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert "./js/map-installer.js" in source
     assert "Oxed's Map Tile Downloader" in source
     assert "OpenStreetMap contributors" in source
+    assert "suggestMapIdentity" in source
+    assert "const suggestion = suggestMapIdentity(file.name);" in source
+    assert "mapPackNameInput.value = suggestion.name;" in source
+    assert "mapPackIdInput.value = suggestion.packId;" in source
+    assert ".map-field select option" in source
+    assert "background: var(--card);" in source
 
     click_start = source.index("mapInstallBtn.addEventListener('click'")
     picker = source.index("const rootDirectory = await window.showDirectoryPicker", click_start)

--- a/tests/native/test_map_screen_presenter.cpp
+++ b/tests/native/test_map_screen_presenter.cpp
@@ -67,6 +67,32 @@ void fixedCapacityAndDedupe() {
     }
 }
 
+void frameBuildLifecycleKeepsReleasedWorkAvailable() {
+    MapScreenPresenter presenter;
+    presenter.show();
+    CHECK(!presenter.frameBuiltForCurrentEpoch());
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 3)) ==
+          Pyxis::MapView::Result::OK);
+    CHECK(presenter.frameBuiltForCurrentEpoch());
+
+    // Rebuilding the unchanged UI model must not revoke the worker's access
+    // to requests that were released after the first render of this epoch.
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 3)) ==
+          Pyxis::MapView::Result::OK);
+    CHECK(presenter.frameBuiltForCurrentEpoch());
+
+    CHECK(presenter.zoomBy(1));
+    CHECK(!presenter.frameBuiltForCurrentEpoch());
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 4)) ==
+          Pyxis::MapView::Result::OK);
+    CHECK(presenter.frameBuiltForCurrentEpoch());
+
+    presenter.invalidateTiles();
+    CHECK(!presenter.frameBuiltForCurrentEpoch());
+    presenter.hide();
+    CHECK(!presenter.frameBuiltForCurrentEpoch());
+}
+
 void staleCompletionsRejectedAndAcceptedOnce() {
     MapScreenPresenter presenter;
     presenter.show();
@@ -285,6 +311,7 @@ void deterministicHundredThousandOperationStress() {
 
 int main() {
     fixedCapacityAndDedupe();
+    frameBuildLifecycleKeepsReleasedWorkAvailable();
     staleCompletionsRejectedAndAcceptedOnce();
     newestFrameReusesSlotsAndPurgesOldRequests();
     generationPanZoomAndRecenterBounds();

--- a/tests/native/test_map_screen_presenter.cpp
+++ b/tests/native/test_map_screen_presenter.cpp
@@ -229,6 +229,28 @@ void resultStatesAndQueueLimit() {
     CHECK(presenter.completionCount() == 0);
 }
 
+void styleChangeInvalidatesEveryVisibleTile() {
+    MapScreenPresenter presenter;
+    presenter.show();
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 5)) ==
+          Pyxis::MapView::Result::OK);
+    MapTileRequest old_request{};
+    CHECK(presenter.takeRequest(old_request));
+    const std::uint32_t old_epoch = presenter.frameEpoch();
+    presenter.invalidateTiles();
+    CHECK(presenter.frameEpoch() != old_epoch);
+    CHECK(presenter.requestCount() == 0U);
+    CHECK(presenter.completionCount() == 0U);
+    for (std::size_t index = 0U; index < MapScreenPresenter::TILE_SLOT_COUNT; ++index) {
+        CHECK(presenter.slot(index).state == MapTileSlot::EMPTY);
+    }
+    CHECK(!presenter.publishCompletion(
+        completionFor(old_request, MapTileLoadResult::READY)));
+    CHECK(presenter.buildFrame(requestAt(0.0, 0.0, 5)) ==
+          Pyxis::MapView::Result::OK);
+    CHECK(presenter.requestCount() == presenter.frame().tile_count);
+}
+
 void deterministicHundredThousandOperationStress() {
     MapScreenPresenter presenter;
     presenter.show();
@@ -268,6 +290,7 @@ int main() {
     generationPanZoomAndRecenterBounds();
     visibleStatusSummarizesTheCurrentFrame();
     resultStatesAndQueueLimit();
+    styleChangeInvalidatesEveryVisibleTile();
     deterministicHundredThousandOperationStress();
     std::cout << "map screen presenter: " << passed << " passed, "
               << failures << " failed\n";

--- a/tests/native/test_map_style_catalog.cpp
+++ b/tests/native/test_map_style_catalog.cpp
@@ -1,0 +1,391 @@
+#include "Hardware/TDeck/MapStyleCatalog.h"
+#include "Hardware/TDeck/MapTilePack.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+using Hardware::TDeck::ActiveMapSetCodec;
+using Hardware::TDeck::ActiveMapSetView;
+using Hardware::TDeck::MapStyleCatalog;
+using Hardware::TDeck::MapStyleCatalogResult;
+using Hardware::TDeck::MapStyleSummary;
+using Hardware::TDeck::MapTilePack;
+using Hardware::TDeck::MapTileStorage;
+using Hardware::TDeck::TileStoreResult;
+using Pyxis::MapPackManifest;
+using Pyxis::RowSpan;
+
+namespace {
+std::size_t tests_run = 0U;
+void fail(const char* expression, int line) {
+    std::cerr << "line " << line << ": " << expression << '\n';
+    std::exit(1);
+}
+#define CHECK(expression) do { if (!(expression)) fail(#expression, __LINE__); } while (false)
+void beginTest() { ++tests_run; }
+
+std::uint32_t crc32(const std::uint8_t* input, std::size_t length) {
+    std::uint32_t crc = UINT32_C(0xffffffff);
+    for (std::size_t index = 0U; index < length; ++index) {
+        crc ^= input[index];
+        for (std::uint8_t bit = 0U; bit < 8U; ++bit) {
+            crc = (crc >> 1U) ^ ((crc & 1U) != 0U ? UINT32_C(0xedb88320) : 0U);
+        }
+    }
+    return ~crc;
+}
+void putU16(std::uint8_t* output, std::uint16_t value) {
+    output[0] = static_cast<std::uint8_t>(value);
+    output[1] = static_cast<std::uint8_t>(value >> 8U);
+}
+void putU32(std::uint8_t* output, std::uint32_t value) {
+    output[0] = static_cast<std::uint8_t>(value);
+    output[1] = static_cast<std::uint8_t>(value >> 8U);
+    output[2] = static_cast<std::uint8_t>(value >> 16U);
+    output[3] = static_cast<std::uint8_t>(value >> 24U);
+}
+std::uint32_t getU32(const std::uint8_t* input) {
+    return static_cast<std::uint32_t>(input[0]) |
+        (static_cast<std::uint32_t>(input[1]) << 8U) |
+        (static_cast<std::uint32_t>(input[2]) << 16U) |
+        (static_cast<std::uint32_t>(input[3]) << 24U);
+}
+
+const char* attributionFor(const char* style) {
+    if (std::strcmp(style, "osm-bright") == 0)
+        return "(c) OpenMapTiles (c) OpenStreetMap contributors";
+    if (std::strcmp(style, "toner") == 0)
+        return "(c) MapTiler (c) OpenStreetMap contributors";
+    return "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO";
+}
+const char* sourceFor(const char* style) {
+    if (std::strcmp(style, "osm-bright") == 0) return "Oxed's Map Tile Downloader (OSM Bright)";
+    if (std::strcmp(style, "dark-matter") == 0) return "Oxed's Map Tile Downloader (Dark Matter)";
+    if (std::strcmp(style, "positron") == 0) return "Oxed's Map Tile Downloader (Positron)";
+    return "Oxed's Map Tile Downloader (Toner)";
+}
+const char* licenseFor(const char* style) {
+    if (std::strcmp(style, "osm-bright") == 0)
+        return "OSM ODbL; style CC-BY-4.0/BSD-3-Clause";
+    if (std::strcmp(style, "toner") == 0)
+        return "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)";
+    return "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)";
+}
+
+std::size_t makeRecord(std::uint8_t* output, const char* style, std::uint32_t generation,
+                       const char* first_pack = "overview", const char* second_pack = NULL) {
+    std::memset(output, 0, ActiveMapSetCodec::MAX_SERIALIZED_SIZE);
+    output[0] = 'P'; output[1] = 'M'; output[2] = 'A'; output[3] = 'S'; output[4] = 2U;
+    putU32(output + 8U, generation);
+    std::size_t position = 12U;
+    const std::size_t style_length = std::strlen(style);
+    output[position++] = static_cast<std::uint8_t>(style_length);
+    std::memcpy(output + position, style, style_length); position += style_length;
+    const char* attribution = attributionFor(style);
+    const std::size_t attribution_length = std::strlen(attribution);
+    output[position++] = static_cast<std::uint8_t>(attribution_length);
+    std::memcpy(output + position, attribution, attribution_length); position += attribution_length;
+    output[position++] = second_pack == NULL ? 1U : 2U;
+    const char* packs[2] = {first_pack, second_pack};
+    const std::size_t pack_count = second_pack == NULL ? 1U : 2U;
+    for (std::size_t pack = 0U; pack < pack_count; ++pack) {
+        const std::size_t id_length = std::strlen(packs[pack]);
+        output[position++] = static_cast<std::uint8_t>(id_length);
+        std::memcpy(output + position, packs[pack], id_length); position += id_length;
+        putU16(output + position, 1U); position += 2U;
+        output[position++] = 2U;
+        putU32(output + position, 1U); position += 4U;
+        putU32(output + position, static_cast<std::uint32_t>(pack + 1U)); position += 4U;
+        putU32(output + position, static_cast<std::uint32_t>(pack + 1U)); position += 4U;
+    }
+    const std::size_t length = position + 4U;
+    putU16(output + 6U, static_cast<std::uint16_t>(length));
+    putU32(output + position, crc32(output, position));
+    return length;
+}
+void refreshCrc(std::uint8_t* record, std::size_t length) {
+    putU32(record + length - 4U, crc32(record, length - 4U));
+}
+
+struct File {
+    char path[96];
+    std::uint8_t bytes[ActiveMapSetCodec::MAX_SERIALIZED_SIZE + 1U];
+    std::size_t size;
+};
+
+class FakeStorage : public MapTileStorage {
+public:
+    FakeStorage() : available(true), file_count(0U), read_file(NULL), read_position(0U),
+        write_file(NULL), write_size(0U), list_calls(0U), abort_calls(0U), begin_write_calls(0U),
+        fail_active_slot_reads(false), fail_write(false), fail_commit(false),
+        corrupt_after_commit(false), short_write(false), fail_manifest_reads(false) {}
+
+    File* find(const char* path) {
+        for (std::size_t index = 0U; index < file_count; ++index) {
+            if (std::strcmp(files[index].path, path) == 0) return &files[index];
+        }
+        return NULL;
+    }
+    void add(const char* path, const std::uint8_t* bytes, std::size_t size) {
+        File* file = find(path);
+        if (file == NULL) {
+            CHECK(file_count < 10U); file = &files[file_count++];
+            CHECK(std::strlen(path) < sizeof(file->path)); std::strcpy(file->path, path);
+        }
+        CHECK(size <= sizeof(file->bytes));
+        if (size != 0U) std::memcpy(file->bytes, bytes, size);
+        file->size = size;
+    }
+    void erase(const char* path) {
+        for (std::size_t index = 0U; index < file_count; ++index) {
+            if (std::strcmp(files[index].path, path) != 0) continue;
+            files[index] = files[file_count - 1U]; --file_count; return;
+        }
+    }
+    virtual bool isAvailable() const { return available; }
+    virtual TileStoreResult beginRead(const char* path, std::uint32_t& size) {
+        if (!available) return TileStoreResult::STORAGE_UNAVAILABLE;
+        if (fail_active_slot_reads && std::strstr(path, "active-pack.") != NULL) return TileStoreResult::IO_ERROR;
+        if (fail_manifest_reads && std::strstr(path, "manifest.pmp") != NULL) return TileStoreResult::BUSY;
+        if (read_file != NULL) return TileStoreResult::BUSY;
+        File* file = find(path); if (file == NULL) return TileStoreResult::MISS;
+        read_file = file; read_position = 0U; size = static_cast<std::uint32_t>(file->size);
+        return TileStoreResult::OK;
+    }
+    virtual TileStoreResult readChunk(std::uint8_t* output, std::size_t capacity, std::size_t& count) {
+        count = 0U; if (read_file == NULL) return TileStoreResult::IO_ERROR;
+        const std::size_t remaining = read_file->size - read_position;
+        count = remaining < capacity ? remaining : capacity;
+        if (count != 0U) std::memcpy(output, read_file->bytes + read_position, count);
+        read_position += count; return TileStoreResult::OK;
+    }
+    virtual void endRead() { read_file = NULL; read_position = 0U; }
+    virtual TileStoreResult beginWrite(const char* path) {
+        ++begin_write_calls;
+        if (fail_write || write_file != NULL) return TileStoreResult::IO_ERROR;
+        File* file = find(path);
+        if (file == NULL) {
+            CHECK(file_count < 10U); file = &files[file_count++];
+            std::strcpy(file->path, path); file->size = 0U;
+        }
+        write_file = file; write_size = 0U; return TileStoreResult::OK;
+    }
+    virtual TileStoreResult writeChunk(const std::uint8_t* data, std::size_t size, std::size_t& written) {
+        written = 0U; if (write_file == NULL) return TileStoreResult::IO_ERROR;
+        const std::size_t amount = short_write && size > 1U ? size - 1U : size;
+        CHECK(write_size + amount <= sizeof(write_file->bytes));
+        std::memcpy(write_file->bytes + write_size, data, amount); write_size += amount; written = amount;
+        return short_write ? TileStoreResult::IO_ERROR : TileStoreResult::OK;
+    }
+    virtual TileStoreResult commitWrite() {
+        if (write_file == NULL || fail_commit) return TileStoreResult::IO_ERROR;
+        write_file->size = write_size;
+        if (corrupt_after_commit && write_file->size != 0U) write_file->bytes[write_file->size - 1U] ^= 1U;
+        write_file = NULL; write_size = 0U; return TileStoreResult::OK;
+    }
+    virtual void abortWrite() { ++abort_calls; write_file = NULL; write_size = 0U; }
+    virtual TileStoreResult remove(const char*) { return TileStoreResult::IO_ERROR; }
+    virtual TileStoreResult rename(const char*, const char*) { return TileStoreResult::IO_ERROR; }
+    virtual TileStoreResult stat(const char*, std::uint32_t&) { return TileStoreResult::IO_ERROR; }
+    virtual TileStoreResult beginList() { ++list_calls; return TileStoreResult::IO_ERROR; }
+    virtual TileStoreResult nextList(char*, std::size_t, bool&) { ++list_calls; return TileStoreResult::IO_ERROR; }
+    virtual void endList() { ++list_calls; }
+
+    bool available; File files[10]; std::size_t file_count; File* read_file; std::size_t read_position;
+    File* write_file; std::size_t write_size; std::size_t list_calls; std::size_t abort_calls;
+    std::size_t begin_write_calls;
+    bool fail_active_slot_reads; bool fail_write; bool fail_commit; bool corrupt_after_commit; bool short_write;
+    bool fail_manifest_reads;
+};
+
+void addStyleManifest(FakeStorage& storage, const char* style, const char* pack_id,
+                      bool mismatch = false) {
+    MapPackManifest manifest = {};
+    std::strcpy(manifest.pack_id, pack_id); std::strcpy(manifest.name, "Style pack");
+    std::strcpy(manifest.attribution, mismatch ? "wrong attribution" : attributionFor(style));
+    std::strcpy(manifest.source, sourceFor(style)); std::strcpy(manifest.license, licenseFor(style));
+    manifest.min_zoom = 2U; manifest.max_zoom = 2U; manifest.tile_count = 1U;
+    const RowSpan span = {2U, 1U, 1U, 1U};
+    std::uint8_t bytes[MapPackManifest::MAX_SERIALIZED_SIZE]; std::size_t written = 0U;
+    CHECK(MapPackManifest::serializeSparse(manifest, &span, 1U, bytes, sizeof(bytes), written) ==
+          Pyxis::ManifestResult::OK);
+    char path[MapTilePack::PATH_CAPACITY];
+    CHECK(MapTilePack::manifestPath(pack_id, path, sizeof(path)) ==
+          Hardware::TDeck::MapTilePackResult::OK);
+    storage.add(path, bytes, written);
+}
+
+void addStyle(FakeStorage& storage, const char* style, std::uint32_t generation = 1U) {
+    std::uint8_t record[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    const std::size_t length = makeRecord(record, style, generation, style);
+    char path[80]; std::strcpy(path, "/pyxis-map/map-sets/"); std::strcat(path, style); std::strcat(path, ".pmas");
+    storage.add(path, record, length);
+    addStyleManifest(storage, style, style);
+}
+void addActive(FakeStorage& storage, unsigned slot, const char* style, std::uint32_t generation) {
+    std::uint8_t record[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    const std::size_t length = makeRecord(record, style, generation);
+    storage.add(slot == 0U ? MapStyleCatalog::ACTIVE_SLOT_0_PATH : MapStyleCatalog::ACTIVE_SLOT_1_PATH,
+                record, length);
+}
+
+void testCodecAcceptsCanonicalAndResequences() {
+    beginTest(); std::uint8_t input[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    std::uint8_t output[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    const std::size_t length = makeRecord(input, "osm-bright", 7U, "overview", "detail");
+    ActiveMapSetView view = {};
+    CHECK(ActiveMapSetCodec::decode(input, length, view));
+    CHECK(view.generation == 7U); CHECK(std::strcmp(view.map_set_id, "osm-bright") == 0);
+    CHECK(view.pack_count == 2U); CHECK(view.total_span_count == 2U);
+    std::size_t written = 0U;
+    CHECK(ActiveMapSetCodec::resequence(input, length, 8U, output, sizeof(output), written));
+    CHECK(written == length); CHECK(getU32(output + 8U) == 8U);
+    CHECK(ActiveMapSetCodec::decode(output, written, view));
+}
+void testCodecRejectsMalformedCanonicalFields() {
+    beginTest(); std::uint8_t record[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    std::size_t length = makeRecord(record, "osm-bright", 1U, "same", "same");
+    ActiveMapSetView view = {}; CHECK(!ActiveMapSetCodec::decode(record, length, view));
+    length = makeRecord(record, "osm-bright", 1U);
+    record[12U] = 10U; record[13U] = 'O'; refreshCrc(record, length);
+    CHECK(!ActiveMapSetCodec::decode(record, length, view));
+    length = makeRecord(record, "osm-bright", 1U);
+    record[length - 5U] = 2U; refreshCrc(record, length);
+    CHECK(!ActiveMapSetCodec::decode(record, length, view));
+    CHECK(!ActiveMapSetCodec::decode(record, ActiveMapSetCodec::MAX_SERIALIZED_SIZE + 1U, view));
+}
+void testDiscoveryUsesOnlyAllowlistedExactPaths() {
+    beginTest(); FakeStorage storage; addStyle(storage, "osm-bright"); addStyle(storage, "positron");
+    std::uint8_t rogue[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+    storage.add("/pyxis-map/map-sets/rogue.pmas", rogue, makeRecord(rogue, "rogue", 1U));
+    MapStyleCatalog catalog(storage); CHECK(catalog.discover() == MapStyleCatalogResult::OK);
+    CHECK(catalog.count() == 2U); CHECK(std::strcmp(catalog.style(0U)->id, "osm-bright") == 0);
+    CHECK(std::strcmp(catalog.style(1U)->id, "positron") == 0); CHECK(storage.list_calls == 0U);
+}
+void testDiscoveryRejectsMismatchedAndMalformedStyleRecords() {
+    beginTest(); FakeStorage mismatch; addStyle(mismatch, "dark-matter");
+    File* file = mismatch.find("/pyxis-map/map-sets/dark-matter.pmas"); CHECK(file != NULL);
+    file->bytes[13U] = 'x'; refreshCrc(file->bytes, file->size);
+    MapStyleCatalog first(mismatch); CHECK(first.discover() == MapStyleCatalogResult::INVALID_STYLE_RECORD);
+
+    FakeStorage oversized; std::uint8_t bytes[ActiveMapSetCodec::MAX_SERIALIZED_SIZE + 1U] = {};
+    oversized.add("/pyxis-map/map-sets/toner.pmas", bytes, sizeof(bytes));
+    MapStyleCatalog second(oversized); CHECK(second.discover() == MapStyleCatalogResult::INVALID_STYLE_RECORD);
+}
+void testMissingCurrentRecordIsSynthesizedWithoutWrite() {
+    beginTest(); FakeStorage storage; addActive(storage, 0U, "toner", 9U);
+    MapStyleCatalog catalog(storage); CHECK(catalog.discover() == MapStyleCatalogResult::OK);
+    CHECK(catalog.count() == 1U); const MapStyleSummary* style = catalog.style(0U); CHECK(style != NULL);
+    CHECK(std::strcmp(style->id, "toner") == 0); CHECK(style->active); CHECK(style->synthesized);
+    CHECK(storage.find("/pyxis-map/map-sets/toner.pmas") == NULL); CHECK(storage.list_calls == 0U);
+}
+void testStaleAndUnknownActivationAreRejectedWithoutWrite() {
+    beginTest(); FakeStorage storage; addStyle(storage, "osm-bright"); addStyle(storage, "dark-matter");
+    addActive(storage, 0U, "osm-bright", 4U); MapStyleCatalog catalog(storage);
+    CHECK(catalog.discover() == MapStyleCatalogResult::OK); const std::uint32_t generation = catalog.generation();
+    CHECK(catalog.activate(generation - 1U, "dark-matter") == MapStyleCatalogResult::STALE_CATALOG);
+    CHECK(catalog.activate(generation, "rogue") == MapStyleCatalogResult::UNKNOWN_STYLE);
+    CHECK(storage.find(MapStyleCatalog::ACTIVE_SLOT_1_PATH) == NULL);
+}
+void testActivationTargetsMissingThenOlderSlotAndVerifiesBytes() {
+    beginTest(); FakeStorage storage; addStyle(storage, "osm-bright"); addStyle(storage, "dark-matter");
+    addActive(storage, 0U, "osm-bright", 4U); MapStyleCatalog catalog(storage);
+    CHECK(catalog.discover() == MapStyleCatalogResult::OK); std::uint32_t generation = catalog.generation();
+    CHECK(catalog.activate(generation, "dark-matter") == MapStyleCatalogResult::OK);
+    File* slot1 = storage.find(MapStyleCatalog::ACTIVE_SLOT_1_PATH); CHECK(slot1 != NULL);
+    ActiveMapSetView view = {}; CHECK(ActiveMapSetCodec::decode(slot1->bytes, slot1->size, view));
+    CHECK(view.generation == 5U); CHECK(std::strcmp(view.map_set_id, "dark-matter") == 0);
+    generation = catalog.generation();
+    CHECK(catalog.activate(generation, "osm-bright") == MapStyleCatalogResult::OK);
+    File* slot0 = storage.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH); CHECK(slot0 != NULL);
+    CHECK(ActiveMapSetCodec::decode(slot0->bytes, slot0->size, view)); CHECK(view.generation == 6U);
+}
+void testActivationSemanticallyValidatesBeforeAnySlotWrite() {
+    beginTest();
+    for (std::size_t case_index = 0U; case_index < 4U; ++case_index) {
+        FakeStorage storage; addStyle(storage, "dark-matter"); addActive(storage, 0U, "osm-bright", 3U);
+        MapStyleCatalog catalog(storage); CHECK(catalog.discover() == MapStyleCatalogResult::OK);
+        File* prior = storage.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH); CHECK(prior != NULL);
+        std::uint8_t prior_bytes[ActiveMapSetCodec::MAX_SERIALIZED_SIZE];
+        const std::size_t prior_size = prior->size; std::memcpy(prior_bytes, prior->bytes, prior_size);
+        if (case_index == 0U) {
+            storage.erase("/pyxis-map/packs/dark-matter/manifest.pmp");
+        } else if (case_index == 1U) {
+            File* manifest = storage.find("/pyxis-map/packs/dark-matter/manifest.pmp");
+            CHECK(manifest != NULL); manifest->bytes[0] ^= 1U;
+        } else if (case_index == 2U) {
+            addStyleManifest(storage, "dark-matter", "dark-matter", true);
+        } else {
+            storage.fail_manifest_reads = true;
+        }
+        const MapStyleCatalogResult expected = case_index == 3U
+            ? MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE
+            : MapStyleCatalogResult::INVALID_STYLE_RECORD;
+        CHECK(catalog.activate(catalog.generation(), "dark-matter") == expected);
+        CHECK(storage.begin_write_calls == 0U);
+        prior = storage.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH);
+        CHECK(prior != NULL && prior->size == prior_size);
+        CHECK(std::memcmp(prior->bytes, prior_bytes, prior_size) == 0);
+        CHECK(storage.find(MapStyleCatalog::ACTIVE_SLOT_1_PATH) == NULL);
+    }
+}
+void testActivationRejectsIndeterminateConflictAndExhaustion() {
+    beginTest(); FakeStorage io; addStyle(io, "dark-matter"); io.fail_active_slot_reads = true;
+    MapStyleCatalog first(io); CHECK(first.discover() == MapStyleCatalogResult::ACTIVE_IO_INDETERMINATE);
+
+    FakeStorage conflict; addStyle(conflict, "dark-matter"); addActive(conflict, 0U, "osm-bright", 7U);
+    addActive(conflict, 1U, "positron", 7U); MapStyleCatalog second(conflict);
+    CHECK(second.discover() == MapStyleCatalogResult::ACTIVE_CONFLICT);
+
+    FakeStorage exhausted; addStyle(exhausted, "dark-matter"); addActive(exhausted, 0U, "osm-bright", UINT32_MAX);
+    MapStyleCatalog third(exhausted); CHECK(third.discover() == MapStyleCatalogResult::OK);
+    CHECK(third.activate(third.generation(), "dark-matter") == MapStyleCatalogResult::GENERATION_EXHAUSTED);
+}
+void testWriteAndReadbackFailuresPreservePriorValidSlot() {
+    beginTest(); FakeStorage torn; addStyle(torn, "dark-matter"); addActive(torn, 0U, "osm-bright", 3U);
+    MapStyleCatalog first(torn); CHECK(first.discover() == MapStyleCatalogResult::OK); torn.fail_commit = true;
+    CHECK(first.activate(first.generation(), "dark-matter") == MapStyleCatalogResult::WRITE_FAILED);
+    File* prior = torn.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH); ActiveMapSetView view = {};
+    CHECK(prior != NULL && ActiveMapSetCodec::decode(prior->bytes, prior->size, view));
+    CHECK(view.generation == 3U && std::strcmp(view.map_set_id, "osm-bright") == 0);
+    CHECK(torn.abort_calls == 1U);
+
+    FakeStorage corrupt; addStyle(corrupt, "dark-matter"); addActive(corrupt, 0U, "osm-bright", 3U);
+    MapStyleCatalog second(corrupt); CHECK(second.discover() == MapStyleCatalogResult::OK);
+    corrupt.corrupt_after_commit = true;
+    CHECK(second.activate(second.generation(), "dark-matter") == MapStyleCatalogResult::READBACK_MISMATCH);
+    prior = corrupt.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH);
+    CHECK(prior != NULL && ActiveMapSetCodec::decode(prior->bytes, prior->size, view));
+    CHECK(view.generation == 3U);
+}
+void testCatalogIsFixedBoundedAndCopiesSummaries() {
+    beginTest(); FakeStorage storage; addStyle(storage, "osm-bright"); addStyle(storage, "dark-matter");
+    addStyle(storage, "positron"); addStyle(storage, "toner"); MapStyleCatalog catalog(storage);
+    CHECK(catalog.discover() == MapStyleCatalogResult::OK); CHECK(catalog.count() == MapStyleCatalog::MAX_STYLES);
+    for (std::size_t index = 0U; index < catalog.count(); ++index) {
+        CHECK(catalog.style(index) != NULL); CHECK(catalog.style(index)->pack_count == 1U);
+        CHECK(std::strcmp(catalog.style(index)->attribution,
+                          attributionFor(catalog.style(index)->id)) == 0);
+    }
+    CHECK(catalog.style(MapStyleCatalog::MAX_STYLES) == NULL); CHECK(storage.list_calls == 0U);
+}
+}  // namespace
+
+int main() {
+    testCodecAcceptsCanonicalAndResequences();
+    testCodecRejectsMalformedCanonicalFields();
+    testDiscoveryUsesOnlyAllowlistedExactPaths();
+    testDiscoveryRejectsMismatchedAndMalformedStyleRecords();
+    testMissingCurrentRecordIsSynthesizedWithoutWrite();
+    testStaleAndUnknownActivationAreRejectedWithoutWrite();
+    testActivationTargetsMissingThenOlderSlotAndVerifiesBytes();
+    testActivationSemanticallyValidatesBeforeAnySlotWrite();
+    testActivationRejectsIndeterminateConflictAndExhaustion();
+    testWriteAndReadbackFailuresPreservePriorValidSlot();
+    testCatalogIsFixedBoundedAndCopiesSummaries();
+    std::cout << "map style catalog: " << tests_run << " tests passed\n";
+    return 0;
+}

--- a/tests/native/test_map_style_catalog.cpp
+++ b/tests/native/test_map_style_catalog.cpp
@@ -26,6 +26,7 @@ void fail(const char* expression, int line) {
 }
 #define CHECK(expression) do { if (!(expression)) fail(#expression, __LINE__); } while (false)
 void beginTest() { ++tests_run; }
+bool rejectCommit(void*) { return false; }
 
 std::uint32_t crc32(const std::uint8_t* input, std::size_t length) {
     std::uint32_t crc = UINT32_C(0xffffffff);
@@ -290,6 +291,20 @@ void testStaleAndUnknownActivationAreRejectedWithoutWrite() {
     CHECK(catalog.activate(generation, "rogue") == MapStyleCatalogResult::UNKNOWN_STYLE);
     CHECK(storage.find(MapStyleCatalog::ACTIVE_SLOT_1_PATH) == NULL);
 }
+void testCancellationAbortsBeforePublishingActiveSlot() {
+    beginTest(); FakeStorage storage; addStyle(storage, "osm-bright");
+    addStyle(storage, "dark-matter"); addActive(storage, 0U, "osm-bright", 4U);
+    MapStyleCatalog catalog(storage); CHECK(catalog.discover() == MapStyleCatalogResult::OK);
+    CHECK(catalog.activate(catalog.generation(), "dark-matter", &rejectCommit,
+                           NULL) == MapStyleCatalogResult::CANCELLED);
+    CHECK(storage.abort_calls == 1U);
+    File* target = storage.find(MapStyleCatalog::ACTIVE_SLOT_1_PATH);
+    CHECK(target != NULL && target->size == 0U);
+    File* active = storage.find(MapStyleCatalog::ACTIVE_SLOT_0_PATH);
+    ActiveMapSetView view = {};
+    CHECK(active != NULL && ActiveMapSetCodec::decode(active->bytes, active->size, view));
+    CHECK(std::strcmp(view.map_set_id, "osm-bright") == 0);
+}
 void testActivationTargetsMissingThenOlderSlotAndVerifiesBytes() {
     beginTest(); FakeStorage storage; addStyle(storage, "osm-bright"); addStyle(storage, "dark-matter");
     addActive(storage, 0U, "osm-bright", 4U); MapStyleCatalog catalog(storage);
@@ -381,6 +396,7 @@ int main() {
     testDiscoveryRejectsMismatchedAndMalformedStyleRecords();
     testMissingCurrentRecordIsSynthesizedWithoutWrite();
     testStaleAndUnknownActivationAreRejectedWithoutWrite();
+    testCancellationAbortsBeforePublishingActiveSlot();
     testActivationTargetsMissingThenOlderSlotAndVerifiesBytes();
     testActivationSemanticallyValidatesBeforeAnySlotWrite();
     testActivationRejectsIndeterminateConflictAndExhaustion();

--- a/tests/native/test_map_style_catalog.py
+++ b/tests/native/test_map_style_catalog.py
@@ -9,20 +9,21 @@ import pytest
 from native_test import find_cxx
 
 ROOT = Path(__file__).resolve().parents[2]
-TEST_SOURCE = ROOT / "tests/native/test_map_tile_pack.cpp"
+TEST_SOURCE = ROOT / "tests/native/test_map_style_catalog.cpp"
+CATALOG_SOURCE = ROOT / "lib/tdeck_ui/Hardware/TDeck/MapStyleCatalog.cpp"
+CODEC_SOURCE = ROOT / "lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.cpp"
 PACK_SOURCE = ROOT / "lib/tdeck_ui/Hardware/TDeck/MapTilePack.cpp"
 MANIFEST_SOURCE = ROOT / "lib/tdeck_ui/UI/LXMF/MapPackManifest.cpp"
-CODEC_SOURCE = ROOT / "lib/tdeck_ui/Hardware/TDeck/ActiveMapSetCodec.cpp"
 
 
 @pytest.mark.parametrize("sanitize", [False, True], ids=["strict-cxx11", "asan-ubsan"])
-def test_map_tile_pack(tmp_path: Path, sanitize: bool) -> None:
-    binary = tmp_path / "test_map_tile_pack"
+def test_map_style_catalog(tmp_path: Path, sanitize: bool) -> None:
+    binary = tmp_path / "test_map_style_catalog"
     command = [
         find_cxx(), "-std=c++11", "-Wall", "-Wextra", "-Werror", "-pedantic",
         "-Wconversion", "-Wsign-conversion", f"-I{ROOT / 'lib/tdeck_ui'}",
-        str(TEST_SOURCE), str(PACK_SOURCE), str(MANIFEST_SOURCE), str(CODEC_SOURCE),
-        "-o", str(binary),
+        str(TEST_SOURCE), str(CATALOG_SOURCE), str(CODEC_SOURCE), str(PACK_SOURCE),
+        str(MANIFEST_SOURCE), "-o", str(binary),
     ]
     if sanitize:
         command[1:1] = ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"]
@@ -34,4 +35,4 @@ def test_map_tile_pack(tmp_path: Path, sanitize: bool) -> None:
         env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60, env=env)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert ran.stdout == "map tile pack: 26 tests passed\n"
+    assert ran.stdout == "map style catalog: 11 tests passed\n"

--- a/tests/native/test_map_style_catalog.py
+++ b/tests/native/test_map_style_catalog.py
@@ -35,4 +35,4 @@ def test_map_style_catalog(tmp_path: Path, sanitize: bool) -> None:
         env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
     ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60, env=env)
     assert ran.returncode == 0, ran.stdout + ran.stderr
-    assert ran.stdout == "map style catalog: 11 tests passed\n"
+    assert ran.stdout == "map style catalog: 12 tests passed\n"

--- a/tests/native/test_map_style_selector.cpp
+++ b/tests/native/test_map_style_selector.cpp
@@ -1,0 +1,124 @@
+#include "UI/LXMF/MapStyleSelector.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+namespace {
+int passed = 0;
+int failed = 0;
+#define CHECK(expr) do { if (expr) { ++passed; } else { ++failed; std::cerr << "FAIL line " << __LINE__ << ": " #expr << '\n'; } } while (false)
+
+Pyxis::MapStyleSummary style(const char* id, const char* label) {
+    Pyxis::MapStyleSummary result{};
+    std::strncpy(result.id, id, sizeof(result.id) - 1U);
+    std::strncpy(result.label, label, sizeof(result.label) - 1U);
+    return result;
+}
+
+void emptyAndSingleStyleDisableCycling() {
+    Pyxis::MapStyleSelector selector;
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::DISCOVERING);
+    CHECK(selector.setCatalog(4U, nullptr, 0U, nullptr));
+    CHECK(selector.count() == 0U);
+    CHECK(!selector.canCycle());
+    CHECK(!selector.requestNext(request));
+
+    const Pyxis::MapStyleSummary only[] = {style("osm-bright", "Bright")};
+    CHECK(selector.setCatalog(5U, only, 1U, "osm-bright"));
+    CHECK(std::strcmp(selector.activeId(), "osm-bright") == 0);
+    CHECK(std::strcmp(selector.activeLabel(), "Bright") == 0);
+    CHECK(!selector.canCycle());
+    CHECK(!selector.requestNext(request));
+}
+
+void cyclesDeterministicallyAndBoundsPendingIntent() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("dark-matter", "Dark"),
+        style("positron", "Positron"), style("toner", "Toner")};
+    CHECK(selector.setCatalog(9U, styles, 4U, "dark-matter"));
+    CHECK(selector.canCycle());
+
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+    CHECK(request.catalog_generation == 9U);
+    CHECK(std::strcmp(request.style_id, "positron") == 0);
+    CHECK(request.token != 0U);
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::APPLYING);
+    Pyxis::MapStyleRequest duplicate{};
+    CHECK(!selector.requestNext(duplicate));
+
+    Pyxis::MapStyleCompletion stale{};
+    stale.token = request.token + 1U;
+    stale.catalog_generation = request.catalog_generation;
+    stale.success = true;
+    std::strcpy(stale.style_id, request.style_id);
+    CHECK(!selector.complete(stale));
+    CHECK(std::strcmp(selector.activeId(), "dark-matter") == 0);
+
+    Pyxis::MapStyleCompletion failure{};
+    failure.token = request.token;
+    failure.catalog_generation = request.catalog_generation;
+    failure.success = false;
+    std::strcpy(failure.style_id, request.style_id);
+    CHECK(selector.complete(failure));
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::ERROR);
+    CHECK(std::strcmp(selector.activeId(), "dark-matter") == 0);
+
+    CHECK(selector.requestNext(request));
+    Pyxis::MapStyleCompletion success{};
+    success.token = request.token;
+    success.catalog_generation = request.catalog_generation;
+    success.success = true;
+    std::strcpy(success.style_id, request.style_id);
+    CHECK(selector.complete(success));
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::READY);
+    CHECK(std::strcmp(selector.activeId(), "positron") == 0);
+    CHECK(std::strcmp(selector.activeLabel(), "Positron") == 0);
+}
+
+void rejectsMalformedCatalogsAndStaleCompletions() {
+    Pyxis::MapStyleSelector selector;
+    Pyxis::MapStyleSummary duplicate[] = {
+        style("osm-bright", "Bright"), style("osm-bright", "Again")};
+    CHECK(!selector.setCatalog(1U, duplicate, 2U, "osm-bright"));
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("toner", "Toner")};
+    CHECK(!selector.setCatalog(0U, styles, 2U, "osm-bright"));
+    CHECK(!selector.setCatalog(2U, styles, 2U, "unknown"));
+    CHECK(selector.setCatalog(3U, styles, 2U, "osm-bright"));
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+    CHECK(selector.setCatalog(4U, styles, 2U, "osm-bright"));
+    Pyxis::MapStyleCompletion old{};
+    old.token = request.token;
+    old.catalog_generation = request.catalog_generation;
+    old.success = true;
+    std::strcpy(old.style_id, request.style_id);
+    CHECK(!selector.complete(old));
+    CHECK(std::strcmp(selector.activeId(), "osm-bright") == 0);
+}
+
+void permitsSoleInstalledStyleWhenNoRecognizedStyleIsActive() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary only[] = {style("positron", "Positron")};
+    CHECK(selector.setCatalog(9U, only, 1U, nullptr));
+    CHECK(selector.canCycle());
+    CHECK(std::strcmp(selector.activeId(), "") == 0);
+    CHECK(std::strcmp(selector.activeLabel(), "Style") == 0);
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+    CHECK(std::strcmp(request.style_id, "positron") == 0);
+}
+}
+
+int main() {
+    emptyAndSingleStyleDisableCycling();
+    cyclesDeterministicallyAndBoundsPendingIntent();
+    rejectsMalformedCatalogsAndStaleCompletions();
+    permitsSoleInstalledStyleWhenNoRecognizedStyleIsActive();
+    std::cout << "map style selector: " << passed << " passed, " << failed << " failed\n";
+    return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tests/native/test_map_style_selector.cpp
+++ b/tests/native/test_map_style_selector.cpp
@@ -47,6 +47,7 @@ void cyclesDeterministicallyAndBoundsPendingIntent() {
     CHECK(std::strcmp(request.style_id, "positron") == 0);
     CHECK(request.token != 0U);
     CHECK(selector.state() == Pyxis::MapStyleSelector::State::APPLYING);
+    CHECK(selector.activationInFlight());
     Pyxis::MapStyleRequest duplicate{};
     CHECK(!selector.requestNext(duplicate));
 
@@ -67,6 +68,8 @@ void cyclesDeterministicallyAndBoundsPendingIntent() {
     CHECK(selector.state() == Pyxis::MapStyleSelector::State::ERROR);
     CHECK(std::strcmp(selector.activeId(), "dark-matter") == 0);
 
+    CHECK(!selector.requestNext(request));
+    CHECK(selector.releaseActivation(failure.token));
     CHECK(selector.requestNext(request));
     Pyxis::MapStyleCompletion success{};
     success.token = request.token;
@@ -74,6 +77,7 @@ void cyclesDeterministicallyAndBoundsPendingIntent() {
     success.success = true;
     std::strcpy(success.style_id, request.style_id);
     CHECK(selector.complete(success));
+    CHECK(selector.releaseActivation(success.token));
     CHECK(selector.state() == Pyxis::MapStyleSelector::State::READY);
     CHECK(std::strcmp(selector.activeId(), "positron") == 0);
     CHECK(std::strcmp(selector.activeLabel(), "Positron") == 0);
@@ -91,13 +95,16 @@ void rejectsMalformedCatalogsAndStaleCompletions() {
     CHECK(selector.setCatalog(3U, styles, 2U, "osm-bright"));
     Pyxis::MapStyleRequest request{};
     CHECK(selector.requestNext(request));
-    CHECK(selector.setCatalog(4U, styles, 2U, "osm-bright"));
+    CHECK(!selector.setCatalog(4U, styles, 2U, "osm-bright"));
     Pyxis::MapStyleCompletion old{};
     old.token = request.token;
-    old.catalog_generation = request.catalog_generation;
-    old.success = true;
+    old.catalog_generation = request.catalog_generation + 1U;
+    old.success = false;
     std::strcpy(old.style_id, request.style_id);
     CHECK(!selector.complete(old));
+    old.catalog_generation = request.catalog_generation;
+    CHECK(selector.complete(old));
+    CHECK(selector.releaseActivation(old.token));
     CHECK(std::strcmp(selector.activeId(), "osm-bright") == 0);
 }
 
@@ -112,6 +119,108 @@ void permitsSoleInstalledStyleWhenNoRecognizedStyleIsActive() {
     CHECK(selector.requestNext(request));
     CHECK(std::strcmp(request.style_id, "positron") == 0);
 }
+
+void activationLeaseSpansCatalogReconciliation() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("toner", "Toner")};
+    CHECK(selector.setCatalog(7U, styles, 2U, "osm-bright"));
+
+    Pyxis::MapStyleRequest first{};
+    CHECK(selector.requestNext(first));
+    CHECK(selector.activationOwnedBy(first.token));
+    CHECK(!selector.activationOwnedBy(first.token + 1U));
+    CHECK(!selector.releaseActivation(first.token + 1U));
+
+    Pyxis::MapStyleCompletion success{};
+    success.token = first.token;
+    success.catalog_generation = first.catalog_generation;
+    success.success = true;
+    std::strcpy(success.style_id, first.style_id);
+    CHECK(selector.complete(success));
+
+    CHECK(!selector.setCatalog(8U, styles, 2U, "toner"));
+    CHECK(selector.reconcileActivation(first.token, 8U, styles, 2U, "toner", false));
+    Pyxis::MapStyleRequest second{};
+    CHECK(!selector.requestNext(second));
+    CHECK(selector.releaseActivation(first.token));
+    CHECK(!selector.activationInFlight());
+    CHECK(selector.requestNext(second));
+    CHECK(second.catalog_generation == 8U);
+    CHECK(std::strcmp(second.style_id, "osm-bright") == 0);
+}
+
+void cancellationIsScopedToUnborrowedOwner() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("toner", "Toner")};
+    CHECK(selector.setCatalog(12U, styles, 2U, "osm-bright"));
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+    CHECK(!selector.cancelPending(request.token + 1U));
+    CHECK(selector.cancelPending(request.token));
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::READY);
+
+    CHECK(selector.requestNext(request));
+    CHECK(selector.cancelPending(request.token));
+    CHECK(selector.requestNext(request));
+    Pyxis::MapStyleCompletion failure{};
+    failure.token = request.token;
+    failure.catalog_generation = request.catalog_generation;
+    failure.success = false;
+    std::strcpy(failure.style_id, request.style_id);
+    CHECK(selector.complete(failure));
+    CHECK(selector.clearError());
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::READY);
+    CHECK(selector.releaseActivation(request.token));
+}
+
+void committedActivationFailureStillReconcilesGeneration() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("toner", "Toner")};
+    CHECK(selector.setCatalog(21U, styles, 2U, "osm-bright"));
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+
+    Pyxis::MapStyleCompletion reload_failure{};
+    reload_failure.token = request.token;
+    reload_failure.catalog_generation = request.catalog_generation;
+    reload_failure.success = false;
+    std::strcpy(reload_failure.style_id, request.style_id);
+    CHECK(selector.complete(reload_failure));
+    CHECK(selector.reconcileActivation(request.token, 22U, styles, 2U,
+                                       "toner", true));
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::ERROR);
+    CHECK(selector.generation() == 22U);
+    CHECK(std::strcmp(selector.activeId(), "toner") == 0);
+    CHECK(selector.releaseActivation(request.token));
+
+    Pyxis::MapStyleRequest retry{};
+    CHECK(selector.requestNext(retry));
+    CHECK(retry.catalog_generation == 22U);
+    CHECK(std::strcmp(retry.style_id, "osm-bright") == 0);
+}
+
+void hiddenLifecycleCannotReintroduceFailureDuringReconciliation() {
+    Pyxis::MapStyleSelector selector;
+    const Pyxis::MapStyleSummary styles[] = {
+        style("osm-bright", "Bright"), style("toner", "Toner")};
+    CHECK(selector.setCatalog(30U, styles, 2U, "osm-bright"));
+    Pyxis::MapStyleRequest request{};
+    CHECK(selector.requestNext(request));
+    Pyxis::MapStyleCompletion failure{};
+    failure.token = request.token;
+    failure.catalog_generation = request.catalog_generation;
+    failure.success = false;
+    std::strcpy(failure.style_id, request.style_id);
+    CHECK(selector.complete(failure));
+    CHECK(selector.clearError());
+    CHECK(selector.reconcileActivation(request.token, 31U, styles, 2U,
+                                       "toner", false));
+    CHECK(selector.state() == Pyxis::MapStyleSelector::State::READY);
+    CHECK(selector.releaseActivation(request.token));
+}
 }
 
 int main() {
@@ -119,6 +228,10 @@ int main() {
     cyclesDeterministicallyAndBoundsPendingIntent();
     rejectsMalformedCatalogsAndStaleCompletions();
     permitsSoleInstalledStyleWhenNoRecognizedStyleIsActive();
+    activationLeaseSpansCatalogReconciliation();
+    cancellationIsScopedToUnborrowedOwner();
+    committedActivationFailureStillReconcilesGeneration();
+    hiddenLifecycleCannotReintroduceFailureDuringReconciliation();
     std::cout << "map style selector: " << passed << " passed, " << failed << " failed\n";
     return failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tests/native/test_map_style_selector.py
+++ b/tests/native/test_map_style_selector.py
@@ -1,0 +1,35 @@
+"""Compile and run the bounded map-style selector under ASan/UBSan."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+from native_test import find_cxx
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+
+
+@pytest.mark.parametrize("sanitized", [False, True], ids=["strict-cxx11", "asan-ubsan"])
+def test_map_style_selector(tmp_path, sanitized):
+    binary = tmp_path / "test_map_style_selector"
+    command = [
+        find_cxx(), "-std=c++11", "-Wall", "-Wextra", "-Werror", "-pedantic",
+        f"-I{ROOT / 'lib/tdeck_ui'}",
+        str(HERE / "test_map_style_selector.cpp"),
+        str(ROOT / "lib/tdeck_ui/UI/LXMF/MapStyleSelector.cpp"),
+        "-o", str(binary),
+    ]
+    if sanitized:
+        command[1:1] = ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"]
+    compiled = subprocess.run(command, capture_output=True, text=True, timeout=60)
+    assert compiled.returncode == 0, compiled.stdout + compiled.stderr
+    env = os.environ.copy()
+    if sanitized:
+        env["ASAN_OPTIONS"] = "detect_leaks=1:halt_on_error=1"
+        env["UBSAN_OPTIONS"] = "halt_on_error=1:print_stacktrace=1"
+    ran = subprocess.run([str(binary)], capture_output=True, text=True, timeout=60, env=env)
+    assert ran.returncode == 0, ran.stdout + ran.stderr
+    assert "0 failed" in ran.stdout

--- a/tests/native/test_map_tile_pack.cpp
+++ b/tests/native/test_map_tile_pack.cpp
@@ -54,7 +54,8 @@ class FakeStorage : public MapTileStorage {
 public:
     FakeStorage()
         : available(true), file_count(0U), open_file(NULL), position(0U),
-          read_calls(0U), end_calls(0U), fail_read_call(0U), zero_read_call(0U) {}
+          read_calls(0U), end_calls(0U), fail_read_call(0U), zero_read_call(0U),
+          fail_begin_path(NULL), fail_begin_result(TileStoreResult::IO_ERROR) {}
 
     void clear() { file_count = 0U; open_file = NULL; position = 0U; }
     void add(const char* path, const std::uint8_t* bytes, std::size_t size) {
@@ -83,6 +84,8 @@ public:
     virtual bool isAvailable() const { return available; }
     virtual TileStoreResult beginRead(const char* path, std::uint32_t& size) {
         if (!available) return TileStoreResult::STORAGE_UNAVAILABLE;
+        if (fail_begin_path != NULL && std::strcmp(path, fail_begin_path) == 0)
+            return fail_begin_result;
         if (open_file != NULL) return TileStoreResult::BUSY;
         File* file = find(path);
         if (file == NULL) return TileStoreResult::MISS;
@@ -122,6 +125,8 @@ public:
     std::size_t end_calls;
     std::size_t fail_read_call;
     std::size_t zero_read_call;
+    const char* fail_begin_path;
+    TileStoreResult fail_begin_result;
 };
 
 MapPackManifest manifestFor(const char* id) {
@@ -172,15 +177,31 @@ void testPutU16(std::uint8_t* output, std::uint16_t value) {
     output[1] = static_cast<std::uint8_t>(value >> 8U);
 }
 
-std::uint8_t hexValue(char value) {
-    if (value >= '0' && value <= '9') return static_cast<std::uint8_t>(value - '0');
-    return static_cast<std::uint8_t>(10 + value - 'a');
-}
-
 void addManifest(FakeStorage& storage, const char* id) {
     std::uint8_t bytes[MapPackManifest::MAX_SERIALIZED_SIZE];
     std::size_t written = 0U;
     CHECK(MapPackManifest::serialize(manifestFor(id), bytes, sizeof(bytes), written) == Pyxis::ManifestResult::OK);
+    char path[MapTilePack::PATH_CAPACITY];
+    CHECK(MapTilePack::manifestPath(id, path, sizeof(path)) == MapTilePackResult::OK);
+    storage.add(path, bytes, written);
+}
+
+void addSparseManifest(FakeStorage& storage, const char* id, const char* attribution,
+                       const char* source, const char* license,
+                       const RowSpan* spans, std::size_t span_count) {
+    MapPackManifest manifest = {};
+    std::strcpy(manifest.pack_id, id); std::strcpy(manifest.name, "Test Pack");
+    std::strcpy(manifest.attribution, attribution); std::strcpy(manifest.source, source);
+    std::strcpy(manifest.license, license);
+    manifest.min_zoom = spans[0].zoom; manifest.max_zoom = spans[span_count - 1U].zoom;
+    std::uint32_t tile_count = 0U;
+    for (std::size_t index = 0U; index < span_count; ++index) {
+        tile_count += spans[index].x_maximum - spans[index].x_minimum + 1U;
+    }
+    manifest.tile_count = tile_count;
+    std::uint8_t bytes[MapPackManifest::MAX_SERIALIZED_SIZE]; std::size_t written = 0U;
+    CHECK(MapPackManifest::serializeSparse(manifest, spans, span_count, bytes,
+        sizeof(bytes), written) == Pyxis::ManifestResult::OK);
     char path[MapTilePack::PATH_CAPACITY];
     CHECK(MapTilePack::manifestPath(id, path, sizeof(path)) == MapTilePackResult::OK);
     storage.add(path, bytes, written);
@@ -199,20 +220,20 @@ void addSlot(FakeStorage& storage, const char* path, const char* id, std::uint32
     storage.add(path, record, sizeof(record));
 }
 
-void addMapSetSlot(FakeStorage& storage, const char* path, std::uint32_t generation) {
+void addMapSetSlot(FakeStorage& storage, const char* path, std::uint32_t generation,
+                   const char* map_set = "osm-bright",
+                   const char* attribution = "Map data (c) OpenStreetMap contributors") {
     std::uint8_t record[256] = {};
     record[0] = 'P'; record[1] = 'M'; record[2] = 'A'; record[3] = 'S'; record[4] = 2U;
     testPutU32(record + 8U, generation);
     std::size_t position = 12U;
-    const char* map_set = "osm-bright";
-    const char* attribution = "Map data attribution";
     record[position++] = static_cast<std::uint8_t>(std::strlen(map_set));
     std::memcpy(record + position, map_set, std::strlen(map_set)); position += std::strlen(map_set);
     record[position++] = static_cast<std::uint8_t>(std::strlen(attribution));
     std::memcpy(record + position, attribution, std::strlen(attribution)); position += std::strlen(attribution);
     record[position++] = 2U;
     const char* ids[2] = {"detail", "state"};
-    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {4U, 5U, 5U, 5U}};
+    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {3U, 5U, 5U, 5U}};
     const RowSpan state[] = {{2U, 1U, 1U, 2U}};
     const RowSpan* spans[2] = {detail, state};
     const std::uint16_t counts[2] = {2U, 1U};
@@ -232,6 +253,16 @@ void addMapSetSlot(FakeStorage& storage, const char* path, std::uint32_t generat
     testPutU16(record + 6U, static_cast<std::uint16_t>(total_length));
     testPutU32(record + position, testCrc32(record, position));
     storage.add(path, record, total_length);
+}
+
+void addLegacyBrightMapSetManifests(FakeStorage& storage) {
+    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {3U, 5U, 5U, 5U}};
+    const RowSpan state[] = {{2U, 1U, 1U, 2U}};
+    const char* attribution = "Map data (c) OpenStreetMap contributors";
+    addSparseManifest(storage, "detail", attribution,
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", detail, 2U);
+    addSparseManifest(storage, "state", attribution,
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", state, 1U);
 }
 
 void testNoSelection() {
@@ -409,26 +440,101 @@ void testActiveSelectionSlotsPreferNewestValidAndRejectConflict() {
     MapTilePack conflict_pack(conflict);
     CHECK(conflict_pack.initialize() == MapTilePackResult::INVALID_PACK_ID);
 }
+void testEqualGenerationIdentityUsesLengthAndExactBytesNotTrailingChecksum() {
+    beginTest();
+    std::uint8_t first[MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE] = {};
+    std::uint8_t second[MapTilePack::LEGACY_ACTIVE_SELECTION_SIZE] = {};
+    FakeStorage records;
+    addSlot(records, "first", "one", 7U); addSlot(records, "second", "two", 7U);
+    std::memcpy(first, records.find("first")->bytes, sizeof(first));
+    std::memcpy(second, records.find("second")->bytes, sizeof(second));
+    std::memcpy(second + sizeof(second) - 4U, first + sizeof(first) - 4U, 4U);
+    CHECK(!MapTilePack::selectionRecordsEqual(first, sizeof(first), second, sizeof(second)));
+    CHECK(MapTilePack::selectionRecordsEqual(first, sizeof(first), first, sizeof(first)));
+    CHECK(!MapTilePack::selectionRecordsEqual(first, sizeof(first), first, sizeof(first) - 1U));
+}
+void testActiveMapSetRequiresAllowlistedStyleAndMatchingImmutableManifests() {
+    beginTest();
+    FakeStorage valid;
+    addMapSetSlot(valid, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    addLegacyBrightMapSetManifests(valid);
+    MapTilePack valid_pack(valid); CHECK(valid_pack.initialize() == MapTilePackResult::OK);
+
+    FakeStorage unknown;
+    addMapSetSlot(unknown, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U, "rogue");
+    addLegacyBrightMapSetManifests(unknown);
+    MapTilePack unknown_pack(unknown); CHECK(unknown_pack.initialize() != MapTilePackResult::OK);
+
+    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {3U, 5U, 5U, 5U}};
+    const RowSpan state[] = {{2U, 1U, 1U, 2U}};
+    FakeStorage altered_attribution;
+    addMapSetSlot(altered_attribution, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    addSparseManifest(altered_attribution, "detail", "changed attribution",
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", detail, 2U);
+    addSparseManifest(altered_attribution, "state", "changed attribution",
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", state, 1U);
+    MapTilePack attribution_pack(altered_attribution);
+    CHECK(attribution_pack.initialize() != MapTilePackResult::OK);
+
+    FakeStorage wrong_coverage;
+    addMapSetSlot(wrong_coverage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    const RowSpan changed_detail[] = {{2U, 1U, 1U, 2U}, {3U, 5U, 5U, 5U}};
+    addSparseManifest(wrong_coverage, "detail", "Map data (c) OpenStreetMap contributors",
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", changed_detail, 2U);
+    addSparseManifest(wrong_coverage, "state", "Map data (c) OpenStreetMap contributors",
+                      "Coalition MUI OSM Bright user download", "ODbL-1.0", state, 1U);
+    MapTilePack coverage_pack(wrong_coverage); CHECK(coverage_pack.initialize() != MapTilePackResult::OK);
+}
+void testNewCanonicalProfilesPassAndCrossStyleCompositionFails() {
+    beginTest();
+    const RowSpan detail[] = {{2U, 1U, 1U, 1U}, {3U, 5U, 5U, 5U}};
+    const RowSpan state[] = {{2U, 1U, 1U, 2U}};
+    const char* styles[] = {"osm-bright", "dark-matter", "positron", "toner"};
+    const char* labels[] = {"OSM Bright", "Dark Matter", "Positron", "Toner"};
+    const char* attributions[] = {
+        "(c) OpenMapTiles (c) OpenStreetMap contributors",
+        "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "(c) MapTiler (c) OpenStreetMap contributors"};
+    const char* licenses[] = {
+        "OSM ODbL; style CC-BY-4.0/BSD-3-Clause",
+        "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+        "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+        "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)"};
+    for (std::size_t index = 0U; index < 4U; ++index) {
+        FakeStorage storage;
+        addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U,
+                      styles[index], attributions[index]);
+        char source[128] = {}; std::snprintf(source, sizeof(source),
+            "Oxed's Map Tile Downloader (%s)", labels[index]);
+        addSparseManifest(storage, "detail", attributions[index], source, licenses[index], detail, 2U);
+        addSparseManifest(storage, "state", attributions[index], source, licenses[index], state, 1U);
+        MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
+    }
+
+    FakeStorage mixed;
+    addMapSetSlot(mixed, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U, "dark-matter", attributions[1]);
+    addSparseManifest(mixed, "detail", attributions[1],
+                      "Oxed's Map Tile Downloader (Positron)", licenses[2], detail, 2U);
+    addSparseManifest(mixed, "state", attributions[1],
+                      "Oxed's Map Tile Downloader (Dark Matter)", licenses[1], state, 1U);
+    MapTilePack mixed_pack(mixed); CHECK(mixed_pack.initialize() != MapTilePackResult::OK);
+}
 void testActiveMapSetComposesPacksByPriorityAndCoverage() {
     beginTest();
     FakeStorage storage;
     addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
-    const char* golden = "504d415302006900010000000a6f736d2d627269676874144d61702064617461206174747269627574696f6e020664657461696c020002010000000100000001000000040500000005000000050000000573746174650100020100000001000000020000009de230d6";
-    File* selection = storage.find(MapTilePack::ACTIVE_PACK_SLOT_0_PATH); CHECK(selection != NULL);
-    CHECK(selection->size * 2U == std::strlen(golden));
-    for (std::size_t index = 0U; index < selection->size; ++index) {
-        CHECK(selection->bytes[index] == static_cast<std::uint8_t>((hexValue(golden[index * 2U]) << 4U) | hexValue(golden[index * 2U + 1U])));
-    }
+    addLegacyBrightMapSetManifests(storage);
     const std::uint8_t detail = 1U, state_overlap = 2U, state_wide = 3U, detail_high = 4U;
     storage.add("/pyxis-map/packs/detail/tiles/2/1/1.png", &detail, 1U);
-    storage.add("/pyxis-map/packs/detail/tiles/4/5/5.png", &detail_high, 1U);
+    storage.add("/pyxis-map/packs/detail/tiles/3/5/5.png", &detail_high, 1U);
     storage.add("/pyxis-map/packs/state/tiles/2/1/1.png", &state_overlap, 1U);
     storage.add("/pyxis-map/packs/state/tiles/2/2/1.png", &state_wide, 1U);
     MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
     CHECK(std::strcmp(pack.metadata().pack_id, "osm-bright") == 0);
     CHECK(pack.selectionGeneration() == 1U);
-    CHECK(std::strcmp(pack.metadata().attribution, "Map data attribution") == 0);
-    const TileKey keys[] = {{2U,1U,1U},{2U,2U,1U},{4U,5U,5U}};
+    CHECK(std::strcmp(pack.metadata().attribution, "Map data (c) OpenStreetMap contributors") == 0);
+    const TileKey keys[] = {{2U,1U,1U},{2U,2U,1U},{3U,5U,5U}};
     const std::uint8_t expected[] = {detail,state_wide,detail_high};
     for (std::size_t index = 0U; index < 3U; ++index) {
         std::uint32_t size = 0U; CHECK(pack.beginGet(keys[index], size) == MapTilePackResult::OK); CHECK(size == 1U);
@@ -436,16 +542,62 @@ void testActiveMapSetComposesPacksByPriorityAndCoverage() {
         CHECK(pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK); CHECK(count == 1U); CHECK(output == expected[index]);
     }
     std::uint32_t size = 0U;
-    CHECK(pack.beginGet(TileKey{3U,1U,1U}, size) == MapTilePackResult::UNCOVERED);
+    CHECK(pack.beginGet(TileKey{4U,1U,1U}, size) == MapTilePackResult::UNCOVERED);
 
     FakeStorage fallback;
     addMapSetSlot(fallback, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 1U);
+    addLegacyBrightMapSetManifests(fallback);
     fallback.add("/pyxis-map/packs/state/tiles/2/1/1.png", &state_overlap, 1U);
     MapTilePack fallback_pack(fallback); CHECK(fallback_pack.initialize() == MapTilePackResult::OK);
     CHECK(fallback_pack.beginGet(TileKey{2U,1U,1U}, size) == MapTilePackResult::OK);
     std::uint8_t output = 0U; std::size_t count = 0U;
     CHECK(fallback_pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK);
     CHECK(output == state_overlap);
+}
+void testRebootFallsBackFromNewerSemanticallyInvalidMapSet() {
+    beginTest(); FakeStorage storage;
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 4U);
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, 5U, "dark-matter",
+                  "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO");
+    addLegacyBrightMapSetManifests(storage);
+    const std::uint8_t tile = 0x5aU;
+    storage.add("/pyxis-map/packs/detail/tiles/2/1/1.png", &tile, 1U);
+    MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
+    CHECK(pack.selectionGeneration() == 4U);
+    CHECK(std::strcmp(pack.metadata().pack_id, "osm-bright") == 0);
+    std::uint32_t size = 0U; CHECK(pack.beginGet(TileKey{2U,1U,1U}, size) == MapTilePackResult::OK);
+    std::uint8_t output = 0U; std::size_t count = 0U;
+    CHECK(pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK);
+    CHECK(count == 1U && output == tile);
+}
+void testNewerManifestIndeterminateDoesNotFallBackAndPreservesSelection() {
+    beginTest(); FakeStorage storage;
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 4U);
+    addLegacyBrightMapSetManifests(storage);
+    const std::uint8_t tile = 0x6bU;
+    storage.add("/pyxis-map/packs/detail/tiles/2/1/1.png", &tile, 1U);
+    MapTilePack pack(storage); CHECK(pack.initialize() == MapTilePackResult::OK);
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, 5U, "dark-matter",
+                  "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO");
+    storage.fail_begin_path = "/pyxis-map/packs/detail/manifest.pmp";
+    storage.fail_begin_result = TileStoreResult::BUSY;
+    CHECK(pack.initialize() == MapTilePackResult::BUSY);
+    CHECK(pack.status() == MapTilePackStatus::READY);
+    CHECK(pack.selectionGeneration() == 4U);
+    CHECK(std::strcmp(pack.metadata().pack_id, "osm-bright") == 0);
+    std::uint32_t size = 0U; CHECK(pack.beginGet(TileKey{2U,1U,1U}, size) == MapTilePackResult::OK);
+    std::uint8_t output = 0U; std::size_t count = 0U;
+    CHECK(pack.readGetChunk(&output, 1U, count) == MapTilePackResult::OK);
+    CHECK(count == 1U && output == tile);
+}
+void testBothSemanticallyInvalidSlotsDoNotUseLegacyMarker() {
+    beginTest(); FakeStorage storage;
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_0_PATH, 4U, "rogue");
+    addMapSetSlot(storage, MapTilePack::ACTIVE_PACK_SLOT_1_PATH, 5U, "also-rogue");
+    addSelection(storage, "legacy", manifestFor("legacy"));
+    MapTilePack pack(storage);
+    CHECK(pack.initialize() == MapTilePackResult::INVALID_MANIFEST);
+    CHECK(!pack.hasSelection());
 }
 void testCoreDoesNotAllocate() {
     beginTest(); FakeStorage storage; addSelection(storage, "one", manifestFor("one")); const std::uint8_t tile[] = {7U};
@@ -463,7 +615,13 @@ int main() {
     testPrematureEndCloses(); testReinitializeSelectionChange(); testFailedReinitializeIsTransactional();
     testReinitializeAndDestructorCloseStreams(); testDeclaredLengthsAndEmbeddedNulFailClosed();
     testTileDeclaredLengthCapsWritesAndProbesEof(); testActiveSelectionSlotsPreferNewestValidAndRejectConflict();
+    testEqualGenerationIdentityUsesLengthAndExactBytesNotTrailingChecksum();
+    testActiveMapSetRequiresAllowlistedStyleAndMatchingImmutableManifests();
+    testNewCanonicalProfilesPassAndCrossStyleCompositionFails();
     testActiveMapSetComposesPacksByPriorityAndCoverage();
+    testRebootFallsBackFromNewerSemanticallyInvalidMapSet();
+    testNewerManifestIndeterminateDoesNotFallBackAndPreservesSelection();
+    testBothSemanticallyInvalidSlotsDoNotUseLegacyMarker();
     testCoreDoesNotAllocate();
     std::cout << "map tile pack: " << tests_run << " tests passed\n";
     return 0;

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -7,9 +7,11 @@ import test from 'node:test';
 import {
   decodeActiveSelection,
   encodeActiveMapSet,
+  getMuiStyleProfile,
   inspectMuiZip,
   installMuiZip,
   parseSparseManifest,
+  resolveMuiStyleProfile,
 } from '../../docs/flasher/js/map-installer.js';
 
 const PNG = Buffer.from(
@@ -178,10 +180,73 @@ const metadata = {
   packId: 'overview',
   mapSetId: 'osm-bright',
   name: 'Overview',
-  attribution: 'Map data (c) OpenStreetMap contributors',
-  source: 'Coalition MUI OSM Bright user download',
-  license: 'ODbL-1.0',
+  attribution: '(c) OpenMapTiles (c) OpenStreetMap contributors',
+  source: "Oxed's Map Tile Downloader (OSM Bright)",
+  license: 'OSM ODbL; style CC-BY-4.0/BSD-3-Clause',
 };
+
+test('maps supported Coalition styles to separate map sets and provenance', async () => {
+  const expected = [
+    ['osm-bright', 'OSM Bright', '(c) OpenMapTiles (c) OpenStreetMap contributors',
+      'OSM ODbL; style CC-BY-4.0/BSD-3-Clause'],
+    ['dark-matter', 'Dark Matter', '(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO',
+      'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)'],
+    ['positron', 'Positron', '(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO',
+      'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)'],
+    ['toner', 'Toner', '(c) MapTiler (c) OpenStreetMap contributors',
+      'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)'],
+  ];
+  for (const [styleId, label, attribution, license] of expected) {
+    assert.deepEqual(getMuiStyleProfile(styleId), {
+      id: styleId,
+      label,
+      attribution,
+      source: `Oxed's Map Tile Downloader (${label})`,
+      license,
+    });
+    const report = await inspectMuiZip(storedZip([[`maps/${styleId}/2/1/1.png`, PNG]]));
+    assert.equal(report.styleId, styleId);
+  }
+  assert.throws(() => getMuiStyleProfile('unknown-style'), /unsupported MUI map style/i);
+});
+
+test('rootless archive requires explicit style before SD mutation and then installs', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const report = await inspectMuiZip(archive);
+  assert.equal(report.styleId, null);
+  const root = new MemoryDirectoryHandle();
+  assert.throws(() => resolveMuiStyleProfile(report.styleId, ''), /select map style/i);
+  assert.equal(root.children.has('pyxis-map'), false);
+
+  const style = resolveMuiStyleProfile(report.styleId, 'positron');
+  assert.equal(style.id, 'positron');
+  const result = await installMuiZip({archive, rootDirectory:root, metadata:{
+    ...metadata, mapSetId:style.id, attribution:style.attribution,
+    source:style.source, license:style.license,
+  }});
+  assert.equal(result.tileCount, 1);
+  assert.ok(root.children.has('pyxis-map'));
+});
+
+test('rejects installing a detected style into a different map set', async () => {
+  const archive = storedZip([['maps/dark-matter/2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  await assert.rejects(
+    installMuiZip({archive, rootDirectory:root, metadata}),
+    /style.*selected map set/i,
+  );
+  assert.equal(root.children.has('pyxis-map'), false);
+});
+
+test('rejects altered required style attribution before touching the SD root', async () => {
+  const root = new MemoryDirectoryHandle();
+  await assert.rejects(
+    installMuiZip({archive:storedZip([['2/1/1.png', PNG]]),rootDirectory:root,
+      metadata:{...metadata,attribution:'Map data'}}),
+    /attribution|provenance/i,
+  );
+  assert.equal(root.children.has('pyxis-map'), false);
+});
 
 test('active map-set wire format matches the cross-language golden record', () => {
   const record = encodeActiveMapSet({generation:1,mapSetId:'osm-bright',attribution:'Map data attribution',packs:[
@@ -307,6 +372,7 @@ test('inspects and transactionally installs a sparse stored MUI XYZ ZIP', async 
   assert.equal(report.tileCount, 3);
   assert.equal(report.minZoom, 2);
   assert.equal(report.maxZoom, 2);
+  assert.equal(report.styleId, null);
   assert.deepEqual(report.rowSpans, [
     {zoom: 2, y: 1, xMinimum: 1, xMaximum: 2},
     {zoom: 2, y: 2, xMinimum: 1, xMaximum: 1},
@@ -327,6 +393,11 @@ test('inspects and transactionally installs a sparse stored MUI XYZ ZIP', async 
   assert.equal(selection.mapSetId, 'osm-bright');
   assert.deepEqual(selection.packs.map(pack => pack.packId), ['overview']);
   assert.equal(selection.generation, 1);
+  const firstCatalog = decodeActiveSelection(
+    (await child(root, 'pyxis-map/map-sets/osm-bright.pmas')).bytes,
+  );
+  assert.equal(firstCatalog.mapSetId, 'osm-bright');
+  assert.deepEqual(firstCatalog.packs.map(pack => pack.packId), ['overview']);
   const firstManifestWrite = root.log.indexOf('write:manifest.pmp');
   assert(firstManifestWrite > root.log.lastIndexOf('write:1.png'));
   assert(root.log.indexOf('write:active-pack.0') > firstManifestWrite);
@@ -339,6 +410,10 @@ test('inspects and transactionally installs a sparse stored MUI XYZ ZIP', async 
   const secondSelection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.1')).bytes);
   assert.equal(secondSelection.generation, 2);
   assert.deepEqual(secondSelection.packs.map(pack => pack.packId), ['overview-two','overview']);
+  const secondCatalog = decodeActiveSelection(
+    (await child(root, 'pyxis-map/map-sets/osm-bright.pmas')).bytes,
+  );
+  assert.deepEqual(secondCatalog.packs.map(pack => pack.packId), ['overview-two','overview']);
   const third = await installMuiZip({
     archive, rootDirectory:root,
     metadata:{...metadata, packId:'overview-three', name:'Overview Three'},
@@ -356,6 +431,36 @@ test('inspects and transactionally installs a sparse stored MUI XYZ ZIP', async 
   const resumedSelection = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.1')).bytes);
   assert.equal(resumedSelection.generation, 4);
   assert.deepEqual(resumedSelection.packs.map(pack => pack.packId), ['overview-two','overview-three','overview']);
+});
+
+test('preserves separate installed-style PMAS snapshots when activation changes', async () => {
+  const root = new MemoryDirectoryHandle();
+  const bright = getMuiStyleProfile('osm-bright');
+  const dark = getMuiStyleProfile('dark-matter');
+  await installMuiZip({
+    archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId:'bright-pack', mapSetId:bright.id,
+      attribution:bright.attribution, source:bright.source, license:bright.license},
+  });
+  await installMuiZip({
+    archive: storedZip([['maps/dark-matter/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId:'dark-pack', mapSetId:dark.id,
+      attribution:dark.attribution, source:dark.source, license:dark.license},
+  });
+  const brightCatalog = decodeActiveSelection(
+    (await child(root, 'pyxis-map/map-sets/osm-bright.pmas')).bytes,
+  );
+  const darkCatalog = decodeActiveSelection(
+    (await child(root, 'pyxis-map/map-sets/dark-matter.pmas')).bytes,
+  );
+  assert.equal(brightCatalog.mapSetId, 'osm-bright');
+  assert.deepEqual(brightCatalog.packs.map(pack => pack.packId), ['bright-pack']);
+  assert.equal(darkCatalog.mapSetId, 'dark-matter');
+  assert.deepEqual(darkCatalog.packs.map(pack => pack.packId), ['dark-pack']);
+  const active = decodeActiveSelection((await child(root, 'pyxis-map/active-pack.1')).bytes);
+  assert.equal(active.mapSetId, 'dark-matter');
 });
 
 test('rejects traversal, duplicate keys, unsupported compression, and malformed PNGs', async () => {

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -12,12 +12,28 @@ import {
   installMuiZip,
   parseSparseManifest,
   resolveMuiStyleProfile,
+  suggestMapIdentity,
 } from '../../docs/flasher/js/map-installer.js';
 
 const PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAA1UlEQVR4nO3BMQEAAADCoPVP7WULoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAGwEtAAHMpTgHAAAAAElFTkSuQmCC',
   'base64',
 );
+
+test('each selected archive receives a fresh suggested name and pack ID', () => {
+  assert.deepEqual(suggestMapIdentity('regional-overview.zip'), {
+    name: 'regional-overview',
+    packId: 'regional-overview',
+  });
+  assert.deepEqual(suggestMapIdentity('Local Detail Tiles.ZIP'), {
+    name: 'Local Detail Tiles',
+    packId: 'local-detail-tiles',
+  });
+  assert.deepEqual(suggestMapIdentity('.zip'), {
+    name: 'Offline map',
+    packId: 'offline-map',
+  });
+});
 
 function crc32(bytes) {
   let crc = 0xffffffff;


### PR DESCRIPTION
## Summary

- add a bounded four-style offline map catalog for OSM Bright, Dark Matter, Positron, and Toner
- activate style-specific PMAS snapshots transactionally with semantic PMP validation, redundant active-slot publication, exact readback, and fail-closed storage handling
- add the Maps toolbar style-cycle control with worker-owned SD I/O, stale-completion rejection, pack reload, decoded-cache clearing, and visible-tile invalidation
- update the browser SD importer to publish persistent per-style snapshots, require explicit style selection for rootless ZIPs, and refresh map name/pack ID for each selected archive
- correct dark-theme styling and cache versioning for the browser style selector/module

## Safety properties

- production firmware probes only four exact allowlisted PMAS paths and never scans SD directories
- malformed, mismatched, missing, or indeterminate PMAS/PMP data fails closed
- immutable active packs never fall through to untyped legacy tile content
- active selection retains redundant generations and exact-byte conflict detection
- NVS, LittleFS, identities, settings, conversations, and unrelated SD contents are not erased or migrated

## Verification

- [x] 17 focused native/contract tests passed on the final head
- [x] 18 browser installer tests passed on the final head
- [x] JavaScript syntax check passed
- [x] complete host suite passed before the two browser-only follow-up commits
- [x] `pio run -e tdeck` passed for the firmware commit
- [x] `pio run -e tdeck-release` and release audit passed for the firmware commit
- [x] physical application flash/readback and two-boot persistence verification completed
- [x] physical SD inspection confirmed valid PMAS/PMP records and tile payloads for all four styles

## Physical validation status

The exact firmware application was flashed and read back successfully, with OTA selection stable across two boots and no panic/watchdog signatures. The SD card now contains valid snapshots for all four styles. Final on-device cycling through all four styles remains a manual acceptance check after reinserting the safely unmounted SD card.
