### PR TITLE
fix(nomadnet): honor Micron colors

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/NomadNetColors.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetColors.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstdint>
+
+#include "NomadNetCompactPage.h"
+
+namespace UI::LXMF::NomadNet {
+
+inline uint32_t resolve_foreground(const CompactPage& page,
+                                   const CompactPage::RunRecord& run,
+                                   uint32_t fallback) {
+    if (run.style & CompactPage::HAS_FOREGROUND) return run.foreground;
+    if (page.has_foreground()) return page.foreground();
+    return fallback;
+}
+
+inline uint32_t resolve_background(const CompactPage& page,
+                                   const CompactPage::RunRecord& run,
+                                   uint32_t fallback) {
+    if (run.style & CompactPage::HAS_BACKGROUND) return run.background;
+    if (page.has_background()) return page.background();
+    return fallback;
+}
+
+// IEC 61966-2-1 sRGB channel values, linearised and scaled to 0..10000.
+// A lookup avoids floating-point and pow() work in the LVGL draw path.
+static constexpr uint16_t SRGB_LINEAR_10000[256] = {
+    0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 37, 40, 44, 48,
+    52, 56, 60, 65, 70, 75, 80, 86, 91, 97, 103, 110, 116, 123, 130, 137,
+    144, 152, 160, 168, 176, 185, 194, 203, 212, 222, 232, 242, 252, 262, 273, 284,
+    296, 307, 319, 331, 343, 356, 369, 382, 395, 409, 423, 437, 452, 467, 482, 497,
+    513, 529, 545, 561, 578, 595, 612, 630, 648, 666, 685, 704, 723, 742, 762, 782,
+    802, 823, 844, 865, 887, 908, 931, 953, 976, 999, 1022, 1046, 1070, 1095, 1119, 1144,
+    1170, 1195, 1221, 1248, 1274, 1301, 1329, 1356, 1384, 1413, 1441, 1470, 1500, 1529, 1559, 1590,
+    1620, 1651, 1683, 1714, 1746, 1779, 1812, 1845, 1878, 1912, 1946, 1981, 2016, 2051, 2086, 2122,
+    2159, 2195, 2232, 2270, 2307, 2346, 2384, 2423, 2462, 2502, 2542, 2582, 2623, 2664, 2705, 2747,
+    2789, 2831, 2874, 2918, 2961, 3005, 3050, 3095, 3140, 3185, 3231, 3278, 3325, 3372, 3419, 3467,
+    3515, 3564, 3613, 3663, 3712, 3763, 3813, 3864, 3916, 3968, 4020, 4072, 4125, 4179, 4233, 4287,
+    4342, 4397, 4452, 4508, 4564, 4621, 4678, 4735, 4793, 4851, 4910, 4969, 5029, 5089, 5149, 5210,
+    5271, 5333, 5395, 5457, 5520, 5583, 5647, 5711, 5776, 5841, 5906, 5972, 6038, 6105, 6172, 6240,
+    6308, 6376, 6445, 6514, 6584, 6654, 6724, 6795, 6867, 6939, 7011, 7084, 7157, 7231, 7305, 7379,
+    7454, 7529, 7605, 7682, 7758, 7835, 7913, 7991, 8070, 8148, 8228, 8308, 8388, 8469, 8550, 8632,
+    8714, 8796, 8879, 8963, 9047, 9131, 9216, 9301, 9387, 9473, 9560, 9647, 9734, 9823, 9911, 10000,
+};
+
+inline uint32_t resolve_focus_border(const CompactPage& page,
+                                     const CompactPage::RunRecord& run,
+                                     uint32_t fallback_background) {
+    const uint32_t background = resolve_background(page, run, fallback_background);
+    const uint32_t red = SRGB_LINEAR_10000[(background >> 16) & 0xff];
+    const uint32_t green = SRGB_LINEAR_10000[(background >> 8) & 0xff];
+    const uint32_t blue = SRGB_LINEAR_10000[background & 0xff];
+    const uint32_t luminance = 2126 * red + 7152 * green + 722 * blue;
+    // Black and white have equal WCAG contrast at relative luminance 0.17913.
+    return luminance >= 17913000 ? 0x000000 : 0xffffff;
+}
+
+} // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetFocus.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetFocus.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace UI::LXMF::NomadNet {
+
+struct FocusSpan {
+    int16_t x = 0;
+    int16_t y = 0;
+    int16_t width = 0;
+    int16_t height = 0;
+    uint16_t run_index = 0;
+
+    FocusSpan() = default;
+    constexpr FocusSpan(int16_t x_value, int16_t y_value, int16_t width_value,
+                        int16_t height_value, uint16_t run_index_value)
+        : x(x_value), y(y_value), width(width_value), height(height_value),
+          run_index(run_index_value) {}
+};
+
+template <typename FragmentRange, typename Callback>
+void for_each_focus_span(const FragmentRange& fragments, int16_t selected_link,
+                         Callback callback) {
+    std::size_t index = 0;
+    while (index < fragments.size()) {
+        const auto& first = fragments[index];
+        if (first.link_index != selected_link) {
+            ++index;
+            continue;
+        }
+
+        int32_t left = first.x;
+        int32_t top = first.y;
+        int32_t right = left + std::max<int16_t>(first.width, 1);
+        int32_t bottom = top + std::max<int16_t>(first.height, 1);
+        std::size_t end = index + 1;
+        while (end < fragments.size()) {
+            const auto& fragment = fragments[end];
+            if (fragment.link_index != selected_link || fragment.y != first.y ||
+                fragment.run_index != first.run_index) break;
+            left = std::min<int32_t>(left, fragment.x);
+            right = std::max<int32_t>(right,
+                static_cast<int32_t>(fragment.x) + std::max<int16_t>(fragment.width, 1));
+            bottom = std::max<int32_t>(bottom,
+                static_cast<int32_t>(fragment.y) + std::max<int16_t>(fragment.height, 1));
+            ++end;
+        }
+
+        callback(FocusSpan{
+            static_cast<int16_t>(left),
+            static_cast<int16_t>(top),
+            static_cast<int16_t>(right - left),
+            static_cast<int16_t>(bottom - top),
+            first.run_index,
+        });
+        index = end;
+    }
+}
+
+} // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -1,6 +1,7 @@
 #include "NomadNetScreen.h"
 #ifdef ARDUINO
 #include "Theme.h"
