### PR TITLE
Bound NomadNet pages and preserve decompression headroom

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
@@ -36,13 +36,16 @@ bool CompactPage::append_display(const std::string& value, uint32_t& offset, uin
 bool CompactPage::assign(const Document& document) {
     clear();
     try {
-        const std::size_t block_count = std::min(document.blocks.size(), MAX_BLOCKS);
+        const bool reserve_notice = document.truncated;
+        const std::size_t block_limit = MAX_BLOCKS - (reserve_notice ? 1 : 0);
+        const std::size_t run_limit = MAX_RUNS - (reserve_notice ? 1 : 0);
+        const std::size_t block_count = std::min(document.blocks.size(), block_limit);
         const std::size_t link_count = std::min(document.links.size(), MAX_LINKS);
         std::size_t run_count = 0;
         std::size_t arena_size = 0;
         for (std::size_t i = 0; i < block_count; ++i) {
             const std::size_t retained = std::min(document.blocks[i].runs.size(),
-                MAX_RUNS - std::min(run_count, MAX_RUNS));
+                run_limit - std::min(run_count, run_limit));
             run_count += retained;
             for (std::size_t r = 0; r < retained; ++r) {
                 const std::size_t bytes = document.blocks[i].runs[r].text.size() + 1;
@@ -58,7 +61,7 @@ bool CompactPage::assign(const Document& document) {
         }
         _arena.reserve(arena_size);
         _blocks.reserve(block_count);
-        _runs.reserve(std::min(run_count, MAX_RUNS));
+        _runs.reserve(std::min(run_count, run_limit));
         _links.reserve(link_count);
 
         for (std::size_t i = 0; i < link_count; ++i) {
@@ -75,15 +78,19 @@ bool CompactPage::assign(const Document& document) {
             _links.push_back(link);
         }
 
-        for (std::size_t i = 0; i < block_count && _runs.size() < MAX_RUNS; ++i) {
+        for (std::size_t i = 0; i < block_count; ++i) {
             const auto& source_block = document.blocks[i];
+            if (!source_block.runs.empty() && _runs.size() >= run_limit) {
+                _truncated = true;
+                continue;
+            }
             BlockRecord block;
             block.first_run = static_cast<uint32_t>(_runs.size());
             block.type = source_block.type;
             block.depth = source_block.depth;
             block.alignment = source_block.alignment;
             for (const auto& source_run : source_block.runs) {
-                if (_runs.size() >= MAX_RUNS || block.run_count == std::numeric_limits<uint16_t>::max()) {
+                if (_runs.size() >= run_limit || block.run_count == std::numeric_limits<uint16_t>::max()) {
                     _truncated = true;
                     break;
                 }
@@ -136,7 +143,24 @@ void CompactPage::clear() {
 }
 
 bool CompactPage::append_notice(const std::string& value) {
-    if (_blocks.size() >= MAX_BLOCKS || _runs.size() >= MAX_RUNS) return false;
+    if (value.size() > MAX_NOTICE_BYTES ||
+        value.size() + 1 > MAX_ARENA_BYTES - std::min(_arena.size(), MAX_ARENA_BYTES))
+        return false;
+    if (_blocks.size() >= MAX_BLOCKS) {
+        const BlockRecord removed = _blocks.back();
+        const std::size_t first = std::min<std::size_t>(removed.first_run, _runs.size());
+        _runs.resize(first);
+        _blocks.pop_back();
+    }
+    if (_runs.size() >= MAX_RUNS) {
+        std::size_t owner = _blocks.size();
+        while (owner > 0 && _blocks[owner - 1].run_count == 0) --owner;
+        if (owner == 0) return false;
+        _runs.pop_back();
+        --_blocks[owner - 1].run_count;
+        for (std::size_t i = owner; i < _blocks.size(); ++i)
+            _blocks[i].first_run = static_cast<uint32_t>(_runs.size());
+    }
     try {
         RunRecord run;
         if (!append(value, run.text_offset, run.text_length)) return false;
@@ -148,6 +172,7 @@ bool CompactPage::append_notice(const std::string& value) {
         _blocks.push_back(block);
         return true;
     } catch (const std::bad_alloc&) {
+        clear();
         return false;
     }
 }

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
@@ -9,6 +9,16 @@
 
 namespace UI::LXMF::NomadNet {
 
+inline bool layout_content_truncated(std::size_t fragment_count,
+                                     std::size_t fragment_limit,
+                                     bool content_remaining) {
+    return content_remaining && fragment_count >= fragment_limit;
+}
+
+inline bool block_has_layout_content(BlockType type, uint16_t run_count) {
+    return type == BlockType::DIVIDER || run_count != 0;
+}
+
 class CompactPage {
 public:
     static constexpr std::size_t MAX_BLOCKS = DocumentParser::MAX_BLOCKS;
@@ -17,8 +27,10 @@ public:
     // Text runs and link targets both originate in the bounded source, but a
     // link's target is also represented inside its visible run. Account for
     // that bounded duplication plus one terminator per retained record.
+    static constexpr std::size_t MAX_NOTICE_BYTES = 96;
     static constexpr std::size_t MAX_ARENA_BYTES =
-        DocumentParser::MAX_DOCUMENT_BYTES * 2 + MAX_RUNS + MAX_LINKS;
+        DocumentParser::MAX_DOCUMENT_BYTES * 2 + MAX_RUNS + MAX_LINKS +
+        MAX_NOTICE_BYTES + 1;
 
     enum Style : uint8_t {
         BOLD = 1 << 0,

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
@@ -57,7 +57,7 @@ struct Style {
 void add_run(Document& doc, Block& block, std::string& text, const Style& style, int link = -1) {
     if (text.empty()) return;
     if (block.runs.size() >= DocumentParser::MAX_RUNS_PER_LINE) {
-        doc.truncated = true;
+        doc.mark_truncated(TruncationReason::RUNS_PER_LINE);
         text.clear();
         return;
     }
@@ -137,7 +137,7 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
                 doc.links.push_back({label, target, fields});
                 std::string link_text = label;
                 add_run(doc, block, link_text, style, static_cast<int>(doc.links.size() - 1));
-            } else doc.truncated = true;
+            } else doc.mark_truncated(TruncationReason::LINKS);
             i = close + 1;
         } else {
             // Unknown modifiers are harmless and visible rather than commands.
@@ -164,7 +164,7 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
     while (retained > 0 && retained < size &&
            (static_cast<uint8_t>(source[retained]) & 0xc0) == 0x80) --retained;
     doc.source_bytes = retained;
-    doc.truncated = size > retained;
+    if (size > retained) doc.mark_truncated(TruncationReason::DOCUMENT_BYTES);
     // Own an exact retained prefix so no find/substr operation can inspect
     // attacker-controlled bytes beyond the documented source cap.
     const std::string input(source ? source : "", retained);
@@ -185,7 +185,7 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
             length = MAX_SOURCE_LINE_BYTES;
             while (length > 0 && offset + length < input.size() &&
                    (static_cast<uint8_t>(input[offset + length]) & 0xc0) == 0x80) --length;
-            doc.truncated = true;
+            doc.mark_truncated(TruncationReason::SOURCE_LINE_BYTES);
         }
         std::string line = input.substr(offset, length);
         if (!line.empty() && line.back() == '\r') line.pop_back();
@@ -220,13 +220,21 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
         }
         if (line == "`=") { literal = !literal; continue; }
         if (line.empty()) {
-            if (doc.blocks.size() >= MAX_BLOCKS) { doc.truncated = true; break; }
+            if (doc.blocks.size() >= MAX_BLOCKS) {
+                doc.mark_truncated(TruncationReason::BLOCKS);
+                break;
+            }
+            if (total_runs >= MAX_TOTAL_RUNS) {
+                doc.mark_truncated(TruncationReason::TOTAL_RUNS);
+                break;
+            }
             Block blank;
             blank.depth = section_depth;
             Run run;
             run.text = " ";
             blank.runs.push_back(std::move(run));
             doc.blocks.push_back(std::move(blank));
+            ++total_runs;
             continue;
         }
         while (!line.empty() && line[0] == '<') {
@@ -234,7 +242,11 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
             line.erase(0, 1);
         }
         if (line.empty()) continue;
-        if (doc.blocks.size() >= MAX_BLOCKS) { doc.truncated = true; break; }
+        if (!literal && line[0] == '#') continue;
+        if (doc.blocks.size() >= MAX_BLOCKS) {
+            doc.mark_truncated(TruncationReason::BLOCKS);
+            break;
+        }
 
         Block block;
         block.depth = section_depth;
@@ -243,8 +255,6 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
             Run run;
             run.text = line;
             block.runs.push_back(std::move(run));
-        } else if (line[0] == '#') {
-            continue;
         } else if (line[0] == '>') {
             block.type = BlockType::HEADING;
             std::size_t depth = 0;
@@ -263,17 +273,45 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
         } else {
             parse_inline(doc, block, line, style);
         }
-        if (total_runs + block.runs.size() > MAX_TOTAL_RUNS) {
+        const bool total_runs_exceeded =
+            total_runs + block.runs.size() > MAX_TOTAL_RUNS;
+        if (total_runs_exceeded) {
             block.runs.resize(MAX_TOTAL_RUNS - total_runs);
-            doc.truncated = true;
+            doc.mark_truncated(TruncationReason::TOTAL_RUNS);
         }
         total_runs += block.runs.size();
         doc.blocks.push_back(std::move(block));
-        if (total_runs >= MAX_TOTAL_RUNS) break;
+        if (total_runs_exceeded) break;
     }
-    if (offset <= retained) doc.truncated = true;
+    if (offset <= retained && doc.source_lines >= MAX_SOURCE_LINES)
+        doc.mark_truncated(TruncationReason::SOURCE_LINES);
     if (literal) doc.malformed = true;
     return doc;
+}
+
+std::string truncation_notice(const Document& document) {
+    if (document.has_truncation(TruncationReason::DOCUMENT_BYTES))
+        return "[Page truncated: source exceeds " +
+            std::to_string(DocumentParser::MAX_DOCUMENT_BYTES / 1024) + " KiB]";
+    if (document.has_truncation(TruncationReason::SOURCE_LINE_BYTES))
+        return "[Page truncated: line exceeds " +
+            std::to_string(DocumentParser::MAX_SOURCE_LINE_BYTES) + " bytes]";
+    if (document.has_truncation(TruncationReason::SOURCE_LINES))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_SOURCE_LINES) + " lines]";
+    if (document.has_truncation(TruncationReason::BLOCKS))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_BLOCKS) + " blocks]";
+    if (document.has_truncation(TruncationReason::RUNS_PER_LINE))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_RUNS_PER_LINE) + " styles on one line]";
+    if (document.has_truncation(TruncationReason::TOTAL_RUNS))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_TOTAL_RUNS) + " styled runs]";
+    if (document.has_truncation(TruncationReason::LINKS))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_LINKS) + " links]";
+    return "[Page truncated to device safety limits]";
 }
 
 } // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
@@ -10,6 +10,16 @@ namespace UI::LXMF::NomadNet {
 enum class BlockType { TEXT, HEADING, DIVIDER, UNSUPPORTED };
 enum class Alignment { LEFT, CENTER, RIGHT };
 
+enum class TruncationReason : uint8_t {
+    DOCUMENT_BYTES = 1 << 0,
+    SOURCE_LINES = 1 << 1,
+    SOURCE_LINE_BYTES = 1 << 2,
+    BLOCKS = 1 << 3,
+    RUNS_PER_LINE = 1 << 4,
+    TOTAL_RUNS = 1 << 5,
+    LINKS = 1 << 6,
+};
+
 struct Run {
     std::string text;
     bool bold = false;
@@ -48,6 +58,15 @@ struct Document {
     bool unsupported = false;
     std::size_t source_bytes = 0;
     std::size_t source_lines = 0;
+    uint8_t truncation_reasons = 0;
+
+    void mark_truncated(TruncationReason reason) {
+        truncated = true;
+        truncation_reasons |= static_cast<uint8_t>(reason);
+    }
+    bool has_truncation(TruncationReason reason) const {
+        return (truncation_reasons & static_cast<uint8_t>(reason)) != 0;
+    }
 };
 
 class DocumentParser {
@@ -64,5 +83,7 @@ public:
     Document parse(const std::string& source) const;
     Document parse(const char* source, std::size_t size) const;
 };
+
+std::string truncation_notice(const Document& document);
 
 } // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -335,9 +335,20 @@ bool NomadNetScreen::set_page(const NomadNet::Document& document) {
         set_status("Page is too large for available memory");
         return false;
     }
-    if(_page.truncated())_page.append_notice("[Page truncated to device safety limits]");
+    if(_page.truncated()){
+        const std::string notice=NomadNet::truncation_notice(document);
+        if(!_page.append_notice(notice)){
+            clear_document();
+            set_status("Page truncation notice could not be retained");
+            return false;
+        }
+    }
     else if(_page.unsupported())_page.append_notice("[Unsupported Micron content]");
-    layout_page();
+    if(!layout_page()){
+        clear_document();
+        set_status("Page layout notice could not be retained");
+        return false;
+    }
     lv_obj_set_style_bg_color(_content,_page.has_background()
         ?lv_color_hex(_page.background()):Theme::surface(),0);
     _page_loaded=true;
@@ -348,17 +359,26 @@ bool NomadNetScreen::set_page(const NomadNet::Document& document) {
     return true;
 }
 
-void NomadNetScreen::layout_page(){
+bool NomadNetScreen::layout_page(){
     _page_layout.clear();
     _page_layout.reserve(std::min<std::size_t>(_page.runs().size()*4,MAX_LAYOUT_FRAGMENTS));
     constexpr std::size_t content_fragment_limit=MAX_LAYOUT_FRAGMENTS-1;
     constexpr int16_t width=304;
     int16_t y=0;
-    for(const auto& block:_page.blocks()){
-        if(_page_layout.size()>=content_fragment_limit)break;
+    bool content_remaining=false;
+    for(std::size_t block_index=0;block_index<_page.blocks().size();++block_index){
+        if(_page_layout.size()>=content_fragment_limit){
+            content_remaining=std::any_of(_page.blocks().begin()+block_index,_page.blocks().end(),
+                [](const NomadNet::CompactPage::BlockRecord& candidate){
+                    return NomadNet::block_has_layout_content(candidate.type,candidate.run_count);
+                });
+            break;
+        }
+        const auto& block=_page.blocks()[block_index];
         if(block.type==NomadNet::BlockType::DIVIDER){
             _page_layout.push_back(LayoutFragment(0,0,0,-1,0,y,width,1,true));y+=9;continue;
         }
+        if(block.run_count==0)continue;
         const int16_t indent=block.type==NomadNet::BlockType::HEADING?0:
             static_cast<int16_t>(std::min<unsigned>(block.depth,8)*4);
         const int16_t available=width-indent;
@@ -377,6 +397,7 @@ void NomadNetScreen::layout_page(){
                 if(_page_layout[i].y==current_y)_page_layout[i].x+=shift;
         };
         for(uint16_t r=0;r<block.run_count&&block.first_run+r<_page.runs().size();++r){
+            if(_page_layout.size()>=content_fragment_limit){content_remaining=true;break;}
             const uint16_t run_index=static_cast<uint16_t>(block.first_run+r);
             const auto& run=_page.runs()[run_index];
             const auto text=_page.text(run);
@@ -385,7 +406,8 @@ void NomadNetScreen::layout_page(){
             const int16_t height=static_cast<int16_t>(font->line_height+3);
             line_h=std::max(line_h,height);
             std::size_t offset=0;
-            while(offset<text.size()&&_page_layout.size()<content_fragment_limit){
+            while(offset<text.size()){
+                if(_page_layout.size()>=content_fragment_limit){content_remaining=true;break;}
                 std::size_t end=offset;
                 const bool whitespace=text[offset]==' '||text[offset]=='\t';
                 while(end<text.size()&&((text[end]==' '||text[end]=='\t')==whitespace)&&end-offset<255)++end;
@@ -419,13 +441,22 @@ void NomadNetScreen::layout_page(){
                 }
                 offset=end;
             }
+            if(content_remaining)break;
         }
         align_line(line_first,_page_layout.size(),line_y);
         y+=line_h+3;
+        if(content_remaining)break;
     }
-    if(_page_layout.size()>=content_fragment_limit&&
-       _page.append_notice("[Page layout truncated to device safety limits]")){
+    if(NomadNet::layout_content_truncated(_page_layout.size(),content_fragment_limit,
+                                         content_remaining)){
+        const std::string layout_notice="[Page layout truncated: "+
+            std::to_string(content_fragment_limit)+" fragments]";
+        if(!_page.append_notice(layout_notice))return false;
         const uint16_t notice_run_index=static_cast<uint16_t>(_page.runs().size()-1);
+        _page_layout.erase(std::remove_if(_page_layout.begin(),_page_layout.end(),
+            [notice_run_index](const LayoutFragment& fragment){
+                return !fragment.divider&&fragment.run_index>=notice_run_index;
+            }),_page_layout.end());
         const auto notice=_page.text(_page.runs()[notice_run_index]);
         const int16_t notice_width=static_cast<int16_t>(std::min<lv_coord_t>(304,
             lv_txt_get_width(notice.data(),static_cast<uint32_t>(notice.size()),
@@ -435,6 +466,7 @@ void NomadNetScreen::layout_page(){
         y+=22;
     }
     _page_height=std::max<int32_t>(y,lv_obj_get_content_height(_content));
+    return true;
 }
 
 void NomadNetScreen::draw_page(lv_event_t* event){

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
@@ -81,7 +81,7 @@ private:
     void show_browser(bool editing);
     void clear_document();
     void clear_directory();
-    void layout_page();
+    bool layout_page();
     void draw_page(lv_event_t* event);
     void select_link(int direction);
     void activate_selected_link();

--- a/platformio.ini
+++ b/platformio.ini
@@ -97,7 +97,10 @@ lib_deps =
     ; comment at the _path_table mirror in Transport::inbound for details.
     ; 6ac0d32: initializes endpoint path storage and bounds request responses,
     ; including Resource advertisements and streaming bzip2 decompression.
-    https://github.com/torlando-tech/microReticulum.git#6ac0d3232cf705d538f9c556f0f82d2d2cc753bc
+    ; 572b570: bounds the persistent/enumerable path and active/held announce
+    ; tables so the explicit 1 MiB RNS container pool cannot grow without limit.
+    ; Local-only pin until the dependency commit is published; do not push this URL.
+    git+file:///home/tyler/repos/microreticulum-bounded-tables#572b5706f442be134f5a9c35a41e6368441b8fc1
     ; microLXMF: chore/microreticulum-0.4.1-layout — includes namespaced to
     ; <microReticulum/...> for the 0.4.x src/microReticulum/ layout.
     ; 3cdde79: faster load_message_metadata — single LittleFS open (read_file
@@ -173,10 +176,15 @@ build_flags =
     ; to path table" / "PropagationNodeManager: Pool full" spam.
     ; RNS_PSRAM_ALLOCATOR routes default new/delete to ps_malloc;
     ; RNS_PSRAM_POOL_ALLOCATOR routes long-lived STL containers (path
-    ; table) into a dedicated 2MB TLSF pool in PSRAM.
+    ; table) into a dedicated TLSF pool in PSRAM. Keep that pool at 1 MiB:
+    ; the persisted path table is capped at 400 records (roughly 225 KiB of
+    ; payload), while Python Resource senders use bz2 level 9 by default.
+    ; libbz2's small decoder needs 2.25 MB of transient block arrays before
+    ; bounded output and state. The former 2 MB pool left only 1.95 MB free
+    ; during a retained-Link response and valid compressed Resources failed.
     -DRNS_DEFAULT_ALLOCATOR=RNS_PSRAM_ALLOCATOR
     -DRNS_CONTAINER_ALLOCATOR=RNS_PSRAM_POOL_ALLOCATOR
-    -DRNS_PSRAM_POOL_BUFFER_SIZE=2048000
+    -DRNS_PSRAM_POOL_BUFFER_SIZE=1048576
     ; Enable filesystem-backed path persistence in microReticulum.
     ; Without these, Transport::start() skips _path_store.init(), and
     ; every announce-driven _new_path_table.put() bails silently at

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,8 +57,8 @@ lib_deps =
     ; as this VCS pin.
     ; 2762f76 closes long-lived segment/index handles before compaction unlinks
     ; their LittleFS files, then reopens the append handles for subsequent puts.
-    ; Local-only pin until the dependency commit is published; do not push this URL.
-    git+file:///home/tyler/repos/microstore-compaction-fix#2762f7606800ffb23f4a593947d4f58e259cda7a
+    ; Immutable published pin for the physically validated compaction fix.
+    https://github.com/torlando-tech/microStore.git#2762f7606800ffb23f4a593947d4f58e259cda7a
     ; Explicit git dep so PIO links exactly ONE microReticulum (the
     ; live source). lib_extra_dirs was creating duplicate compilations
     ; — PIO compiled deps/microReticulum/ as one library AND auto-
@@ -102,8 +102,8 @@ lib_deps =
     ; including Resource advertisements and streaming bzip2 decompression.
     ; 572b570: bounds the persistent/enumerable path and active/held announce
     ; tables so the explicit 1 MiB RNS container pool cannot grow without limit.
-    ; Local-only pin until the dependency commit is published; do not push this URL.
-    git+file:///home/tyler/repos/microreticulum-bounded-tables#572b5706f442be134f5a9c35a41e6368441b8fc1
+    ; Immutable published pin for bounded transport tables.
+    https://github.com/torlando-tech/microReticulum.git#572b5706f442be134f5a9c35a41e6368441b8fc1
     ; microLXMF: chore/microreticulum-0.4.1-layout — includes namespaced to
     ; <microReticulum/...> for the 0.4.x src/microReticulum/ layout.
     ; 3cdde79: faster load_message_metadata — single LittleFS open (read_file

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,12 +50,15 @@ lib_ldf_mode = chain+
 ; Build type
 build_type = release
 lib_deps =
-    ; Install the immutable microStore pin before microReticulum. Its upstream
+    ; Install the exact microStore pin before microReticulum. Its upstream
     ; metadata declares an unconstrained registry microStore dependency; if
     ; microReticulum resolves first, PlatformIO can populate the shared library
     ; name with a newer registry package while misleadingly labeling the graph
     ; as this VCS pin.
-    https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2
+    ; 2762f76 closes long-lived segment/index handles before compaction unlinks
+    ; their LittleFS files, then reopens the append handles for subsequent puts.
+    ; Local-only pin until the dependency commit is published; do not push this URL.
+    git+file:///home/tyler/repos/microstore-compaction-fix#2762f7606800ffb23f4a593947d4f58e259cda7a
     ; Explicit git dep so PIO links exactly ONE microReticulum (the
     ; live source). lib_extra_dirs was creating duplicate compilations
     ; — PIO compiled deps/microReticulum/ as one library AND auto-

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 MICROSTORE_PIN = "https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2"
-MICRORETICULUM_PIN = "https://github.com/torlando-tech/microReticulum.git#6ac0d3232cf705d538f9c556f0f82d2d2cc753bc"
+MICRORETICULUM_PIN = "git+file:///home/tyler/repos/microreticulum-bounded-tables#572b5706f442be134f5a9c35a41e6368441b8fc1"
+MAX_RNS_PSRAM_POOL_BYTES = 1024 * 1024
 
 
 def test_microstore_pin_resolves_before_transitive_registry_requirement():
@@ -19,6 +20,21 @@ def test_release_auditor_expects_the_configured_microreticulum_pin():
     expected_revision = MICRORETICULUM_PIN.rsplit("#", 1)[1]
 
     assert f'"microReticulum": "{expected_revision}"' in audit
+
+
+def test_rns_psram_pool_leaves_workspace_for_python_level9_bz2_responses():
+    config = (ROOT / "platformio.ini").read_text()
+    prefix = "-DRNS_PSRAM_POOL_BUFFER_SIZE="
+    configured = next(
+        int(line.strip()[len(prefix) :])
+        for line in config.splitlines()
+        if line.strip().startswith(prefix)
+    )
+
+    # Python bz2.compress() defaults to level 9. libbz2's small decoder needs
+    # 2.25 MB for its two block arrays before output/state allocations. Keep the
+    # long-lived RNS container pool bounded so that workspace remains available.
+    assert configured == MAX_RNS_PSRAM_POOL_BYTES
 
 
 def test_tdeck_release_removes_diagnostic_flags():

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-MICROSTORE_PIN = "git+file:///home/tyler/repos/microstore-compaction-fix#2762f7606800ffb23f4a593947d4f58e259cda7a"
-MICRORETICULUM_PIN = "git+file:///home/tyler/repos/microreticulum-bounded-tables#572b5706f442be134f5a9c35a41e6368441b8fc1"
+MICROSTORE_PIN = "https://github.com/torlando-tech/microStore.git#2762f7606800ffb23f4a593947d4f58e259cda7a"
+MICRORETICULUM_PIN = "https://github.com/torlando-tech/microReticulum.git#572b5706f442be134f5a9c35a41e6368441b8fc1"
 MAX_RNS_PSRAM_POOL_BYTES = 1024 * 1024
 
 

--- a/tests/build_scripts/test_release_build_contract.py
+++ b/tests/build_scripts/test_release_build_contract.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
-MICROSTORE_PIN = "https://github.com/attermann/microStore.git#c5fb69d68229e684c7fbd17692a67ae8193b84e2"
+MICROSTORE_PIN = "git+file:///home/tyler/repos/microstore-compaction-fix#2762f7606800ffb23f4a593947d4f58e259cda7a"
 MICRORETICULUM_PIN = "git+file:///home/tyler/repos/microreticulum-bounded-tables#572b5706f442be134f5a9c35a41e6368441b8fc1"
 MAX_RNS_PSRAM_POOL_BYTES = 1024 * 1024
 

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -377,11 +377,19 @@ int main(int argc, char** argv) {
     auto huge_doc = parser.parse(huge);
     check("document bytes capped and truncation propagated", huge_doc.truncated &&
                                                              huge_doc.source_bytes == DocumentParser::MAX_DOCUMENT_BYTES);
+    check("document byte truncation reports its exact boundary",
+          huge_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::DOCUMENT_BYTES) &&
+          UI::LXMF::NomadNet::truncation_notice(huge_doc) ==
+              "[Page truncated: source exceeds 64 KiB]");
     check("parser never processes metadata beyond retained source", huge_doc.cache_seconds == 0);
     std::string long_line(DocumentParser::MAX_SOURCE_LINE_BYTES + 20, 'q');
     auto line_doc = parser.parse(long_line);
     check("source line capped", line_doc.truncated && !line_doc.blocks.empty() &&
                                 line_doc.blocks[0].runs[0].text.size() == DocumentParser::MAX_SOURCE_LINE_BYTES);
+    check("source line truncation reports its exact boundary",
+          line_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::SOURCE_LINE_BYTES) &&
+          UI::LXMF::NomadNet::truncation_notice(line_doc) ==
+              "[Page truncated: line exceeds 4096 bytes]");
     auto utf8_boundary = parser.parse(std::string(DocumentParser::MAX_SOURCE_LINE_BYTES - 1, 'x') + "\xe2\x82\xac");
     check("line truncation preserves UTF-8 boundaries", utf8_boundary.truncated && !utf8_boundary.malformed &&
                                                         utf8_boundary.blocks[0].runs[0].text.size() ==
@@ -389,26 +397,115 @@ int main(int argc, char** argv) {
     auto blank_lines = parser.parse("one\n\nthree\n");
     check("blank lines preserve vertical structure", blank_lines.blocks.size() == 4 &&
                                                       blank_lines.blocks[1].runs[0].text == " ");
+    std::string many_blocks;
+    for (std::size_t i = 0; i < DocumentParser::MAX_BLOCKS + 1; ++i) many_blocks += "\n";
+    auto blocks_doc = parser.parse(many_blocks);
+    check("block truncation reports its exact boundary",
+          blocks_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::BLOCKS) &&
+          UI::LXMF::NomadNet::truncation_notice(blocks_doc) ==
+              "[Page truncated: more than 1024 blocks]");
+    CompactPage blocks_page;
+    check("block-limit page reserves room for its truncation notice",
+          blocks_page.assign(blocks_doc) &&
+          blocks_page.append_notice(UI::LXMF::NomadNet::truncation_notice(blocks_doc)) &&
+          blocks_page.blocks().size() <= CompactPage::MAX_BLOCKS &&
+          blocks_page.runs().size() <= CompactPage::MAX_RUNS);
     std::string many_lines;
-    for (std::size_t i = 0; i < DocumentParser::MAX_SOURCE_LINES + 50; ++i) many_lines += "x\n";
+    for (std::size_t i = 0; i < DocumentParser::MAX_SOURCE_LINES + 50; ++i) many_lines += "#\n";
     auto lines_doc = parser.parse(many_lines);
     check("source line count capped", lines_doc.truncated &&
                                       lines_doc.source_lines <= DocumentParser::MAX_SOURCE_LINES);
+    check("source line-count truncation reports its exact boundary",
+          lines_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::SOURCE_LINES) &&
+          UI::LXMF::NomadNet::truncation_notice(lines_doc) ==
+              "[Page truncated: more than 4096 lines]");
     std::string many_runs;
     for (std::size_t i = 0; i < DocumentParser::MAX_RUNS_PER_LINE + 20; ++i) many_runs += "x`!";
     auto runs_doc = parser.parse(many_runs);
     check("runs per line capped", runs_doc.truncated &&
                                     runs_doc.blocks[0].runs.size() == DocumentParser::MAX_RUNS_PER_LINE);
+    check("per-line run truncation reports its exact boundary",
+          runs_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::RUNS_PER_LINE) &&
+          UI::LXMF::NomadNet::truncation_notice(runs_doc) ==
+              "[Page truncated: more than 128 styles on one line]");
     std::string global_runs;
     for (std::size_t i = 0; i < DocumentParser::MAX_TOTAL_RUNS; ++i) global_runs += "a`!b`!\n";
     auto global_runs_doc = parser.parse(global_runs);
     std::size_t retained_runs = 0;
     for (const auto& block : global_runs_doc.blocks) retained_runs += block.runs.size();
     check("runs are globally bounded", global_runs_doc.truncated && retained_runs <= DocumentParser::MAX_TOTAL_RUNS);
+    check("total-run truncation reports its exact boundary",
+          global_runs_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::TOTAL_RUNS) &&
+          UI::LXMF::NomadNet::truncation_notice(global_runs_doc) ==
+              "[Page truncated: more than 1024 styled runs]");
+    CompactPage runs_page;
+    check("run-limit page reserves room for its truncation notice",
+          runs_page.assign(global_runs_doc) &&
+          runs_page.append_notice(UI::LXMF::NomadNet::truncation_notice(global_runs_doc)) &&
+          runs_page.blocks().size() <= CompactPage::MAX_BLOCKS &&
+          runs_page.runs().size() <= CompactPage::MAX_RUNS);
+    std::string exact_blocks_and_runs;
+    for (std::size_t i = 0; i < DocumentParser::MAX_TOTAL_RUNS; ++i)
+        exact_blocks_and_runs += "x\n";
+    exact_blocks_and_runs += "# comment-only tail";
+    auto exact_doc = parser.parse(exact_blocks_and_runs);
+    check("comment tail does not falsely exceed exact block or run limits",
+          !exact_doc.truncated &&
+          !exact_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::BLOCKS) &&
+          !exact_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::TOTAL_RUNS));
+    std::string exact_runs_with_directive;
+    for (std::size_t i = 0; i < DocumentParser::MAX_TOTAL_RUNS; ++i)
+        exact_runs_with_directive += "x\n";
+    exact_runs_with_directive += "#!bg=fff";
+    auto directive_tail_doc = parser.parse(exact_runs_with_directive);
+    check("page directive after exact run limit is still applied",
+          !directive_tail_doc.truncated && directive_tail_doc.has_background &&
+          directive_tail_doc.background == 0xffffff);
+    std::string exact_runs_with_divider;
+    for (std::size_t i = 0; i < DocumentParser::MAX_TOTAL_RUNS / 2; ++i)
+        exact_runs_with_divider += "a`!b\n";
+    exact_runs_with_divider += "-";
+    auto divider_tail_doc = parser.parse(exact_runs_with_divider);
+    CompactPage divider_tail_page;
+    check("compact page retains divider after exact run limit",
+          !divider_tail_doc.truncated && divider_tail_page.assign(divider_tail_doc) &&
+          divider_tail_page.blocks().size() == divider_tail_doc.blocks.size() &&
+          !divider_tail_page.blocks().empty() &&
+          divider_tail_page.blocks().back().type == BlockType::DIVIDER);
+    check("run-cap notice eviction preserves trailing divider and record bounds",
+          divider_tail_page.append_notice("[Page layout truncated: 1023 fragments]") &&
+          divider_tail_page.blocks().size() >= 2 &&
+          divider_tail_page.blocks()[divider_tail_page.blocks().size() - 2].type ==
+              BlockType::DIVIDER &&
+          std::all_of(divider_tail_page.blocks().begin(), divider_tail_page.blocks().end(),
+              [&divider_tail_page](const CompactPage::BlockRecord& block) {
+                  return block.first_run <= divider_tail_page.runs().size() &&
+                      block.run_count <= divider_tail_page.runs().size() - block.first_run;
+              }));
+    CompactPage exact_page;
+    check("full valid compact page can replace tail content with a layout notice",
+          exact_page.assign(exact_doc) &&
+          exact_page.append_notice("[Page layout truncated: 1023 fragments]") &&
+          exact_page.blocks().size() <= CompactPage::MAX_BLOCKS &&
+          exact_page.runs().size() <= CompactPage::MAX_RUNS);
+    auto truncated_with_divider = parser.parse(
+        std::string(DocumentParser::MAX_SOURCE_LINE_BYTES + 1, 'q') + "\n-");
+    CompactPage truncated_divider_page;
+    check("appending notice preserves retained trailing divider",
+          truncated_with_divider.truncated && truncated_divider_page.assign(truncated_with_divider) &&
+          truncated_divider_page.append_notice(UI::LXMF::NomadNet::truncation_notice(
+              truncated_with_divider)) &&
+          truncated_divider_page.blocks().size() >= 2 &&
+          truncated_divider_page.blocks()[truncated_divider_page.blocks().size() - 2].type ==
+              BlockType::DIVIDER);
     std::string many_links;
     for (std::size_t i = 0; i < DocumentParser::MAX_LINKS + 10; ++i) many_links += "`[x`:/page/x]";
     auto links_doc = parser.parse(many_links);
     check("links are globally bounded", links_doc.truncated && links_doc.links.size() == DocumentParser::MAX_LINKS);
+    check("link truncation reports its exact boundary",
+          links_doc.has_truncation(UI::LXMF::NomadNet::TruncationReason::LINKS) &&
+          UI::LXMF::NomadNet::truncation_notice(links_doc) ==
+              "[Page truncated: more than 128 links]");
 
     auto malformed = parser.parse("#!c=not-a-number\n#!bg=xyz\n`F1broken\n[label`target\n`=\ntext");
     check("malformed micron remains bounded", malformed.blocks.size() <= DocumentParser::MAX_BLOCKS);
@@ -478,6 +575,15 @@ int main(int argc, char** argv) {
     check("oversize advertised payload is rejected before retention",
           !UI::LXMF::NomadNet::normalize_response(oversize_advertised, sizeof(oversize_advertised), response) && response.size() == 0);
     check("null and empty responses are rejected", !UI::LXMF::NomadNet::normalize_response(nullptr, 0, response));
+
+    check("exactly full layout is not truncated when no content remains",
+          !UI::LXMF::NomadNet::layout_content_truncated(1023, 1023, false));
+    check("exactly full layout is truncated when content remains",
+          UI::LXMF::NomadNet::layout_content_truncated(1023, 1023, true));
+    check("zero-run text block has no layout content",
+          !UI::LXMF::NomadNet::block_has_layout_content(BlockType::TEXT, 0));
+    check("divider has layout content without a text run",
+          UI::LXMF::NomadNet::block_has_layout_content(BlockType::DIVIDER, 0));
 
     check("compact address preserves short values", compact_address("node:/page/a.mu", 32) == "node:/page/a.mu");
     check("compact address abbreviates destination but preserves path",

--- a/tests/native/test_app_launcher_nomadnet.py
+++ b/tests/native/test_app_launcher_nomadnet.py
@@ -134,7 +134,10 @@ def test_nomadnet_page_body_uses_one_compact_custom_viewport():
     assert "LV_EVENT_DRAW_MAIN" in screen
     assert "lv_draw_label(" in screen
     assert "align_line" in screen
-    assert "[Page truncated to device safety limits]" in screen
+    assert "NomadNet::truncation_notice(document)" in set_page
+    assert "if(!_page.append_notice(notice))" in set_page
+    assert "if(!layout_page())" in set_page
+    assert "[Page truncated to device safety limits]" not in set_page
     assert "[Unsupported Micron content]" in screen
     assert "lv_obj_set_scroll_dir(_content,LV_DIR_VER)" in screen
     assert "CompactPage _page;" in screen_h
@@ -147,7 +150,9 @@ def test_nomadnet_page_body_uses_one_compact_custom_viewport():
     assert "const std::string rendered_text" not in compact_cpp
     assert "visit_display_text" in compact_cpp
     assert "lv_indev_get_type(indev)!=LV_INDEV_TYPE_POINTER" in screen
-    assert "_page.append_notice(\"[Page layout truncated to device safety limits]\")" in screen
+    assert "const std::string layout_notice=\"[Page layout truncated: \"+" in screen
+    assert "std::to_string(content_fragment_limit)+\" fragments]\"" in screen
+    assert "fragment.run_index>=notice_run_index" in screen
     assert "notice_run_index" in screen
     assert "_page_layout.push_back(LayoutFragment(notice_run_index" in screen
     assert "whitespace&&x+fragment_w>indent+available" in screen
@@ -494,7 +499,7 @@ def test_nomadnet_page_fonts_do_not_leak_into_navigation_widgets():
         browser_cpp.index("void NomadNetScreen::detach_focusables(")
     ]
     layout = browser_cpp[
-        browser_cpp.index("void NomadNetScreen::layout_page()") :
+        browser_cpp.index("bool NomadNetScreen::layout_page()") :
         browser_cpp.index("void NomadNetScreen::draw_page(")
     ]
     draw = browser_cpp[

--- a/tools/audit_release_build.py
+++ b/tools/audit_release_build.py
@@ -45,7 +45,7 @@ EXCLUDED_SYMBOLS = (
     "MapTileHttpArduino::",
 )
 PINNED_DEPENDENCIES = {
-    "microReticulum": "6ac0d3232cf705d538f9c556f0f82d2d2cc753bc",
+    "microReticulum": "572b5706f442be134f5a9c35a41e6368441b8fc1",
     "microLXMF": "60fb7d6951bd17275da83fdd9581900d55b0a2ab",
     "microStore": "c5fb69d68229e684c7fbd17692a67ae8193b84e2",
 }

--- a/tools/audit_release_build.py
+++ b/tools/audit_release_build.py
@@ -47,7 +47,7 @@ EXCLUDED_SYMBOLS = (
 PINNED_DEPENDENCIES = {
     "microReticulum": "572b5706f442be134f5a9c35a41e6368441b8fc1",
     "microLXMF": "60fb7d6951bd17275da83fdd9581900d55b0a2ab",
-    "microStore": "c5fb69d68229e684c7fbd17692a67ae8193b84e2",
+    "microStore": "2762f7606800ffb23f4a593947d4f58e259cda7a",
 }
 
 


### PR DESCRIPTION
## Summary
- bound NomadNet parser, model, compact-record, and layout work while retaining the 65,536-byte document-body limit
- reserve one deterministic warning slot, allowing 1,023 drawable fragments within the 1,024-fragment model
- reduce the long-lived RNS container pool to an exact tested 1 MiB, restoring transient PSRAM for Python-compatible level-9 bzip2 Resource decompression
- pin reviewed microReticulum and microStore revisions and enforce them in the release contract/auditor

## Verification
- Pyxis host suite: 232 passed, 1 skipped
- clean `tdeck-release` build and release audit passed
- independent coordinated integration review: PASS
- exact app-only flash read-back matched SHA-256
- partition table, OTA metadata, NVS, app1, LittleFS, and coredump were preserved
- physical long NomadNet page loaded successfully without the prior bzip2 failure
- physical layout stopped deterministically at 1,023 drawable fragments plus warning
- five physical PathStore compactions across boot/reboot completed with zero LittleFS open-FD unlink failures
- no panic, watchdog reset, rollback, or slot switch observed

## Risk and rollback
All peer-controlled limits remain finite and the release build contains no diagnostic/test hooks. Rollback can use the preserved app1 image or revert the focused commits while preserving persistent partitions.
