### PR TITLE
fix: show prereleases in web flasher

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -134,7 +134,7 @@ jobs:
           # Fetch all published releases and download their firmware assets
           # so versioned firmware is available same-origin on GitHub Pages.
           # With keep_files: true, each release only needs to be downloaded once.
-          for tag in $(gh api repos/${{ github.repository }}/releases --jq '.[] | select(.draft == false and .prerelease == false) | select(any(.assets[]; .name == "pyxis-release.json")) | .tag_name'); do
+          for tag in $(gh api repos/${{ github.repository }}/releases --jq '.[] | select(.draft == false) | select(any(.assets[]; .name == "pyxis-release.json")) | .tag_name'); do
             dir="docs/flasher/firmware/releases/${tag}"
             # Skip if we already have this version's firmware (e.g., current tagged build)
             if python tools/validate_pyxis_web_release.py --directory "${dir}" --version "${tag}"; then

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -189,17 +189,27 @@
         .version-select-group select {
             width: 100%;
             padding: 0.625rem 1rem;
-            background: rgba(0,0,0,0.3);
+            background-color: #111827;
             color: var(--text);
             border: 1px solid rgba(255,255,255,0.15);
             border-radius: 8px;
             font-family: inherit;
             font-size: 1rem;
             cursor: pointer;
+            color-scheme: dark;
             appearance: none;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%2394a3b8' viewBox='0 0 16 16'%3E%3Cpath d='M8 11L3 6h10z'/%3E%3C/svg%3E");
             background-repeat: no-repeat;
             background-position: right 1rem center;
+        }
+
+        .version-select-group select option {
+            background-color: #111827;
+            color: var(--text);
+        }
+
+        .version-select-group select option:disabled {
+            color: var(--muted);
         }
 
         .version-select-group select:focus {
@@ -319,7 +329,6 @@
                 <li>
                     Download a compatible MUI map ZIP from
                     <a href="https://download.tiles.coalition.space/" target="_blank" rel="noopener noreferrer">Oxed's Map Tile Downloader</a>.
-                    Choose OSM Bright for current Pyxis compatibility.
                 </li>
                 <li>Turn the T-Deck off, remove its microSD card, and insert the card into your computer.</li>
                 <li>Choose the downloaded ZIP below, enter a map name and pack ID, and wait for local validation.</li>

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -795,6 +795,7 @@
                 if (!resp.ok) throw new Error(`GitHub API returned HTTP ${resp.status}`);
                 const releases = await resp.json();
                 let publishedCount = 0;
+                let defaultStableOption = null;
 
                 for (const release of releases) {
                     if (release.draft) continue;
@@ -821,6 +822,9 @@
                     option.dataset.hasFullAssets = hasAll ? 'true' : 'false';
                     option.releaseMetadata = metadata;
                     versionSelect.appendChild(option);
+                    if (!release.prerelease && defaultStableOption === null) {
+                        defaultStableOption = option;
+                    }
                     publishedCount++;
                 }
 
@@ -835,8 +839,8 @@
 
                 versionSelect.options[0].textContent = 'Select a published release...';
                 versionSelect.disabled = false;
-                if (customFirmwareSelectionToken === 0) {
-                    versionSelect.selectedIndex = 1;
+                if (customFirmwareSelectionToken === 0 && defaultStableOption !== null) {
+                    versionSelect.value = defaultStableOption.value;
                     selectPublishedRelease();
                 }
             } catch (e) {

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -411,7 +411,7 @@
         const CONNECT_TIMEOUT_MS = 15000;
         const EXPECTED_CHIP = 'ESP32-S3';
 
-        // Fail closed until the GitHub API supplies a published, non-prerelease version.
+        // Fail closed until the GitHub API supplies a published release with audited metadata.
         let firmwarePathPrefix = null;
         let selectedReleaseMetadata = null;
         let customFirmwareBytes = null;
@@ -788,7 +788,7 @@
                 let publishedCount = 0;
 
                 for (const release of releases) {
-                    if (release.draft || release.prerelease) continue;
+                    if (release.draft) continue;
                     const assetNames = release.assets.map(a => a.name);
                     if (!assetNames.includes(RELEASE_METADATA_ASSET)) continue;
                     if (!assetNames.includes('firmware.bin')) continue;
@@ -803,8 +803,11 @@
 
                     const option = document.createElement('option');
                     const hasAll = REQUIRED_FULL_ASSETS.every(f => assetNames.includes(f));
+                    const releaseChannel = release.prerelease ? ' — Pre-release' : '';
                     option.value = release.tag_name;
-                    option.textContent = release.tag_name + (release.name && release.name !== release.tag_name ? ` — ${release.name}` : '');
+                    option.textContent = release.tag_name
+                        + (release.name && release.name !== release.tag_name ? ` — ${release.name}` : '')
+                        + releaseChannel;
                     option.dataset.downloadUrl = prefix;
                     option.dataset.hasFullAssets = hasAll ? 'true' : 'false';
                     option.releaseMetadata = metadata;
@@ -953,7 +956,7 @@
         flashBtn.addEventListener('click', flash);
 
         // Initialize with no flashable target; loadVersions enables flashing only
-        // after selecting a published, non-prerelease GitHub release.
+        // after selecting a published GitHub release with audited metadata.
         loadVersions();
     </script>
 </body>

--- a/tests/build_scripts/test_web_flasher_release_safety.py
+++ b/tests/build_scripts/test_web_flasher_release_safety.py
@@ -20,10 +20,12 @@ def test_flasher_starts_disabled_until_a_published_release_is_selected():
     assert '<option value="latest">' not in source
 
 
-def test_flasher_filters_drafts_and_prereleases_and_selects_a_versioned_path():
+def test_flasher_filters_drafts_but_includes_prereleases_with_a_clear_label():
     source = FLASHER.read_text()
 
-    assert "if (release.draft || release.prerelease) continue;" in source
+    assert "if (release.draft) continue;" in source
+    assert "if (release.draft || release.prerelease) continue;" not in source
+    assert "const releaseChannel = release.prerelease ? ' — Pre-release' : '';" in source
     assert "RELEASE_METADATA_ASSET = 'pyxis-release.json'" in source
     assert "if (!assetNames.includes(RELEASE_METADATA_ASSET)) continue;" in source
     assert "firmware/releases/${release.tag_name}/" in source
@@ -123,7 +125,8 @@ def test_tag_builds_cannot_overwrite_pages_and_only_main_deploys():
     workflow = WORKFLOW.read_text()
 
     assert workflow.count("if: github.ref == 'refs/heads/main'") >= 4
-    assert "select(.draft == false and .prerelease == false)" in workflow
+    assert "select(.draft == false)" in workflow
+    assert "select(.draft == false and .prerelease == false)" not in workflow
     assert 'select(any(.assets[]; .name == "pyxis-release.json"))' in workflow
     assert 'validate_pyxis_web_release.py --directory "${dir}" --version "${tag}"' in workflow
     assert 'rm -rf "${dir}"' in workflow

--- a/tests/build_scripts/test_web_flasher_release_safety.py
+++ b/tests/build_scripts/test_web_flasher_release_safety.py
@@ -26,6 +26,9 @@ def test_flasher_filters_drafts_but_includes_prereleases_with_a_clear_label():
     assert "if (release.draft) continue;" in source
     assert "if (release.draft || release.prerelease) continue;" not in source
     assert "const releaseChannel = release.prerelease ? ' — Pre-release' : '';" in source
+    assert """option.textContent = release.tag_name
+                        + (release.name && release.name !== release.tag_name ? ` — ${release.name}` : '')
+                        + releaseChannel;""" in source
     assert "RELEASE_METADATA_ASSET = 'pyxis-release.json'" in source
     assert "if (!assetNames.includes(RELEASE_METADATA_ASSET)) continue;" in source
     assert "firmware/releases/${release.tag_name}/" in source

--- a/tests/build_scripts/test_web_flasher_release_safety.py
+++ b/tests/build_scripts/test_web_flasher_release_safety.py
@@ -41,6 +41,16 @@ def test_flasher_filters_drafts_but_includes_prereleases_with_a_clear_label():
     assert "RELEASE_METADATA_ASSET = 'pyxis-release.json'" in source
     assert "if (!assetNames.includes(RELEASE_METADATA_ASSET)) continue;" in source
     assert "firmware/releases/${release.tag_name}/" in source
+
+
+def test_flasher_defaults_to_a_stable_release_not_a_prerelease():
+    source = FLASHER.read_text()
+
+    assert "let defaultStableOption = null;" in source
+    assert "if (!release.prerelease && defaultStableOption === null)" in source
+    assert "if (customFirmwareSelectionToken === 0 && defaultStableOption !== null)" in source
+    assert "versionSelect.value = defaultStableOption.value;" in source
+    assert "versionSelect.selectedIndex = 1;" not in source
     assert "selectPublishedRelease" in source
     assert "flashBtn.disabled = false;" in source
 

--- a/tests/build_scripts/test_web_flasher_release_safety.py
+++ b/tests/build_scripts/test_web_flasher_release_safety.py
@@ -20,6 +20,15 @@ def test_flasher_starts_disabled_until_a_published_release_is_selected():
     assert '<option value="latest">' not in source
 
 
+def test_firmware_version_menu_uses_high_contrast_dark_colors():
+    source = FLASHER.read_text()
+
+    assert ".version-select-group select option {" in source
+    assert "background-color: #111827;" in source
+    assert "color: var(--text);" in source
+    assert "color-scheme: dark;" in source
+
+
 def test_flasher_filters_drafts_but_includes_prereleases_with_a_clear_label():
     source = FLASHER.read_text()
 


### PR DESCRIPTION
## Summary

- include published GitHub prereleases in the web flasher and clearly label them as pre-release builds
- mirror audited prerelease assets into the versioned GitHub Pages firmware catalog while continuing to exclude drafts
- improve the native firmware-version selector contrast in dark mode
- remove obsolete OSM Bright compatibility guidance

## Verification

- `uv run --with pytest pytest -q tests/build_scripts tests/native` (`194 passed`)
- validated the mirrored `v0.3.2-beta`, `v0.2.7`, and `v0.2.6` asset sets with `tools/validate_pyxis_web_release.py`
- browser-tested the hosted candidate with all three releases present, the beta clearly labeled, update/full-install controls enabled, and no console errors
- verified computed selector and option colors use a dark `#111827` background with light text
- mutation-tested the prerelease label contract by removing its display wiring and confirming the focused test fails
- `git diff --check origin/main...HEAD`

## Risk and rollback

The release picker still fails closed when audited metadata or required release assets are missing or invalid. Draft releases remain excluded. Rollback is a normal revert of this PR.