+#include "NomadNetColors.h"
 #include "NomadNetDisplay.h"
 #include "NomadNetGlyphs.h"
 #include "../LVGL/LVGLInit.h"
@@ -454,13 +455,17 @@ void NomadNetScreen::draw_page(lv_event_t* event){
         if(fragment.byte_offset+fragment.byte_length>text.size()||fragment.byte_length>=sizeof(scratch))continue;
         std::memcpy(scratch,text.data()+fragment.byte_offset,fragment.byte_length);scratch[fragment.byte_length]='\0';
         const bool selected=fragment.link_index>=0&&fragment.link_index==_selected_link;
-        if((run.style&NomadNet::CompactPage::HAS_BACKGROUND)||selected){
-            lv_draw_rect_dsc_t bg;lv_draw_rect_dsc_init(&bg);bg.bg_color=selected?Theme::primaryPressed():lv_color_hex(run.background);lv_draw_rect(draw_ctx,&bg,&area);
+        if(run.style&NomadNet::CompactPage::HAS_BACKGROUND){
+            lv_draw_rect_dsc_t bg;lv_draw_rect_dsc_init(&bg);bg.bg_color=lv_color_hex(run.background);lv_draw_rect(draw_ctx,&bg,&area);
+        }
+        if(selected){
+            lv_draw_rect_dsc_t focus;lv_draw_rect_dsc_init(&focus);focus.bg_opa=LV_OPA_TRANSP;
+            focus.border_color=lv_color_hex(NomadNet::resolve_focus_border(
+                _page,run,Theme::SURFACE));focus.border_width=1;lv_draw_rect(draw_ctx,&focus,&area);
         }
         lv_draw_label_dsc_t dsc;lv_draw_label_dsc_init(&dsc);
         dsc.font=page_run_font(run, fragment.large_font);
-        dsc.color=run.link_index>=0?Theme::primaryLight():(run.style&NomadNet::CompactPage::HAS_FOREGROUND)
-            ?lv_color_hex(run.foreground):_page.has_foreground()?lv_color_hex(_page.foreground()):Theme::textPrimary();
+        dsc.color=lv_color_hex(NomadNet::resolve_foreground(_page,run,Theme::TEXT_PRIMARY));
         dsc.letter_space=0;
         dsc.decor=(run.style&NomadNet::CompactPage::UNDERLINE)||run.link_index>=0?LV_TEXT_DECOR_UNDERLINE:LV_TEXT_DECOR_NONE;
         lv_draw_label(draw_ctx,&dsc,&area,scratch,nullptr);

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -3,6 +3,7 @@
 #include "Theme.h"
 #include "NomadNetColors.h"
 #include "NomadNetDisplay.h"
+#include "NomadNetFocus.h"
 #include "NomadNetGlyphs.h"
 #include "../LVGL/LVGLInit.h"
 #include "../TextAreaHelper.h"
@@ -454,14 +455,8 @@ void NomadNetScreen::draw_page(lv_event_t* event){
         const auto text=_page.text(run);
         if(fragment.byte_offset+fragment.byte_length>text.size()||fragment.byte_length>=sizeof(scratch))continue;
         std::memcpy(scratch,text.data()+fragment.byte_offset,fragment.byte_length);scratch[fragment.byte_length]='\0';
-        const bool selected=fragment.link_index>=0&&fragment.link_index==_selected_link;
         if(run.style&NomadNet::CompactPage::HAS_BACKGROUND){
             lv_draw_rect_dsc_t bg;lv_draw_rect_dsc_init(&bg);bg.bg_color=lv_color_hex(run.background);lv_draw_rect(draw_ctx,&bg,&area);
-        }
-        if(selected){
-            lv_draw_rect_dsc_t focus;lv_draw_rect_dsc_init(&focus);focus.bg_opa=LV_OPA_TRANSP;
-            focus.border_color=lv_color_hex(NomadNet::resolve_focus_border(
-                _page,run,Theme::SURFACE));focus.border_width=1;lv_draw_rect(draw_ctx,&focus,&area);
         }
         lv_draw_label_dsc_t dsc;lv_draw_label_dsc_init(&dsc);
         dsc.font=page_run_font(run, fragment.large_font);
@@ -469,6 +464,20 @@ void NomadNetScreen::draw_page(lv_event_t* event){
         dsc.letter_space=0;
         dsc.decor=(run.style&NomadNet::CompactPage::UNDERLINE)||run.link_index>=0?LV_TEXT_DECOR_UNDERLINE:LV_TEXT_DECOR_NONE;
         lv_draw_label(draw_ctx,&dsc,&area,scratch,nullptr);
+    }
+    if(_selected_link>=0){
+        NomadNet::for_each_focus_span(_page_layout,_selected_link,[&](const NomadNet::FocusSpan& span){
+            if(span.run_index>=_page.runs().size())return;
+            const int16_t draw_y=static_cast<int16_t>(top+span.y-scroll);
+            if(draw_y+span.height<_content->coords.y1||draw_y>_content->coords.y2)return;
+            lv_area_t area{static_cast<lv_coord_t>(left+span.x),draw_y,
+                static_cast<lv_coord_t>(left+span.x+std::max<int16_t>(span.width,1)-1),
+                static_cast<lv_coord_t>(draw_y+std::max<int16_t>(span.height,1)-1)};
+            lv_draw_rect_dsc_t focus;lv_draw_rect_dsc_init(&focus);focus.bg_opa=LV_OPA_TRANSP;
+            focus.border_color=lv_color_hex(NomadNet::resolve_focus_border(
+                _page,_page.runs()[span.run_index],Theme::SURFACE));
+            focus.border_width=1;lv_draw_rect(draw_ctx,&focus,&area);
+        });
     }
 }
 

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -15,6 +15,7 @@
 #include "NomadNetActionMailbox.h"
 #include "NomadNetMailbox.h"
 #include "NomadNetCompactPage.h"
+#include "NomadNetColors.h"
 #include "NomadNetProtocol.h"
 #include "NomadNetRequestPolicy.h"
 #include "NomadNetUrl.h"
@@ -35,6 +36,7 @@ using UI::LXMF::NomadNet::sanitize_directory_name;
 using UI::LXMF::NomadNet::page_title;
 using UI::LXMF::NomadNet::AsyncMailbox;
 using UI::LXMF::NomadNet::CompactPage;
+using UI::LXMF::NomadNet::resolve_foreground;
 using UI::LXMF::NomadNet::ResponseBuffer;
 using UI::LXMF::NomadNet::RequestPolicy;
 using UI::LXMF::NomadNet::Url;
@@ -165,6 +167,124 @@ int main(int argc, char** argv) {
     check("compact page preserves document presentation flags",
           compact.has_background() == doc.has_background && compact.background() == doc.background &&
           compact.has_foreground() == doc.has_foreground && compact.foreground() == doc.foreground);
+
+    auto color_doc = parser.parse(
+        "#!bg=123\n#!fg=abc\n"
+        "plain `Ff00inline`f `B0f0back`b "
+        "`F79d`_`[styled link`:/page/next.mu]`_`f\n");
+    CompactPage color_page;
+    check("Micron color fixture compacts", color_page.assign(color_doc) &&
+                                             color_page.has_background() &&
+                                             color_page.background() == 0x112233 &&
+                                             color_page.has_foreground() &&
+                                             color_page.foreground() == 0xaabbcc);
+    bool saw_plain = false;
+    bool saw_inline = false;
+    bool saw_colored_background = false;
+    bool saw_styled_link = false;
+    for (const auto& run : color_page.runs()) {
+        const auto view = color_page.text(run);
+        const std::string text(view.data(), view.size());
+        if (text == "plain ") {
+            saw_plain = resolve_foreground(color_page, run, 0xe8b4f0) == 0xaabbcc;
+        } else if (text == "inline") {
+            saw_inline = resolve_foreground(color_page, run, 0xe8b4f0) == 0xff0000;
+        } else if (text == "back") {
+            saw_colored_background = (run.style & CompactPage::HAS_BACKGROUND) &&
+                                     run.background == 0x00ff00;
+        } else if (text == "styled link") {
+            saw_styled_link = run.link_index >= 0 &&
+                              resolve_foreground(color_page, run, 0xe8b4f0) == 0x7799dd;
+        }
+    }
+    check("page foreground is the unstyled text default", saw_plain);
+    check("inline foreground overrides the page default", saw_inline);
+    check("inline background is preserved", saw_colored_background);
+    check("links preserve their authored Micron foreground", saw_styled_link);
+
+    auto truecolor_doc = parser.parse(
+        "#!fg=102030\n#!bg=405060\n"
+        "`FTa1b2c3true foreground`f `BTd4e5f6true background`b\n");
+    check("six-digit page truecolor parses",
+          truecolor_doc.has_foreground && truecolor_doc.foreground == 0x102030 &&
+              truecolor_doc.has_background && truecolor_doc.background == 0x405060);
+    bool saw_truecolor_foreground = false;
+    bool saw_truecolor_background = false;
+    for (const auto& run : truecolor_doc.blocks.front().runs) {
+        if (run.text == "true foreground") {
+            saw_truecolor_foreground = run.has_foreground && run.foreground == 0xa1b2c3;
+        } else if (run.text == "true background") {
+            saw_truecolor_background = run.has_background && run.background == 0xd4e5f6;
+        }
+    }
+    check("FT inline truecolor parses", saw_truecolor_foreground);
+    check("BT inline truecolor parses", saw_truecolor_background);
+
+    CompactPage::RunRecord light_background_run{};
+    light_background_run.style = CompactPage::HAS_BACKGROUND;
+    light_background_run.background = 0xe8b4f0;
+    check("focus border contrasts with a light authored inline background",
+          resolve_focus_border(color_page, light_background_run, 0x1d1a1e) == 0x000000);
+    CompactPage::RunRecord inherited_background_run{};
+    check("focus border contrasts with a dark authored page background",
+          resolve_focus_border(color_page, inherited_background_run, 0x1d1a1e) == 0xffffff);
+    CompactPage::RunRecord saturated_green_run{};
+    saturated_green_run.style = CompactPage::HAS_BACKGROUND;
+    saturated_green_run.background = 0x00da00;
+    check("focus border uses sRGB contrast for saturated green",
+          resolve_focus_border(color_page, saturated_green_run, 0x1d1a1e) == 0x000000);
+    CompactPage::RunRecord saturated_blue_run{};
+    saturated_blue_run.style = CompactPage::HAS_BACKGROUND;
+    saturated_blue_run.background = 0x0000ff;
+    check("focus border uses sRGB contrast for saturated blue",
+          resolve_focus_border(color_page, saturated_blue_run, 0x1d1a1e) == 0xffffff);
+
+    auto reset_color_doc = parser.parse(
+        "#!fg=abc\n`Ff00inline`fpage `[unstyled link`:/page/plain.mu]\n");
+    CompactPage reset_color_page;
+    bool saw_reset_page_color = false;
+    bool saw_unstyled_link_color = false;
+    check("foreground reset fixture compacts", reset_color_page.assign(reset_color_doc));
+    for (const auto& run : reset_color_page.runs()) {
+        const auto view = reset_color_page.text(run);
+        const std::string text(view.data(), view.size());
+        if (text == "page ") {
+            saw_reset_page_color = !(run.style & CompactPage::HAS_FOREGROUND) &&
+                                   resolve_foreground(reset_color_page, run, 0xe8b4f0) ==
+                                       0xaabbcc;
+        } else if (text == "unstyled link") {
+            saw_unstyled_link_color = run.link_index >= 0 &&
+                                      !(run.style & CompactPage::HAS_FOREGROUND) &&
+                                      resolve_foreground(reset_color_page, run, 0xe8b4f0) ==
+                                          0xaabbcc;
+        }
+    }
+    check("foreground reset returns to the page foreground", saw_reset_page_color);
+    check("unstyled links inherit the page foreground", saw_unstyled_link_color);
+
+    auto default_color_doc = parser.parse("plain\n");
+    CompactPage default_color_page;
+    check("unstyled Micron keeps the Pyxis fallback foreground",
+          default_color_page.assign(default_color_doc) &&
+          !default_color_page.runs().empty() &&
+          resolve_foreground(default_color_page, default_color_page.runs().front(), 0xe8b4f0) ==
+              0xe8b4f0);
+    auto background_only_doc = parser.parse("#!bg=abc\nplain\n");
+    CompactPage background_only_page;
+    check("page background does not replace the fallback foreground",
+          background_only_page.assign(background_only_doc) &&
+              background_only_page.has_background() &&
+              background_only_page.background() == 0xaabbcc &&
+              !background_only_page.has_foreground() &&
+              resolve_foreground(background_only_page, background_only_page.runs().front(),
+                                 0xe8b4f0) == 0xe8b4f0);
+    auto foreground_only_doc = parser.parse("#!fg=123\nplain\n");
+    CompactPage foreground_only_page;
+    check("page foreground does not invent a page background",
+          foreground_only_page.assign(foreground_only_doc) &&
+              foreground_only_page.has_foreground() &&
+              foreground_only_page.foreground() == 0x112233 &&
+              !foreground_only_page.has_background());
     compact.clear();
     check("compact page teardown releases every retained record", compact.empty() &&
           compact.arena_bytes() == 0 && compact.blocks().empty() && compact.runs().empty() && compact.links().empty());

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -16,6 +16,7 @@
 #include "NomadNetMailbox.h"
 #include "NomadNetCompactPage.h"
 #include "NomadNetColors.h"
+#include "NomadNetFocus.h"
 #include "NomadNetProtocol.h"
 #include "NomadNetRequestPolicy.h"
 #include "NomadNetUrl.h"
@@ -37,6 +38,7 @@ using UI::LXMF::NomadNet::page_title;
 using UI::LXMF::NomadNet::AsyncMailbox;
 using UI::LXMF::NomadNet::CompactPage;
 using UI::LXMF::NomadNet::resolve_foreground;
+using UI::LXMF::NomadNet::for_each_focus_span;
 using UI::LXMF::NomadNet::ResponseBuffer;
 using UI::LXMF::NomadNet::RequestPolicy;
 using UI::LXMF::NomadNet::Url;
@@ -238,6 +240,38 @@ int main(int argc, char** argv) {
     saturated_blue_run.background = 0x0000ff;
     check("focus border uses sRGB contrast for saturated blue",
           resolve_focus_border(color_page, saturated_blue_run, 0x1d1a1e) == 0xffffff);
+
+    struct FocusFragmentFixture {
+        int16_t link_index;
+        uint16_t run_index;
+        int16_t x;
+        int16_t y;
+        int16_t width;
+        int16_t height;
+    };
+    const std::vector<FocusFragmentFixture> focus_fragments{
+        {3, 7, 10, 20, 28, 16},
+        {3, 7, 38, 20, 7, 16},
+        {3, 7, 45, 20, 35, 16},
+        {3, 7, 10, 39, 24, 16},
+        {3, 8, 34, 39, 20, 16},
+        {4, 9, 60, 39, 30, 16},
+    };
+    std::vector<UI::LXMF::NomadNet::FocusSpan> focus_spans;
+    for_each_focus_span(focus_fragments, 3, [&](const auto& span) {
+        focus_spans.push_back(span);
+    });
+    check("selected multi-word links use one focus outline per visual line and style run",
+          focus_spans.size() == 3 &&
+              focus_spans[0].x == 10 && focus_spans[0].y == 20 &&
+              focus_spans[0].width == 70 && focus_spans[0].height == 16 &&
+              focus_spans[0].run_index == 7 &&
+              focus_spans[1].x == 10 && focus_spans[1].y == 39 &&
+              focus_spans[1].width == 24 && focus_spans[1].height == 16 &&
+              focus_spans[1].run_index == 7 &&
+              focus_spans[2].x == 34 && focus_spans[2].y == 39 &&
+              focus_spans[2].width == 20 && focus_spans[2].height == 16 &&
+              focus_spans[2].run_index == 8);
 
     auto reset_color_doc = parser.parse(
         "#!fg=abc\n`Ff00inline`fpage `[unstyled link`:/page/plain.mu]\n");

--- a/tests/native/test_app_launcher_nomadnet.py
+++ b/tests/native/test_app_launcher_nomadnet.py
@@ -529,6 +529,21 @@ def test_nomadnet_navigation_keeps_theme_font_with_remote_glyph_fallback():
     assert directory.count("navigation_font_12()") == 3
 
 
+def test_nomadnet_draw_preserves_authored_colors_for_links_and_focus():
+    browser_cpp = (INCLUDE / "NomadNetScreen.cpp").read_text()
+    draw = browser_cpp[
+        browser_cpp.index("void NomadNetScreen::draw_page(") :
+        browser_cpp.index("void NomadNetScreen::select_link(")
+    ]
+
+    assert "dsc.color=lv_color_hex(NomadNet::resolve_foreground(_page,run,Theme::TEXT_PRIMARY));" in draw
+    assert "run.link_index>=0?Theme::primaryLight()" not in draw
+    assert "selected?Theme::primaryPressed()" not in draw
+    assert "bg.bg_color=lv_color_hex(run.background)" in draw
+    assert "focus.bg_opa=LV_OPA_TRANSP" in draw
+    assert "focus.border_color=lv_color_hex(NomadNet::resolve_focus_border(" in draw
+
+
 def test_nomadnet_bold_body_text_keeps_body_font_metrics():
     browser_cpp = (INCLUDE / "NomadNetScreen.cpp").read_text()
     fonts = INCLUDE.parent / "Fonts"


### PR DESCRIPTION
## Summary

- honor Micron page and inline foreground/background colors in the NomadNet LVGL renderer
- resolve each color component independently, with inline values overriding page values and Pyxis theme colors remaining the fallback for unspecified components
- preserve authored link colors while drawing a black or white focus border selected by sRGB relative luminance
- coalesce selected multi-word link fragments into one focus outline per visual line and style run
- add native coverage for RGB shorthand, six-digit truecolor, Urwid grayscale quantization, reset semantics, inheritance, links, component independence, contrast selection, wrapping, and focus-span geometry

PR #73 is merged. This branch contains two follow-up commits on top of its merged head and now targets `main` directly.

Micron truecolor values remain logical 24-bit RGB values and are quantized by the existing LVGL RGB565 display pipeline. This PR does not change display color depth, SPI traffic, or framebuffer allocation.

## Verification

- `/tmp/pyxis-test-venv/bin/python -m pytest tests/native/test_app_launcher_nomadnet.py -q`
  - 24 passed
- `/tmp/pyxis-test-venv/bin/python -m pytest tests/build_scripts tests/native -q`
  - 231 passed, 1 hardware-dependent skip
- independent strict C++17 ASan/UBSan fixture run
  - 153 passed, 0 failed per fixture
- `/tmp/pyxis-pio-venv/bin/pio run -e tdeck`
  - success
  - RAM: 75,808 / 327,680 bytes (23.1%)
  - Flash: 2,796,693 / 3,145,728 bytes (88.9%)
  - microReticulum: `6ac0d32`
  - microLXMF: `60fb7d6`
- `git diff --check`
  - clean
- added-line secret/private-endpoint scan
  - no findings

## Physical validation

A T-Deck was flashed with version `0.3.3-beta-11-g76eae01` and exercised against the Mac-hosted Python RNS 1.4.2 NomadNet renderer test site.

- authored page and inline colors rendered correctly through the RGB565 output path
- selected multi-word links showed one continuous focus outline without interior lines between words
- identity, settings, LittleFS, and six conversations remained available after the helper upload
- Wi-Fi and TCP reconnected and the device reached `System Ready`
- no panic or watchdog reset was observed

Physical artifact:

- size: 2,797,040 bytes
- SHA-256: `ea8627cfbafd0c02fad852133f252236113434c1ef7ec23e8a5963eadcc75132`

The helper upload performed esptool block hash verification. It did not perform an independent full-region read-back or byte-for-byte protected-region comparison.
