### PR TITLE
fix: keep opened chats at newest message

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/ChatScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/ChatScreen.cpp
@@ -275,10 +275,11 @@ void ChatScreen::refresh() {
     _bg_fill_target = (_all_message_hashes.size() > MESSAGES_PER_PAGE)
                           ? _all_message_hashes.size() - MESSAGES_PER_PAGE
                           : 0;
-    _bg_fill_active.store(_display_start_idx > _bg_fill_target);
+    const bool initial_fill_active = _display_start_idx > _bg_fill_target;
+    _keep_bottom_during_background_fill.store(initial_fill_active);
+    _bg_fill_active.store(initial_fill_active);
 
-    // Scroll to bottom
-    lv_obj_scroll_to_y(_message_list, LV_COORD_MAX, LV_ANIM_OFF);
+    scroll_to_bottom();
 }
 
 // Stream older messages in a few at a time, called from UIManager::update() on
@@ -290,12 +291,17 @@ void ChatScreen::tick_background_fill() {
     }
     if (_display_start_idx <= _bg_fill_target) {
         _bg_fill_active.store(false);
+        _keep_bottom_during_background_fill.store(false);
         return;
     }
     size_t remaining = _display_start_idx - _bg_fill_target;
     load_more_messages(remaining < BG_FILL_BATCH ? remaining : BG_FILL_BATCH);
+    if (_keep_bottom_during_background_fill.load()) {
+        scroll_to_bottom();
+    }
     if (_display_start_idx <= _bg_fill_target) {
         _bg_fill_active.store(false);
+        _keep_bottom_during_background_fill.store(false);
     }
 }
 
@@ -361,6 +367,15 @@ void ChatScreen::load_more_messages(size_t batch) {
     }
 }
 
+void ChatScreen::scroll_to_bottom() {
+    LVGL_LOCK();
+    // Flex children are laid out lazily. Resolve their final heights before
+    // asking LVGL for the maximum offset, otherwise a just-opened chat can
+    // scroll against the old zero-height layout and remain at the top.
+    lv_obj_update_layout(_message_list);
+    lv_obj_scroll_to_y(_message_list, LV_COORD_MAX, LV_ANIM_OFF);
+}
+
 void ChatScreen::on_scroll(lv_event_t* event) {
     ChatScreen* screen = (ChatScreen*)lv_event_get_user_data(event);
 
@@ -371,6 +386,7 @@ void ChatScreen::on_scroll(lv_event_t* event) {
         // Near the top: stream the next page in incrementally on the main loop
         // (tick_background_fill) rather than loading a full batch synchronously
         // under the LVGL lock here, which froze scrolling. Target before active.
+        screen->_keep_bottom_during_background_fill.store(false);
         screen->_bg_fill_target = (screen->_display_start_idx > MESSAGES_PER_PAGE)
                                       ? screen->_display_start_idx - MESSAGES_PER_PAGE
                                       : 0;
@@ -562,6 +578,9 @@ void ChatScreen::show() {
     LVGL_LOCK();
     lv_obj_clear_flag(_screen, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_foreground(_screen);  // Bring to front for touch events
+    // refresh() runs while this screen is hidden, so resolve the now-visible
+    // flex layout once more before selecting the newest message offset.
+    scroll_to_bottom();
 
     // Add buttons to default group for trackball navigation
     // Note: text area not included since edit mode consumes arrow keys

--- a/lib/tdeck_ui/UI/LXMF/ChatScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/ChatScreen.h
@@ -212,9 +212,14 @@ private:
     // visible once active is observed true.
     std::atomic<bool> _bg_fill_active{false};      // streaming the rest of the page in
     size_t _bg_fill_target = 0;                    // _display_start_idx to fill down to
+    // Opening a chat prepends the rest of its first page asynchronously. Keep
+    // the viewport pinned to the newest message during only that initial fill;
+    // user-triggered pagination at the top must preserve the user's position.
+    std::atomic<bool> _keep_bottom_during_background_fill{false};
 
     // Load more messages (infinite scroll + background fill)
     void load_more_messages(size_t batch = MESSAGES_PER_PAGE);
+    void scroll_to_bottom();
     static void on_scroll(lv_event_t* event);
 
     // Utility

--- a/tests/build_scripts/test_chat_scroll_contract.py
+++ b/tests/build_scripts/test_chat_scroll_contract.py
@@ -1,0 +1,51 @@
+"""Source-level contracts for opening a conversation at its newest message."""
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_CPP = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ChatScreen.cpp"
+CHAT_H = REPO_ROOT / "lib/tdeck_ui/UI/LXMF/ChatScreen.h"
+
+
+def function_body(source: str, signature: str, next_signature: str) -> str:
+    start = source.index(signature)
+    end = source.index(next_signature, start)
+    return source[start:end]
+
+
+def test_initial_background_fill_stays_at_newest_message():
+    source = CHAT_CPP.read_text()
+    header = CHAT_H.read_text()
+    refresh = function_body(source, "void ChatScreen::refresh()", "void ChatScreen::tick_background_fill()")
+    tick = function_body(source, "void ChatScreen::tick_background_fill()", "void ChatScreen::load_more_messages(")
+    on_scroll = function_body(source, "void ChatScreen::on_scroll(", "void ChatScreen::create_message_bubble(")
+    assert "void ChatScreen::scroll_to_bottom()" in source
+    helper = function_body(source, "void ChatScreen::scroll_to_bottom()", "void ChatScreen::on_scroll(")
+
+    assert "std::atomic<bool> _keep_bottom_during_background_fill" in header
+    assert "void scroll_to_bottom();" in header
+    assert helper.index("lv_obj_update_layout(_message_list)") < helper.index(
+        "lv_obj_scroll_to_y(_message_list, LV_COORD_MAX, LV_ANIM_OFF)"
+    )
+
+    keep = refresh.index("_keep_bottom_during_background_fill.store(initial_fill_active)")
+    activate = refresh.index("_bg_fill_active.store(initial_fill_active)")
+    bottom = refresh.index("scroll_to_bottom()")
+    assert keep < activate < bottom
+
+    load = tick.index("load_more_messages(")
+    keep_check = tick.index("if (_keep_bottom_during_background_fill.load())")
+    bottom_after_fill = tick.index("scroll_to_bottom()", keep_check)
+    assert load < keep_check < bottom_after_fill
+
+    user_fill = on_scroll.index("_bg_fill_active.store(true)")
+    stop_pinning = on_scroll.index("_keep_bottom_during_background_fill.store(false)")
+    assert stop_pinning < user_fill
+
+
+def test_show_resolves_hidden_layout_before_presenting_newest_message():
+    source = CHAT_CPP.read_text()
+    show = function_body(source, "void ChatScreen::show()", "void ChatScreen::hide()")
+    unhide = show.index("lv_obj_clear_flag(_screen, LV_OBJ_FLAG_HIDDEN)")
+    bottom = show.index("scroll_to_bottom()")
+    assert unhide < bottom


### PR DESCRIPTION
## Summary
- keep newly opened conversations anchored to the newest message while incremental background rows are filled
- resolve hidden-layout scrolling before presenting the chat screen
- add focused source contracts for initial fill and show behavior

## Verification
- `python -m pytest tests/build_scripts/test_chat_scroll_contract.py -v` — 2 passed
- `pio run -e tdeck` — success
- `git diff --check origin/main...HEAD` — passed

## Validation boundary
- Host tests and compilation completed. Physical T-Deck behavior remains pending.

## Risk / rollback
- Scope is limited to chat scrolling/layout timing and focused tests. Revert the single commit to roll back.