### PR TITLE
fix: bring NomadNet parser and navigation into parity

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/NomadNetColors.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetColors.h
@@ -6,6 +6,22 @@
 
 namespace UI::LXMF::NomadNet {
 
+inline uint32_t heading_foreground(uint8_t depth) {
+    switch (heading_display_level(depth)) {
+        case 1: return 0x222222;
+        case 2: return 0x111111;
+        default: return 0x000000;
+    }
+}
+
+inline uint32_t heading_background(uint8_t depth) {
+    switch (heading_display_level(depth)) {
+        case 1: return 0xbbbbbb;
+        case 2: return 0x999999;
+        default: return 0x777777;
+    }
+}
+
 inline uint32_t resolve_foreground(const CompactPage& page,
                                    const CompactPage::RunRecord& run,
                                    uint32_t fallback) {
@@ -15,11 +31,29 @@ inline uint32_t resolve_foreground(const CompactPage& page,
 }
 
 inline uint32_t resolve_background(const CompactPage& page,
-                                   const CompactPage::RunRecord& run,
-                                   uint32_t fallback) {
+                                    const CompactPage::RunRecord& run,
+                                    uint32_t fallback) {
     if (run.style & CompactPage::HAS_BACKGROUND) return run.background;
     if (page.has_background()) return page.background();
     return fallback;
+}
+
+inline uint32_t resolve_effective_foreground(const CompactPage& page,
+                                              const CompactPage::RunRecord& run,
+                                              uint8_t heading_level,
+                                              uint32_t fallback) {
+    if (run.style & CompactPage::HAS_FOREGROUND) return run.foreground;
+    if (heading_level != 0) return heading_foreground(heading_level);
+    return resolve_foreground(page, run, fallback);
+}
+
+inline uint32_t resolve_effective_background(const CompactPage& page,
+                                              const CompactPage::RunRecord& run,
+                                              uint8_t heading_level,
+                                              uint32_t fallback) {
+    if (run.style & CompactPage::HAS_BACKGROUND) return run.background;
+    if (heading_level != 0) return heading_background(heading_level);
+    return resolve_background(page, run, fallback);
 }
 
 // IEC 61966-2-1 sRGB channel values, linearised and scaled to 0..10000.
@@ -44,9 +78,11 @@ static constexpr uint16_t SRGB_LINEAR_10000[256] = {
 };
 
 inline uint32_t resolve_focus_border(const CompactPage& page,
-                                     const CompactPage::RunRecord& run,
-                                     uint32_t fallback_background) {
-    const uint32_t background = resolve_background(page, run, fallback_background);
+                                      const CompactPage::RunRecord& run,
+                                      uint32_t fallback_background,
+                                      uint8_t heading_level = 0) {
+    const uint32_t background = resolve_effective_background(
+        page, run, heading_level, fallback_background);
     const uint32_t red = SRGB_LINEAR_10000[(background >> 16) & 0xff];
     const uint32_t green = SRGB_LINEAR_10000[(background >> 8) & 0xff];
     const uint32_t blue = SRGB_LINEAR_10000[background & 0xff];

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
@@ -89,6 +89,7 @@ bool CompactPage::assign(const Document& document) {
             block.type = source_block.type;
             block.depth = source_block.depth;
             block.alignment = source_block.alignment;
+            block.divider_codepoint = source_block.divider_codepoint;
             for (const auto& source_run : source_block.runs) {
                 if (_runs.size() >= run_limit || block.run_count == std::numeric_limits<uint16_t>::max()) {
                     _truncated = true;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.cpp
@@ -2,6 +2,7 @@
 #include "NomadNetGlyphs.h"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 
 namespace UI::LXMF::NomadNet {
@@ -41,6 +42,13 @@ bool CompactPage::assign(const Document& document) {
         const std::size_t run_limit = MAX_RUNS - (reserve_notice ? 1 : 0);
         const std::size_t block_count = std::min(document.blocks.size(), block_limit);
         const std::size_t link_count = std::min(document.links.size(), MAX_LINKS);
+        std::size_t anchor_count = 0;
+        for (const auto& anchor : document.anchors) {
+            if (anchor_count >= MAX_ANCHORS) break;
+            if (anchor.block_index < block_count &&
+                anchor.name.size() <= DocumentParser::MAX_ANCHOR_NAME_BYTES)
+                ++anchor_count;
+        }
         std::size_t run_count = 0;
         std::size_t arena_size = 0;
         for (std::size_t i = 0; i < block_count; ++i) {
@@ -59,10 +67,21 @@ bool CompactPage::assign(const Document& document) {
             if (bytes > MAX_ARENA_BYTES - std::min(arena_size, MAX_ARENA_BYTES)) return false;
             arena_size += bytes;
         }
+        std::size_t anchors_accounted = 0;
+        for (const auto& anchor : document.anchors) {
+            if (anchors_accounted >= anchor_count) break;
+            if (anchor.block_index >= block_count ||
+                anchor.name.size() > DocumentParser::MAX_ANCHOR_NAME_BYTES) continue;
+            const std::size_t bytes = anchor.name.size() + 1;
+            if (bytes > MAX_ARENA_BYTES - std::min(arena_size, MAX_ARENA_BYTES)) return false;
+            arena_size += bytes;
+            ++anchors_accounted;
+        }
         _arena.reserve(arena_size);
         _blocks.reserve(block_count);
         _runs.reserve(std::min(run_count, run_limit));
         _links.reserve(link_count);
+        _anchors.reserve(anchor_count);
 
         for (std::size_t i = 0; i < link_count; ++i) {
             LinkRecord link;
@@ -76,6 +95,19 @@ bool CompactPage::assign(const Document& document) {
                 return false;
             }
             _links.push_back(link);
+        }
+
+        for (const auto& source_anchor : document.anchors) {
+            if (_anchors.size() >= anchor_count) break;
+            if (source_anchor.block_index >= block_count ||
+                source_anchor.name.size() > DocumentParser::MAX_ANCHOR_NAME_BYTES) continue;
+            AnchorRecord anchor;
+            if (!append(source_anchor.name, anchor.name_offset, anchor.name_length)) {
+                clear();
+                return false;
+            }
+            anchor.block_index = source_anchor.block_index;
+            _anchors.push_back(anchor);
         }
 
         for (std::size_t i = 0; i < block_count; ++i) {
@@ -121,7 +153,7 @@ bool CompactPage::assign(const Document& document) {
         _has_foreground = document.has_foreground;
         _foreground = document.foreground;
         _truncated = _truncated || document.truncated || document.blocks.size() > block_count ||
-            document.links.size() > link_count;
+            document.links.size() > link_count || document.anchors.size() > anchor_count;
         _unsupported = document.unsupported;
         return true;
     } catch (const std::bad_alloc&) {
@@ -135,6 +167,7 @@ void CompactPage::clear() {
     ExternalVector<BlockRecord>().swap(_blocks);
     ExternalVector<RunRecord>().swap(_runs);
     ExternalVector<LinkRecord>().swap(_links);
+    ExternalVector<AnchorRecord>().swap(_anchors);
     _has_background = false;
     _background = 0;
     _has_foreground = false;
@@ -162,6 +195,9 @@ bool CompactPage::append_notice(const std::string& value) {
         for (std::size_t i = owner; i < _blocks.size(); ++i)
             _blocks[i].first_run = static_cast<uint32_t>(_runs.size());
     }
+    _anchors.erase(std::remove_if(_anchors.begin(),_anchors.end(),
+        [this](const AnchorRecord& anchor){return anchor.block_index>=_blocks.size();}),
+        _anchors.end());
     try {
         RunRecord run;
         if (!append(value, run.text_offset, run.text_length)) return false;
@@ -188,6 +224,20 @@ CompactPage::TextView CompactPage::target(std::size_t index) const {
     const auto& link = _links[index];
     if (link.target_offset > _arena.size() || link.target_length > _arena.size() - link.target_offset) return {};
     return {_arena.data() + link.target_offset, link.target_length};
+}
+
+bool CompactPage::find_anchor(const std::string& name, uint16_t& block_index) const {
+    if (name.size() > DocumentParser::MAX_ANCHOR_NAME_BYTES) return false;
+    for (const auto& anchor : _anchors) {
+        if (anchor.name_offset > _arena.size() ||
+            anchor.name_length > _arena.size() - anchor.name_offset) continue;
+        if (anchor.name_length == name.size() &&
+            std::memcmp(_arena.data() + anchor.name_offset, name.data(), name.size()) == 0) {
+            block_index = anchor.block_index;
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
@@ -46,6 +46,7 @@ public:
         BlockType type = BlockType::TEXT;
         uint8_t depth = 0;
         Alignment alignment = Alignment::LEFT;
+        uint32_t divider_codepoint = 0x2500;
     };
 
     struct RunRecord {

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
@@ -16,7 +16,26 @@ inline bool layout_content_truncated(std::size_t fragment_count,
 }
 
 inline bool block_has_layout_content(BlockType type, uint16_t run_count) {
-    return type == BlockType::DIVIDER || run_count != 0;
+    return type == BlockType::DIVIDER || type == BlockType::HEADING || run_count != 0;
+}
+
+inline uint8_t heading_display_level(uint8_t depth) {
+    return depth <= 1 ? 1 : depth == 2 ? 2 : 3;
+}
+
+inline bool heading_uses_large_font(uint8_t depth) {
+    return heading_display_level(depth) == 1;
+}
+
+inline uint8_t heading_indent_spaces(uint8_t depth) {
+    if (depth <= 1) return 0;
+    const uint8_t bounded_levels = depth > 8 ? 7 : static_cast<uint8_t>(depth - 1);
+    return static_cast<uint8_t>(bounded_levels * 2);
+}
+
+inline uint8_t heading_bottom_spacing(uint8_t depth) {
+    const uint8_t level = heading_display_level(depth);
+    return level == 1 ? 6 : level == 2 ? 4 : 3;
 }
 
 class CompactPage {

--- a/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetCompactPage.h
@@ -43,13 +43,15 @@ public:
     static constexpr std::size_t MAX_BLOCKS = DocumentParser::MAX_BLOCKS;
     static constexpr std::size_t MAX_RUNS = DocumentParser::MAX_TOTAL_RUNS;
     static constexpr std::size_t MAX_LINKS = DocumentParser::MAX_LINKS;
-    // Text runs and link targets both originate in the bounded source, but a
-    // link's target is also represented inside its visible run. Account for
-    // that bounded duplication plus one terminator per retained record.
+    static constexpr std::size_t MAX_ANCHORS = DocumentParser::MAX_ANCHORS;
+    // Text runs, link targets, and anchor names originate in the bounded source.
+    // Link targets also remain visible in runs, while anchor declarations are
+    // zero-width. Account for both bounded copies and one terminator per record.
     static constexpr std::size_t MAX_NOTICE_BYTES = 96;
     static constexpr std::size_t MAX_ARENA_BYTES =
-        DocumentParser::MAX_DOCUMENT_BYTES * 2 + MAX_RUNS + MAX_LINKS +
-        MAX_NOTICE_BYTES + 1;
+        DocumentParser::MAX_DOCUMENT_BYTES * 2 +
+        MAX_ANCHORS * (DocumentParser::MAX_ANCHOR_NAME_BYTES + 1) +
+        MAX_RUNS + MAX_LINKS + MAX_NOTICE_BYTES + 1;
 
     enum Style : uint8_t {
         BOLD = 1 << 0,
@@ -82,6 +84,12 @@ public:
         uint16_t target_length = 0;
     };
 
+    struct AnchorRecord {
+        uint32_t name_offset = 0;
+        uint16_t name_length = 0;
+        uint16_t block_index = 0;
+    };
+
     struct TextView {
         const char* value = nullptr;
         std::size_t length = 0;
@@ -101,8 +109,10 @@ public:
     const ExternalVector<BlockRecord>& blocks() const { return _blocks; }
     const ExternalVector<RunRecord>& runs() const { return _runs; }
     const ExternalVector<LinkRecord>& links() const { return _links; }
+    const ExternalVector<AnchorRecord>& anchors() const { return _anchors; }
     TextView text(const RunRecord& run) const;
     TextView target(std::size_t index) const;
+    bool find_anchor(const std::string& name, uint16_t& block_index) const;
 
     bool has_background() const { return _has_background; }
     uint32_t background() const { return _background; }
@@ -120,6 +130,7 @@ private:
     ExternalVector<BlockRecord> _blocks;
     ExternalVector<RunRecord> _runs;
     ExternalVector<LinkRecord> _links;
+    ExternalVector<AnchorRecord> _anchors;
     bool _has_background = false;
     uint32_t _background = 0;
     bool _has_foreground = false;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
@@ -95,6 +95,86 @@ bool parse_micron_color(const std::string& value, uint32_t& result) {
     return end && *end == '\0';
 }
 
+bool anchor_char(unsigned char c) {
+    return c < 0x80 && (std::isalnum(c) != 0 || c == '_' || c == '-');
+}
+
+void add_anchor(Document& doc, const std::string& name, std::size_t block_index) {
+    if (name.empty()) return;
+    if (name.size() > DocumentParser::MAX_ANCHOR_NAME_BYTES) {
+        doc.mark_truncated(TruncationReason::ANCHOR_NAME_BYTES);
+        return;
+    }
+    for (const auto& anchor : doc.anchors)
+        if (anchor.name == name) return;
+    if (doc.anchors.size() >= DocumentParser::MAX_ANCHORS) {
+        doc.mark_truncated(TruncationReason::ANCHORS);
+        return;
+    }
+    doc.anchors.push_back({name, static_cast<uint16_t>(block_index)});
+}
+
+bool modifier_without_arguments(char command) {
+    switch (command) {
+        case '!': case '*': case '_': case '=': case 'f': case 'b':
+        case 'a': case 'c': case 'r': case 'l': case '`': case '<':
+        case '>': case '{': case '}': return true;
+        default: return false;
+    }
+}
+
+std::string heading_slug(const std::string& line) {
+    std::string slug;
+    slug.reserve(DocumentParser::MAX_ANCHOR_NAME_BYTES + 1);
+    bool pending_separator = false;
+    for (std::size_t i = 0; i < line.size();) {
+        if (line[i] == '`' && i + 1 < line.size()) {
+            const char command = line[i + 1];
+            if (command == ':') {
+                i += 2;
+                while (i < line.size() && anchor_char(static_cast<unsigned char>(line[i]))) ++i;
+                continue;
+            }
+            if (command == 'F' || command == 'B') {
+                std::size_t value_start = i + 2;
+                std::size_t count = 3;
+                if (value_start < line.size() && line[value_start] == 'T') {
+                    ++value_start;
+                    count = 6;
+                }
+                uint32_t ignored = 0;
+                if (value_start + count <= line.size() &&
+                    parse_micron_color(line.substr(value_start, count), ignored)) {
+                    i = value_start + count;
+                    continue;
+                }
+            }
+            if (modifier_without_arguments(command)) {
+                i += 2;
+                continue;
+            }
+        }
+
+        const unsigned char c = static_cast<unsigned char>(line[i]);
+        if (c < 0x80 && std::isalnum(c) != 0) {
+            if (pending_separator && !slug.empty() &&
+                slug.size() <= DocumentParser::MAX_ANCHOR_NAME_BYTES)
+                slug.push_back('-');
+            if (slug.size() <= DocumentParser::MAX_ANCHOR_NAME_BYTES)
+                slug.push_back(static_cast<char>(std::tolower(c)));
+            pending_separator = false;
+            ++i;
+        } else {
+            pending_separator = !slug.empty();
+            if (c < 0x80) ++i;
+            else if (c <= 0xdf) i += 2;
+            else if (c <= 0xef) i += 3;
+            else i += 4;
+        }
+    }
+    return slug;
+}
+
 struct Style {
     bool bold = false;
     bool italic = false;
@@ -170,6 +250,10 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
             } else doc.malformed = true;
         } else if (command == '`') {
             style = Style{};
+        } else if (command == ':') {
+            const std::size_t name_start = i;
+            while (i < line.size() && anchor_char(static_cast<unsigned char>(line[i]))) ++i;
+            add_anchor(doc, line.substr(name_start, i - name_start), doc.blocks.size());
         } else if (command == '[') {
             const auto close = line.find(']', i);
             if (close == std::string::npos) { doc.malformed = true; text += "`["; continue; }
@@ -323,7 +407,9 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
             while (depth < line.size() && line[depth] == '>') ++depth;
             block.depth = static_cast<uint8_t>(std::min<std::size_t>(depth, 255));
             section_depth = block.depth;
-            parse_inline(doc, block, line.substr(depth), style);
+            const std::string heading = line.substr(depth);
+            parse_inline(doc, block, heading, style);
+            add_anchor(doc, heading_slug(heading), doc.blocks.size());
         } else if (line[0] == '-') {
             block.type = BlockType::DIVIDER;
             uint32_t codepoint = 0;
@@ -379,6 +465,12 @@ std::string truncation_notice(const Document& document) {
     if (document.has_truncation(TruncationReason::LINKS))
         return "[Page truncated: more than " +
             std::to_string(DocumentParser::MAX_LINKS) + " links]";
+    if (document.has_truncation(TruncationReason::ANCHOR_NAME_BYTES))
+        return "[Page truncated: anchor name exceeds " +
+            std::to_string(DocumentParser::MAX_ANCHOR_NAME_BYTES) + " bytes]";
+    if (document.has_truncation(TruncationReason::ANCHORS))
+        return "[Page truncated: more than " +
+            std::to_string(DocumentParser::MAX_ANCHORS) + " anchors]";
     return "[Page truncated to device safety limits]";
 }
 

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
@@ -31,6 +31,34 @@ bool valid_utf8(const std::string& value) {
     return true;
 }
 
+bool first_codepoint(const std::string& value, std::size_t offset,
+                     uint32_t& codepoint, std::size_t& length) {
+    if (offset >= value.size()) return false;
+    const uint8_t lead = static_cast<uint8_t>(value[offset]);
+    if (lead <= 0x7f) {
+        codepoint = lead;
+        length = 1;
+        return true;
+    }
+    std::size_t continuation = 0;
+    if (lead >= 0xc2 && lead <= 0xdf) {
+        codepoint = lead & 0x1f;
+        continuation = 1;
+    } else if (lead >= 0xe0 && lead <= 0xef) {
+        codepoint = lead & 0x0f;
+        continuation = 2;
+    } else if (lead >= 0xf0 && lead <= 0xf4) {
+        codepoint = lead & 0x07;
+        continuation = 3;
+    } else return false;
+    length = continuation + 1;
+    if (offset + length > value.size()) return false;
+    for (std::size_t i = 1; i <= continuation; ++i)
+        codepoint = (codepoint << 6) |
+            (static_cast<uint8_t>(value[offset + i]) & 0x3f);
+    return true;
+}
+
 bool color(const std::string& value, uint32_t& result) {
     if (value.size() != 3 && value.size() != 6) return false;
     if (!std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isxdigit(c); })) return false;
@@ -264,6 +292,12 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
             parse_inline(doc, block, line.substr(depth), style);
         } else if (line[0] == '-') {
             block.type = BlockType::DIVIDER;
+            uint32_t codepoint = 0;
+            std::size_t codepoint_bytes = 0;
+            if (first_codepoint(line, 1, codepoint, codepoint_bytes) &&
+                line.size() == 1 + codepoint_bytes && codepoint >= 32) {
+                block.divider_codepoint = codepoint;
+            }
         } else if (line.rfind("`t", 0) == 0 || line.rfind("`{", 0) == 0 || line.find("`<") != std::string::npos) {
             block.type = BlockType::UNSUPPORTED;
             Run run;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
@@ -59,7 +59,31 @@ bool first_codepoint(const std::string& value, std::size_t offset,
     return true;
 }
 
-bool color(const std::string& value, uint32_t& result) {
+bool parse_micron_color(const std::string& value, uint32_t& result) {
+    if (value.size() == 3 && value[0] == 'g') {
+        if (!std::isdigit(static_cast<unsigned char>(value[1])) ||
+            !std::isdigit(static_cast<unsigned char>(value[2]))) return false;
+        const uint32_t percent = static_cast<uint32_t>(value[1] - '0') * 10 +
+            static_cast<uint32_t>(value[2] - '0');
+        // Urwid first scales gNN to 0..255, then chooses the nearest xterm
+        // grayscale ramp entry. Preserve that quantization before RGB565.
+        const uint32_t scaled = (percent * 255 * 2 + 100) / 200;
+        static constexpr uint8_t levels[] = {
+            0, 8, 18, 28, 38, 48, 58, 68, 78, 88, 98, 108, 118,
+            128, 132, 148, 158, 168, 178, 188, 198, 208, 218, 228, 238, 255,
+        };
+        uint8_t gray = levels[sizeof(levels) - 1];
+        for (std::size_t i = 0; i + 1 < sizeof(levels); ++i) {
+            const uint32_t midpoint =
+                (static_cast<uint32_t>(levels[i]) + levels[i + 1] + 1) / 2;
+            if (scaled < midpoint) {
+                gray = levels[i];
+                break;
+            }
+        }
+        result = static_cast<uint32_t>(gray) * 0x010101;
+        return true;
+    }
     if (value.size() != 3 && value.size() != 6) return false;
     if (!std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isxdigit(c); })) return false;
     char* end = nullptr;
@@ -127,7 +151,7 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
             if (i < line.size() && line[i] == 'T') { ++i; count = 6; }
             if (i + count <= line.size()) {
                 uint32_t value = 0;
-                if (color(line.substr(i, count), value)) {
+                if (parse_micron_color(line.substr(i, count), value)) {
                     style.has_foreground = true;
                     style.foreground = value;
                     i += count;
@@ -138,7 +162,7 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
             if (i < line.size() && line[i] == 'T') { ++i; count = 6; }
             if (i + count <= line.size()) {
                 uint32_t value = 0;
-                if (color(line.substr(i, count), value)) {
+                if (parse_micron_color(line.substr(i, count), value)) {
                     style.has_background = true;
                     style.background = value;
                     i += count;
@@ -236,13 +260,13 @@ Document DocumentParser::parse(const char* source, std::size_t size) const {
         }
         if (line.rfind("#!bg=", 0) == 0) {
             uint32_t value = 0;
-            if (color(line.substr(5), value)) { doc.has_background = true; doc.background = value; }
+            if (parse_micron_color(line.substr(5), value)) { doc.has_background = true; doc.background = value; }
             else doc.malformed = true;
             continue;
         }
         if (line.rfind("#!fg=", 0) == 0) {
             uint32_t value = 0;
-            if (color(line.substr(5), value)) { doc.has_foreground = true; doc.foreground = value; }
+            if (parse_micron_color(line.substr(5), value)) { doc.has_foreground = true; doc.foreground = value; }
             else doc.malformed = true;
             continue;
         }

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.cpp
@@ -133,7 +133,7 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
             text.push_back(line[i + 1]); i += 2; continue;
         }
         if (line[i] != '`') { text.push_back(line[i++]); continue; }
-        if (i + 1 >= line.size()) { text.push_back('`'); ++i; continue; }
+        if (i + 1 >= line.size()) { ++i; continue; }
         add_run(doc, block, text, style);
         const char command = line[i + 1];
         i += 2;
@@ -192,8 +192,18 @@ void parse_inline(Document& doc, Block& block, const std::string& line, Style& s
             } else doc.mark_truncated(TruncationReason::LINKS);
             i = close + 1;
         } else {
-            // Unknown modifiers are harmless and visible rather than commands.
-            text.push_back('`'); text.push_back(command);
+            const auto lead = static_cast<unsigned char>(command);
+            const std::size_t continuation_count =
+                lead >= 0xc2 && lead <= 0xdf ? 1 :
+                lead >= 0xe0 && lead <= 0xef ? 2 :
+                lead >= 0xf0 && lead <= 0xf4 ? 3 : 0;
+            std::size_t consumed = 0;
+            while (consumed < continuation_count && i < line.size()) {
+                const auto next = static_cast<unsigned char>(line[i]);
+                if ((next & 0xc0) != 0x80) break;
+                ++i;
+                ++consumed;
+            }
         }
     }
     add_run(doc, block, text, style);

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
@@ -36,6 +36,7 @@ struct Block {
     BlockType type = BlockType::TEXT;
     uint8_t depth = 0;
     Alignment alignment = Alignment::LEFT;
+    uint32_t divider_codepoint = 0x2500;
     std::vector<Run> runs;
 };
 

--- a/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetDocument.h
@@ -10,7 +10,7 @@ namespace UI::LXMF::NomadNet {
 enum class BlockType { TEXT, HEADING, DIVIDER, UNSUPPORTED };
 enum class Alignment { LEFT, CENTER, RIGHT };
 
-enum class TruncationReason : uint8_t {
+enum class TruncationReason : uint16_t {
     DOCUMENT_BYTES = 1 << 0,
     SOURCE_LINES = 1 << 1,
     SOURCE_LINE_BYTES = 1 << 2,
@@ -18,6 +18,8 @@ enum class TruncationReason : uint8_t {
     RUNS_PER_LINE = 1 << 4,
     TOTAL_RUNS = 1 << 5,
     LINKS = 1 << 6,
+    ANCHORS = 1 << 7,
+    ANCHOR_NAME_BYTES = 1 << 8,
 };
 
 struct Run {
@@ -46,9 +48,19 @@ struct Link {
     std::string fields;
 };
 
+struct Anchor {
+    Anchor() = default;
+    Anchor(const std::string& value, uint16_t block)
+        : name(value), block_index(block) {}
+
+    std::string name;
+    uint16_t block_index = 0;
+};
+
 struct Document {
     std::vector<Block> blocks;
     std::vector<Link> links;
+    std::vector<Anchor> anchors;
     uint32_t cache_seconds = 0;
     bool has_background = false;
     uint32_t background = 0;
@@ -59,14 +71,14 @@ struct Document {
     bool unsupported = false;
     std::size_t source_bytes = 0;
     std::size_t source_lines = 0;
-    uint8_t truncation_reasons = 0;
+    uint16_t truncation_reasons = 0;
 
     void mark_truncated(TruncationReason reason) {
         truncated = true;
-        truncation_reasons |= static_cast<uint8_t>(reason);
+        truncation_reasons |= static_cast<uint16_t>(reason);
     }
     bool has_truncation(TruncationReason reason) const {
-        return (truncation_reasons & static_cast<uint8_t>(reason)) != 0;
+        return (truncation_reasons & static_cast<uint16_t>(reason)) != 0;
     }
 };
 
@@ -79,6 +91,8 @@ public:
     static constexpr std::size_t MAX_TOTAL_RUNS = 1024;
     static constexpr std::size_t MAX_SOURCE_LINE_BYTES = 4096;
     static constexpr std::size_t MAX_LINKS = 128;
+    static constexpr std::size_t MAX_ANCHORS = 128;
+    static constexpr std::size_t MAX_ANCHOR_NAME_BYTES = 64;
     static constexpr uint32_t MAX_CACHE_SECONDS = 7 * 24 * 60 * 60;
 
     Document parse(const std::string& source) const;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetFocus.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetFocus.h
@@ -12,12 +12,14 @@ struct FocusSpan {
     int16_t width = 0;
     int16_t height = 0;
     uint16_t run_index = 0;
+    uint8_t heading_level = 0;
 
     FocusSpan() = default;
     constexpr FocusSpan(int16_t x_value, int16_t y_value, int16_t width_value,
-                        int16_t height_value, uint16_t run_index_value)
+                        int16_t height_value, uint16_t run_index_value,
+                        uint8_t heading_level_value = 0)
         : x(x_value), y(y_value), width(width_value), height(height_value),
-          run_index(run_index_value) {}
+          run_index(run_index_value), heading_level(heading_level_value) {}
 };
 
 template <typename FragmentRange, typename Callback>
@@ -54,6 +56,7 @@ void for_each_focus_span(const FragmentRange& fragments, int16_t selected_link,
             static_cast<int16_t>(right - left),
             static_cast<int16_t>(bottom - top),
             first.run_index,
+            first.heading_level(),
         });
         index = end;
     }

--- a/lib/tdeck_ui/UI/LXMF/NomadNetGlyphs.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetGlyphs.cpp
@@ -57,6 +57,33 @@ bool decode_utf8(const std::string& value, std::size_t offset,
 
 } // namespace
 
+std::size_t display_codepoint(uint32_t codepoint, char utf8[5]) {
+    if (!nomadnet_font_has_codepoint(codepoint) || codepoint > 0x10ffff ||
+        (codepoint >= 0xd800 && codepoint <= 0xdfff)) {
+        utf8[0] = '?';
+        utf8[1] = '\0';
+        return 1;
+    }
+    std::size_t length = 0;
+    if (codepoint <= 0x7f) {
+        utf8[length++] = static_cast<char>(codepoint);
+    } else if (codepoint <= 0x7ff) {
+        utf8[length++] = static_cast<char>(0xc0 | (codepoint >> 6));
+        utf8[length++] = static_cast<char>(0x80 | (codepoint & 0x3f));
+    } else if (codepoint <= 0xffff) {
+        utf8[length++] = static_cast<char>(0xe0 | (codepoint >> 12));
+        utf8[length++] = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f));
+        utf8[length++] = static_cast<char>(0x80 | (codepoint & 0x3f));
+    } else {
+        utf8[length++] = static_cast<char>(0xf0 | (codepoint >> 18));
+        utf8[length++] = static_cast<char>(0x80 | ((codepoint >> 12) & 0x3f));
+        utf8[length++] = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3f));
+        utf8[length++] = static_cast<char>(0x80 | (codepoint & 0x3f));
+    }
+    utf8[length] = '\0';
+    return length;
+}
+
 void visit_display_text(const std::string& utf8, DisplayTextVisitor visitor, void* context) {
     static const char replacement = '?';
     for (std::size_t offset = 0; offset < utf8.size();) {

--- a/lib/tdeck_ui/UI/LXMF/NomadNetGlyphs.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetGlyphs.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <cstddef>
+#include <cstdint>
 
 #ifdef ARDUINO
 #include <lvgl.h>
@@ -25,5 +26,6 @@ namespace UI::LXMF::NomadNet {
 std::string display_text(const std::string& utf8);
 using DisplayTextVisitor = void (*)(const char* bytes, std::size_t length, void* context);
 void visit_display_text(const std::string& utf8, DisplayTextVisitor visitor, void* context);
+std::size_t display_codepoint(uint32_t codepoint, char utf8[5]);
 
 } // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/NomadNetHistory.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetHistory.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace UI::LXMF::NomadNet {
@@ -10,19 +11,23 @@ class PageHistory {
 public:
     static constexpr std::size_t MAX_DEPTH = 16;
 
-    const std::string& current() const { return _current; }
+    const std::string& current() const { return _current.address; }
+    int32_t current_scroll() const { return _current.logical_scroll; }
     std::size_t depth() const { return _depth; }
 
-    void open(const std::string& address, bool add_history = true) {
-        if (address == _current) return;
-        if (add_history && !_current.empty()) {
+    void open(const std::string& address, bool add_history = true,
+              int32_t current_logical_scroll = 0) {
+        if (address == _current.address) return;
+        if (add_history && !_current.address.empty()) {
+            _current.logical_scroll = current_logical_scroll;
             if (_depth == MAX_DEPTH) {
-                for (std::size_t i = 1; i < MAX_DEPTH; ++i) _entries[i - 1] = std::move(_entries[i]);
+                for (std::size_t i = 1; i < MAX_DEPTH; ++i)
+                    _entries[i - 1] = std::move(_entries[i]);
                 --_depth;
             }
-            _entries[_depth++] = _current;
+            _entries[_depth++] = std::move(_current);
         }
-        _current = address;
+        _current = Entry{address, 0};
     }
 
     void reload() {}
@@ -34,13 +39,22 @@ public:
     }
 
     void clear() {
-        _current.clear();
+        _current = Entry{};
         _depth = 0;
     }
 
 private:
-    std::array<std::string, MAX_DEPTH> _entries{};
-    std::string _current;
+    struct Entry {
+        Entry() = default;
+        Entry(const std::string& value, int32_t scroll)
+            : address(value), logical_scroll(scroll) {}
+
+        std::string address;
+        int32_t logical_scroll = 0;
+    };
+
+    std::array<Entry, MAX_DEPTH> _entries{};
+    Entry _current;
     std::size_t _depth = 0;
 };
 

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -451,12 +451,15 @@ bool NomadNetScreen::layout_from(std::size_t start_block,int32_t start_y,
         }
         const auto& block=_page.blocks()[block_index];
         if(block.type==NomadNet::BlockType::DIVIDER){
-            if(y+1>=window_top&&y<window_bottom){
+            const int16_t divider_height=static_cast<int16_t>(nomadnet_font_12.line_height);
+            if(y+divider_height>=window_top&&y<window_bottom){
                 if(_page_layout.size()>=MAX_WINDOW_FRAGMENTS)return false;
-                _page_layout.push_back(LayoutFragment(0,0,0,-1,0,
-                    static_cast<int16_t>(y-window_top),width,1,true));
+                LayoutFragment divider(0,0,0,-1,0,
+                    static_cast<int16_t>(y-window_top),width,divider_height,true);
+                divider.divider_codepoint=block.divider_codepoint;
+                _page_layout.push_back(divider);
             }
-            y+=9;continue;
+            y+=divider_height;continue;
         }
         if(block.run_count==0)continue;
         const int16_t indent=block.type==NomadNet::BlockType::HEADING?0:
@@ -581,7 +584,22 @@ void NomadNetScreen::draw_page(lv_event_t* event){
         lv_area_t area{static_cast<lv_coord_t>(left+fragment.x),static_cast<lv_coord_t>(draw_y),
             static_cast<lv_coord_t>(left+fragment.x+std::max<int16_t>(fragment.width,1)-1),
             static_cast<lv_coord_t>(draw_y+std::max<int16_t>(fragment.height,1)-1)};
-        if(fragment.divider){lv_draw_rect_dsc_t dsc;lv_draw_rect_dsc_init(&dsc);dsc.bg_color=Theme::border();lv_draw_rect(draw_ctx,&dsc,&area);continue;}
+        if(fragment.divider){
+            const std::size_t bytes=NomadNet::display_codepoint(fragment.divider_codepoint,scratch);
+            const lv_font_t* font=&nomadnet_font_12;
+            const int16_t glyph_width=static_cast<int16_t>(lv_txt_get_width(
+                scratch,static_cast<uint32_t>(bytes),font,0,LV_TEXT_FLAG_NONE));
+            if(glyph_width>0){
+                lv_draw_label_dsc_t dsc;lv_draw_label_dsc_init(&dsc);
+                dsc.font=font;dsc.color=Theme::border();dsc.letter_space=0;
+                for(int16_t x=0;x<fragment.width;x=static_cast<int16_t>(x+glyph_width)){
+                    lv_area_t glyph_area{static_cast<lv_coord_t>(area.x1+x),area.y1,
+                        static_cast<lv_coord_t>(std::min<int32_t>(area.x1+x+glyph_width-1,area.x2)),area.y2};
+                    lv_draw_label(draw_ctx,&dsc,&glyph_area,scratch,nullptr);
+                }
+            }
+            continue;
+        }
         if(fragment.run_index>=_page.runs().size())continue;
         const auto& run=_page.runs()[fragment.run_index];
         const auto text=_page.text(run);

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -415,22 +415,33 @@ bool NomadNetScreen::append_line_fragment(const LayoutFragment& fragment){
 
 bool NomadNetScreen::commit_line(int32_t line_y,int16_t line_height,
                                  NomadNet::Alignment alignment,int16_t indent,
-                                 int16_t available,int32_t window_top,
-                                 int32_t window_bottom){
-    if(_line_layout.empty())return true;
+                                 int16_t available,uint8_t heading_level,
+                                 int32_t window_top,int32_t window_bottom){
+    if(_line_layout.empty()&&heading_level==0)return true;
     int16_t line_width=0;
     for(const auto& fragment:_line_layout)
         line_width=std::max<int16_t>(line_width,fragment.x+fragment.width-indent);
     const int16_t shift=alignment==NomadNet::Alignment::CENTER?(available-line_width)/2:
         alignment==NomadNet::Alignment::RIGHT?available-line_width:0;
     if(line_y+line_height>=window_top&&line_y<window_bottom){
-        for(auto fragment:_line_layout){
+        const int32_t relative_y=line_y-window_top;
+        if(relative_y<INT16_MIN||relative_y>INT16_MAX)return false;
+        if(_line_layout.empty()){
             if(_page_layout.size()>=MAX_WINDOW_FRAGMENTS)return false;
-            if(shift>0)fragment.x=static_cast<int16_t>(fragment.x+shift);
-            const int32_t relative_y=line_y-window_top;
-            if(relative_y<INT16_MIN||relative_y>INT16_MAX)return false;
-            fragment.y=static_cast<int16_t>(relative_y);
-            _page_layout.push_back(fragment);
+            LayoutFragment band(UINT16_MAX,0,0,-1,0,static_cast<int16_t>(relative_y),
+                                0,line_height,false,heading_level==1);
+            band.set_heading(heading_level,true);
+            _page_layout.push_back(band);
+        }else{
+            bool starts_band=true;
+            for(auto fragment:_line_layout){
+                if(_page_layout.size()>=MAX_WINDOW_FRAGMENTS)return false;
+                if(shift>0)fragment.x=static_cast<int16_t>(fragment.x+shift);
+                fragment.y=static_cast<int16_t>(relative_y);
+                if(heading_level!=0)fragment.set_heading(heading_level,starts_band);
+                starts_band=false;
+                _page_layout.push_back(fragment);
+            }
         }
     }
     _line_layout.clear();
@@ -461,19 +472,30 @@ bool NomadNetScreen::layout_from(std::size_t start_block,int32_t start_y,
             }
             y+=divider_height;continue;
         }
-        if(block.run_count==0)continue;
-        const int16_t indent=block.type==NomadNet::BlockType::HEADING?0:
-            static_cast<int16_t>(std::min<unsigned>(block.depth,8)*4);
+        const bool heading=block.type==NomadNet::BlockType::HEADING;
+        const bool has_runs=block.run_count!=0&&block.first_run<_page.runs().size();
+        if(!heading&&!has_runs)continue;
+        const uint8_t heading_level=heading?NomadNet::heading_display_level(block.depth):0;
+        const bool large_heading=heading&&NomadNet::heading_uses_large_font(block.depth);
+        int16_t indent=static_cast<int16_t>(std::min<unsigned>(block.depth,8)*4);
+        NomadNet::CompactPage::RunRecord default_run{};
+        const auto& first_run=has_runs?_page.runs()[block.first_run]:default_run;
+        if(heading){
+            const lv_font_t* indent_font=page_run_font(first_run,large_heading);
+            const int16_t space_width=static_cast<int16_t>(lv_txt_get_width(
+                " ",1,indent_font,0,LV_TEXT_FLAG_NONE));
+            indent=static_cast<int16_t>(NomadNet::heading_indent_spaces(block.depth)*space_width);
+        }
         const int16_t available=width-indent;
         int16_t x=indent;
-        int16_t line_h=16;
+        int16_t line_h=heading?static_cast<int16_t>(page_run_font(first_run,large_heading)->line_height+3):16;
         int32_t line_y=y;
         _line_layout.clear();
         for(uint16_t r=0;r<block.run_count&&block.first_run+r<_page.runs().size();++r){
             const uint16_t run_index=static_cast<uint16_t>(block.first_run+r);
             const auto& run=_page.runs()[run_index];
             const auto text=_page.text(run);
-            const bool large=block.type==NomadNet::BlockType::HEADING;
+            const bool large=large_heading;
             const lv_font_t* font=page_run_font(run,large);
             const int16_t height=static_cast<int16_t>(font->line_height+3);
             line_h=std::max(line_h,height);
@@ -488,7 +510,7 @@ bool NomadNetScreen::layout_from(std::size_t start_block,int32_t start_y,
                 if(whitespace&&x+fragment_w>indent+available){offset=end;continue;}
                 if(!whitespace&&x>indent&&x+fragment_w>indent+available){
                     if(!commit_line(line_y,line_h,block.alignment,indent,available,
-                                    window_top,window_bottom))return false;
+                                    heading_level,window_top,window_bottom))return false;
                     y+=line_h;x=indent;line_h=height;line_y=y;
                 }
                 if(fragment_w>available){
@@ -505,7 +527,7 @@ bool NomadNetScreen::layout_from(std::size_t start_block,int32_t start_y,
                         fragment_w=candidate;
                     }
                 }
-                if(!(whitespace&&x==indent)){
+                if(!(whitespace&&x==indent&&!heading)){
                     if(run.link_index>=0&&static_cast<std::size_t>(run.link_index)<_link_y.size()){
                         if(_link_y[run.link_index]<0)_link_y[run.link_index]=line_y;
                         _link_bottom[run.link_index]=std::max(_link_bottom[run.link_index],line_y+height);
@@ -519,8 +541,8 @@ bool NomadNetScreen::layout_from(std::size_t start_block,int32_t start_y,
             }
         }
         if(!commit_line(line_y,line_h,block.alignment,indent,available,
-                        window_top,window_bottom))return false;
-        y+=line_h+3;
+                        heading_level,window_top,window_bottom))return false;
+        y+=line_h+(heading?NomadNet::heading_bottom_spacing(block.depth):3);
     }
     if(build_index)_page_height=std::max<int32_t>(y,lv_obj_get_content_height(_content));
     return true;
@@ -600,6 +622,13 @@ void NomadNetScreen::draw_page(lv_event_t* event){
             }
             continue;
         }
+        if(fragment.heading_starts_band()){
+            lv_area_t band_area{content_area.x1,static_cast<lv_coord_t>(draw_y),content_area.x2,
+                static_cast<lv_coord_t>(draw_y+std::max<int16_t>(fragment.height,1)-1)};
+            lv_draw_rect_dsc_t band;lv_draw_rect_dsc_init(&band);
+            band.bg_color=lv_color_hex(NomadNet::heading_background(fragment.heading_level()));
+            lv_draw_rect(draw_ctx,&band,&band_area);
+        }
         if(fragment.run_index>=_page.runs().size())continue;
         const auto& run=_page.runs()[fragment.run_index];
         const auto text=_page.text(run);
@@ -610,7 +639,8 @@ void NomadNetScreen::draw_page(lv_event_t* event){
         }
         lv_draw_label_dsc_t dsc;lv_draw_label_dsc_init(&dsc);
         dsc.font=page_run_font(run, fragment.large_font);
-        dsc.color=lv_color_hex(NomadNet::resolve_foreground(_page,run,Theme::TEXT_PRIMARY));
+        dsc.color=lv_color_hex(NomadNet::resolve_effective_foreground(
+            _page,run,fragment.heading_level(),Theme::TEXT_PRIMARY));
         dsc.letter_space=0;
         dsc.decor=(run.style&NomadNet::CompactPage::UNDERLINE)||run.link_index>=0?LV_TEXT_DECOR_UNDERLINE:LV_TEXT_DECOR_NONE;
         lv_draw_label(draw_ctx,&dsc,&area,scratch,nullptr);
@@ -625,7 +655,7 @@ void NomadNetScreen::draw_page(lv_event_t* event){
                 static_cast<lv_coord_t>(draw_y+std::max<int16_t>(span.height,1)-1)};
             lv_draw_rect_dsc_t focus;lv_draw_rect_dsc_init(&focus);focus.bg_opa=LV_OPA_TRANSP;
             focus.border_color=lv_color_hex(NomadNet::resolve_focus_border(
-                _page,_page.runs()[span.run_index],Theme::SURFACE));
+                _page,_page.runs()[span.run_index],Theme::SURFACE,span.heading_level));
             focus.border_width=1;lv_draw_rect(draw_ctx,&focus,&area);
         });
     }

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.cpp
@@ -588,6 +588,32 @@ void NomadNetScreen::scroll_to_logical(int32_t logical,lv_anim_enable_t animatio
     lv_obj_invalidate(_content);
 }
 
+bool NomadNetScreen::jump_to_anchor(const std::string& name){
+    if(!_page_loaded)return false;
+    uint16_t block_index=0;
+    int32_t target=-1;
+    if(!name.empty()){
+        if(!_page.find_anchor(name,block_index))return false;
+        for(const auto& checkpoint:_layout_checkpoints){
+            if(checkpoint.block_index==block_index){target=checkpoint.y;break;}
+        }
+    }else{
+        for(const auto& checkpoint:_layout_checkpoints){
+            if(checkpoint.y<=_logical_scroll||checkpoint.block_index>=_page.blocks().size())continue;
+            if(_page.blocks()[checkpoint.block_index].type==NomadNet::BlockType::HEADING){
+                target=checkpoint.y;break;
+            }
+        }
+    }
+    if(target<0)return false;
+    scroll_to_logical(target,LV_ANIM_OFF);
+    return true;
+}
+
+void NomadNetScreen::restore_logical_scroll(int32_t logical){
+    if(_page_loaded)scroll_to_logical(logical,LV_ANIM_OFF);
+}
+
 void NomadNetScreen::draw_page(lv_event_t* event){
     auto* draw_ctx=lv_event_get_draw_ctx(event);
     lv_area_t content_area;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
@@ -28,6 +28,10 @@ public:
     std::string address() const;
     void set_status(const char* status);
     bool set_page(const NomadNet::Document& document);
+    bool jump_to_anchor(const std::string& name);
+    void restore_logical_scroll(int32_t logical);
+    int32_t logical_scroll() const { return _logical_scroll; }
+    bool page_loaded() const { return _page_loaded; }
     void set_library(const NomadNet::Library& library);
     void set_page_saved(bool saved);
     void begin_navigation(const std::string& target);

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
@@ -50,6 +50,7 @@ private:
         int16_t y = 0;
         int16_t width = 0;
         int16_t height = 0;
+        uint32_t divider_codepoint = 0x2500;
         bool divider = false;
         bool large_font = false;
         LayoutFragment() = default;

--- a/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetScreen.h
@@ -53,12 +53,18 @@ private:
         uint32_t divider_codepoint = 0x2500;
         bool divider = false;
         bool large_font = false;
+        uint8_t heading_style = 0;
         LayoutFragment() = default;
         LayoutFragment(uint16_t run, uint16_t offset, uint16_t length, int16_t link,
                        int16_t left, int16_t top, int16_t w, int16_t h,
                        bool is_divider, bool is_large = false)
             : run_index(run), byte_offset(offset), byte_length(length), link_index(link),
               x(left), y(top), width(w), height(h), divider(is_divider), large_font(is_large) {}
+        void set_heading(uint8_t level, bool starts_band) {
+            heading_style = static_cast<uint8_t>((level & 0x03u) | (starts_band ? 0x80u : 0u));
+        }
+        uint8_t heading_level() const { return static_cast<uint8_t>(heading_style & 0x03u); }
+        bool heading_starts_band() const { return (heading_style & 0x80u) != 0; }
     };
     struct LayoutCheckpoint {
         uint16_t block_index = 0;
@@ -107,8 +113,8 @@ private:
     bool append_line_fragment(const LayoutFragment& fragment);
     bool commit_line(int32_t line_y, int16_t line_height,
                      NomadNet::Alignment alignment, int16_t indent,
-                     int16_t available, int32_t window_top,
-                     int32_t window_bottom);
+                     int16_t available, uint8_t heading_level,
+                     int32_t window_top, int32_t window_bottom);
     int32_t logical_scroll_from_widget() const;
     void scroll_to_logical(int32_t logical, lv_anim_enable_t animation);
     void draw_page(lv_event_t* event);

--- a/lib/tdeck_ui/UI/LXMF/NomadNetUrl.cpp
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetUrl.cpp
@@ -4,9 +4,21 @@
 #include <cctype>
 
 namespace UI::LXMF::NomadNet {
+namespace {
+
+bool valid_fragment(const std::string& fragment) {
+    if (fragment.size() > Url::MAX_FRAGMENT_BYTES) return false;
+    return std::all_of(fragment.begin(), fragment.end(), [](unsigned char c) {
+        return c < 0x80 && (std::isalnum(c) != 0 || c == '_' || c == '-');
+    });
+}
+
+} // namespace
 
 bool Url::parse(const std::string& input, Url& result, std::string& error,
-                const std::string& current_destination) {
+                const std::string& current_destination,
+                const std::string& current_path,
+                const std::string& current_fields) {
     error.clear();
     if (input.empty() || input.size() > 512) {
         error = "Address is empty or too long";
@@ -18,16 +30,37 @@ bool Url::parse(const std::string& input, Url& result, std::string& error,
             return false;
         }
     }
+
     const auto fields_separator = input.find('`');
     if (fields_separator != std::string::npos &&
         input.find('`', fields_separator + 1) != std::string::npos) {
         error = "Address has too many field separators";
         return false;
     }
-    const std::string address = fields_separator == std::string::npos
+    std::string address = fields_separator == std::string::npos
         ? input : input.substr(0, fields_separator);
     std::string fields = fields_separator == std::string::npos
         ? std::string() : input.substr(fields_separator + 1);
+
+    const auto fragment_separator = address.find('#');
+    const bool has_fragment = fragment_separator != std::string::npos;
+    std::string fragment;
+    if (has_fragment) {
+        fragment = address.substr(fragment_separator + 1);
+        address.resize(fragment_separator);
+        if (!valid_fragment(fragment)) {
+            error = "Fragment must contain only letters, digits, _ or -";
+            return false;
+        }
+    }
+
+    const bool fragment_only = has_fragment && address.empty();
+    if (fragment_only && fields_separator != std::string::npos) {
+        error = "Fragment-only links cannot replace request fields";
+        return false;
+    }
+    if (fragment_only) fields = current_fields;
+
     const auto colon = address.find(':');
     if (colon != std::string::npos && address.find(':', colon + 1) != std::string::npos) {
         error = "Address has too many separators";
@@ -35,9 +68,12 @@ bool Url::parse(const std::string& input, Url& result, std::string& error,
     }
     std::string destination = colon == std::string::npos ? address : address.substr(0, colon);
     std::string path = colon == std::string::npos ? DEFAULT_PATH : address.substr(colon + 1);
+    if (fragment_only) path = current_path.empty() ? DEFAULT_PATH : current_path;
     if (destination.empty()) destination = current_destination;
     if (destination.size() != 32 ||
-        !std::all_of(destination.begin(), destination.end(), [](unsigned char c) { return std::isxdigit(c); })) {
+        !std::all_of(destination.begin(), destination.end(), [](unsigned char c) {
+            return std::isxdigit(c) != 0;
+        })) {
         error = "Destination must be exactly 32 hexadecimal characters";
         return false;
     }
@@ -52,9 +88,12 @@ bool Url::parse(const std::string& input, Url& result, std::string& error,
         error = "Downloads are not supported in this MVP";
         return false;
     }
+
     result.destination_hex = std::move(destination);
     result.path = std::move(path);
     result.fields = std::move(fields);
+    result.fragment = std::move(fragment);
+    result.has_fragment = has_fragment;
     return true;
 }
 

--- a/lib/tdeck_ui/UI/LXMF/NomadNetUrl.h
+++ b/lib/tdeck_ui/UI/LXMF/NomadNetUrl.h
@@ -1,21 +1,41 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 namespace UI::LXMF::NomadNet {
 
 struct Url {
     static constexpr const char* DEFAULT_PATH = "/page/index.mu";
+    static constexpr std::size_t MAX_FRAGMENT_BYTES = 64;
+
     std::string destination_hex;
     std::string path;
     std::string fields;
+    std::string fragment;
+    bool has_fragment = false;
 
     std::string str() const {
-        return destination_hex + ":" + path + (fields.empty() ? std::string() : "`" + fields);
+        return destination_hex + ":" + path +
+            (has_fragment ? std::string("#") + fragment : std::string()) +
+            (fields.empty() ? std::string() : "`" + fields);
+    }
+
+    bool same_resource(const Url& other) const {
+        return destination_hex == other.destination_hex && path == other.path &&
+            fields == other.fields;
     }
 
     static bool parse(const std::string& input, Url& result, std::string& error,
-                      const std::string& current_destination = {});
+                      const std::string& current_destination = {},
+                      const std::string& current_path = {},
+                      const std::string& current_fields = {});
 };
+
+inline bool should_jump_locally(const Url& current, const Url& candidate,
+                                bool page_loaded, bool restoring_history) {
+    return page_loaded && current.same_resource(candidate) &&
+        (candidate.has_fragment || restoring_history);
+}
 
 } // namespace UI::LXMF::NomadNet

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -954,7 +954,7 @@ void UIManager::replace_route(Route route) {
 
 void UIManager::back() {
     if (_navigation.current() == Route::NOMADNET && _nomad_history.back()) {
-        nomad_open(_nomad_history.current(), false);
+        nomad_open(_nomad_history.current(), false, _nomad_history.current_scroll());
         return;
     }
     if (_navigation.current() == Route::NOMADNET) {
@@ -2049,6 +2049,7 @@ void UIManager::nomad_stop_transport() {
     nomad_heap_checkpoint("stop-enter");
     _nomad_state = NomadState::IDLE;
     _nomad_deadline_ms = 0;
+    _nomad_pending_scroll = -1;
     _nomad_mailbox.seal();
     if (_nomad_link && _nomad_link.status() != Type::Link::CLOSED) _nomad_link.teardown();
     nomad_release_request();
@@ -2078,19 +2079,56 @@ bool UIManager::nomad_refresh_path_after_link_failure() {
     return true;
 }
 
-void UIManager::nomad_open(const std::string& address, bool add_history) {
+void UIManager::nomad_open(const std::string& address, bool add_history,
+                           int32_t restore_logical_scroll) {
     nomad_heap_checkpoint("open-enter");
     NomadNet::Url parsed;
     std::string error;
-    if (!NomadNet::Url::parse(address, parsed, error, _nomad_url.destination_hex)) {
+    if (!NomadNet::Url::parse(address, parsed, error, _nomad_url.destination_hex,
+            _nomad_url.path,_nomad_url.fields)) {
         LVGL_LOCK();
         _nomadnet_screen->set_status(error.c_str());
         return;
     }
     nomad_heap_checkpoint("open-parsed");
 
+    int32_t current_scroll=0;
+    bool page_loaded=false;
+    {
+        LVGL_LOCK();
+        current_scroll=_nomadnet_screen->logical_scroll();
+        page_loaded=_nomadnet_screen->page_loaded();
+    }
+    const bool restoring_history=restore_logical_scroll>=0;
+    if(NomadNet::should_jump_locally(_nomad_url,parsed,page_loaded,restoring_history)){
+        bool resolved=true;
+        {
+            LVGL_LOCK();
+            if(restoring_history)
+                _nomadnet_screen->restore_logical_scroll(restore_logical_scroll);
+            else
+                resolved=_nomadnet_screen->jump_to_anchor(parsed.fragment);
+            if(!resolved&&parsed.fragment.empty())return;
+            if(!resolved){
+                const std::string status="Unknown anchor: #"+parsed.fragment;
+                _nomadnet_screen->set_status(status.c_str());
+            }
+        }
+        if(!resolved)return;
+        _nomad_history.open(parsed.str(),add_history,current_scroll);
+        _nomad_url=parsed;
+        _nomad_pending_scroll=-1;
+        {
+            LVGL_LOCK();
+            _nomadnet_screen->set_address(parsed.str());
+            _nomadnet_screen->set_status("Page loaded");
+        }
+        return;
+    }
+
     RouterLock router_lock;
     if (!router_lock.acquired()) return;
+    _nomad_pending_scroll=restore_logical_scroll;
     nomad_heap_checkpoint("open-locked");
     {
         // Validation must precede destructive UI cleanup so a malformed manual
@@ -2109,7 +2147,7 @@ void UIManager::nomad_open(const std::string& address, bool add_history) {
         _nomad_response.clear();
         _nomad_request_policy.reset();
         _nomad_url = parsed;
-        _nomad_history.open(parsed.str(), add_history);
+        _nomad_history.open(parsed.str(), add_history, current_scroll);
         {
             LVGL_LOCK();
             _nomadnet_screen->set_address(parsed.str());
@@ -2130,7 +2168,7 @@ void UIManager::nomad_open(const std::string& address, bool add_history) {
     nomad_heap_checkpoint("open-cleared");
     _nomad_request_policy.reset();
     _nomad_url = parsed;
-    _nomad_history.open(parsed.str(), add_history);
+    _nomad_history.open(parsed.str(), add_history, current_scroll);
     _nomad_destination_hash = Bytes();
     _nomad_destination_hash.assignHex(parsed.destination_hex.c_str());
     nomad_heap_checkpoint("open-state-ready");
@@ -2288,11 +2326,17 @@ void UIManager::nomad_update() {
                 break;
             }
             bool page_applied = false;
+            bool anchor_resolved = true;
             {
                 LVGL_LOCK();
                 _nomadnet_screen->set_library(_nomad_library);
                 page_applied = _nomadnet_screen->set_page(document);
+                if(page_applied&&_nomad_pending_scroll>=0)
+                    _nomadnet_screen->restore_logical_scroll(_nomad_pending_scroll);
+                else if(page_applied&&_nomad_url.has_fragment)
+                    anchor_resolved=_nomadnet_screen->jump_to_anchor(_nomad_url.fragment);
             }
+            _nomad_pending_scroll=-1;
             if (page_applied) _nomad_response.release();
             nomad_heap_checkpoint("response-page-applied");
             if (!page_applied) {
@@ -2311,7 +2355,12 @@ void UIManager::nomad_update() {
             {
                 LVGL_LOCK();
                 _nomadnet_screen->set_page_saved(page_saved);
-                _nomadnet_screen->set_status(document.truncated ? "Page loaded (truncated)" : "Page loaded");
+                if(!anchor_resolved&&!_nomad_url.fragment.empty()){
+                    const std::string status="Unknown anchor: #"+_nomad_url.fragment;
+                    _nomadnet_screen->set_status(status.c_str());
+                }else{
+                    _nomadnet_screen->set_status(document.truncated ? "Page loaded (truncated)" : "Page loaded");
+                }
             }
             break;
         }

--- a/lib/tdeck_ui/UI/LXMF/UIManager.h
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.h
@@ -424,12 +424,14 @@ private:
     enum class NomadState { IDLE, PATH, LINK, REQUEST };
     std::atomic<NomadState> _nomad_state{NomadState::IDLE};
     uint32_t _nomad_deadline_ms = 0;
+    int32_t _nomad_pending_scroll = -1;
     static UIManager* s_nomad_instance;
 
     void render_route(Route route);
     void replace_route(Route route);
     void hide_all_screens();
-    void nomad_open(const std::string& address, bool add_history = true);
+    void nomad_open(const std::string& address, bool add_history = true,
+                    int32_t restore_logical_scroll = -1);
     void nomad_reload();
     void nomad_update();
     void nomad_start_link();

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -148,6 +148,42 @@ int main(int argc, char** argv) {
     check("downloads explicitly unsupported", !Url::parse("0123456789abcdef0123456789abcdef:/file/x", url, error));
 
     DocumentParser parser;
+    auto block_text = [](const UI::LXMF::NomadNet::Block& block) {
+        std::string value;
+        for (const auto& run : block.runs) value += run.text;
+        return value;
+    };
+    auto unknown_modifier = parser.parse("before `xafter");
+    check("unknown modifier is consumed like canonical NomadNet",
+          unknown_modifier.blocks.size() == 1 && block_text(unknown_modifier.blocks[0]) == "before after");
+
+    auto trailing_introducer = parser.parse("before `");
+    check("trailing formatting introducer is consumed",
+          trailing_introducer.blocks.size() == 1 && block_text(trailing_introducer.blocks[0]) == "before ");
+
+    auto escaped_backtick = parser.parse("before \\`after");
+    check("escaped backtick remains visible",
+          escaped_backtick.blocks.size() == 1 && block_text(escaped_backtick.blocks[0]) == "before `after");
+
+    auto consecutive_unknown = parser.parse("`x`ytext");
+    check("consecutive unknown modifiers are consumed independently",
+          consecutive_unknown.blocks.size() == 1 && block_text(consecutive_unknown.blocks[0]) == "text");
+
+    auto unicode_unknown = parser.parse(u8"`§two `☃three `🙂four");
+    check("unknown Unicode modifiers consume one complete codepoint",
+          unicode_unknown.blocks.size() == 1 && block_text(unicode_unknown.blocks[0]) == "two three four");
+
+    auto unknown_then_bold = parser.parse("`x`!bold`! plain");
+    bool unknown_preserves_formatting = false;
+    if (unknown_then_bold.blocks.size() == 1) {
+        for (const auto& run : unknown_then_bold.blocks[0].runs) {
+            if (run.text == "bold" && run.bold) unknown_preserves_formatting = true;
+        }
+    }
+    check("unknown modifier does not change formatting state",
+          unknown_then_bold.blocks.size() == 1 && block_text(unknown_then_bold.blocks[0]) == "bold plain" &&
+              unknown_preserves_formatting);
+
     auto doc = parser.parse(
         "#!c=60\n#!bg=123\n#!fg=abcdef\n>> Heading\n"
         "ordinary `!bold`! `*italic`* `_under`_ `Ff00red`f `B0f0back`b `ccentre\n"

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -231,6 +231,52 @@ int main(int argc, char** argv) {
     check("FT inline truecolor parses", saw_truecolor_foreground);
     check("BT inline truecolor parses", saw_truecolor_background);
 
+    // Byte-exact Urwid 2.6.16 AttrSpec g00..g99 truecolor expansion.
+    static constexpr uint32_t grayscale_rgb[100] = {
+        0x000000, 0x000000, 0x080808, 0x080808, 0x080808, 0x121212, 0x121212, 0x121212, 0x121212, 0x1c1c1c,
+        0x1c1c1c, 0x1c1c1c, 0x1c1c1c, 0x262626, 0x262626, 0x262626, 0x262626, 0x303030, 0x303030, 0x303030,
+        0x303030, 0x3a3a3a, 0x3a3a3a, 0x3a3a3a, 0x3a3a3a, 0x444444, 0x444444, 0x444444, 0x444444, 0x4e4e4e,
+        0x4e4e4e, 0x4e4e4e, 0x4e4e4e, 0x585858, 0x585858, 0x585858, 0x585858, 0x626262, 0x626262, 0x626262,
+        0x626262, 0x6c6c6c, 0x6c6c6c, 0x6c6c6c, 0x6c6c6c, 0x767676, 0x767676, 0x767676, 0x767676, 0x808080,
+        0x808080, 0x848484, 0x848484, 0x848484, 0x848484, 0x949494, 0x949494, 0x949494, 0x949494, 0x949494,
+        0x9e9e9e, 0x9e9e9e, 0x9e9e9e, 0x9e9e9e, 0xa8a8a8, 0xa8a8a8, 0xa8a8a8, 0xa8a8a8, 0xb2b2b2, 0xb2b2b2,
+        0xb2b2b2, 0xb2b2b2, 0xbcbcbc, 0xbcbcbc, 0xbcbcbc, 0xbcbcbc, 0xc6c6c6, 0xc6c6c6, 0xc6c6c6, 0xc6c6c6,
+        0xd0d0d0, 0xd0d0d0, 0xd0d0d0, 0xd0d0d0, 0xdadada, 0xdadada, 0xdadada, 0xdadada, 0xe4e4e4, 0xe4e4e4,
+        0xe4e4e4, 0xe4e4e4, 0xeeeeee, 0xeeeeee, 0xeeeeee, 0xeeeeee, 0xeeeeee, 0xffffff, 0xffffff, 0xffffff,
+    };
+    for (std::size_t percent = 0; percent < 100; ++percent) {
+        std::string token = "g00";
+        token[1] = static_cast<char>('0' + percent / 10);
+        token[2] = static_cast<char>('0' + percent % 10);
+        const auto foreground_page = parser.parse(std::string("#!fg=") + token + "\ntext");
+        const auto background_page = parser.parse(std::string("#!bg=") + token + "\ntext");
+        const std::string name = std::string("page grayscale matches Urwid for ") + token;
+        check(name.c_str(),
+              foreground_page.has_foreground && foreground_page.foreground == grayscale_rgb[percent] &&
+                  background_page.has_background && background_page.background == grayscale_rgb[percent] &&
+                  !foreground_page.malformed && !background_page.malformed);
+    }
+    auto inline_grayscale = parser.parse("`Fg02dark`f `Bg51mid`b `Fg99light`f");
+    bool saw_dark_gray = false;
+    bool saw_mid_gray_background = false;
+    bool saw_light_gray = false;
+    for (const auto& run : inline_grayscale.blocks.front().runs) {
+        if (run.text == "dark")
+            saw_dark_gray = run.has_foreground && run.foreground == 0x080808;
+        else if (run.text == "mid")
+            saw_mid_gray_background = run.has_background && run.background == 0x848484;
+        else if (run.text == "light")
+            saw_light_gray = run.has_foreground && run.foreground == 0xffffff;
+    }
+    check("inline grayscale foreground and background match Urwid",
+          saw_dark_gray && saw_mid_gray_background && saw_light_gray);
+    for (const char* invalid : {"g0", "g100", "G50", "gx0", "g0x"}) {
+        const auto malformed_grayscale = parser.parse(std::string("#!fg=") + invalid + "\ntext");
+        const std::string name = std::string("malformed grayscale is rejected: ") + invalid;
+        check(name.c_str(),
+              malformed_grayscale.malformed && !malformed_grayscale.has_foreground);
+    }
+
     CompactPage::RunRecord light_background_run{};
     light_background_run.style = CompactPage::HAS_BACKGROUND;
     light_background_run.background = 0xe8b4f0;

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -27,6 +27,7 @@ using UI::LXMF::Route;
 using UI::LXMF::NomadNet::Alignment;
 using UI::LXMF::NomadNet::BlockType;
 using UI::LXMF::NomadNet::DocumentParser;
+using UI::LXMF::NomadNet::TruncationReason;
 using UI::LXMF::NomadNet::compact_address;
 using UI::LXMF::NomadNet::PageHistory;
 using UI::LXMF::NomadNet::display_text;
@@ -78,10 +79,20 @@ int main(int argc, char** argv) {
 
     PageHistory history;
     history.open("a");
-    history.open("b");
+    history.open("b", true, 84);
     history.reload();
     check("reload does not add browser history", history.current() == "b" && history.depth() == 1);
-    check("browser back restores prior page", history.back() && history.current() == "a" && history.depth() == 0);
+    check("browser back restores prior page and logical scroll",
+          history.back() && history.current() == "a" && history.current_scroll() == 84 &&
+              history.depth() == 0);
+    history.clear();
+    history.open("node:/page/a.mu");
+    history.open("node:/page/a.mu#details", true, 137);
+    check("anchor navigation creates meaningful history entry",
+          history.depth() == 1 && history.current() == "node:/page/a.mu#details");
+    check("anchor back restores exact prior position",
+          history.back() && history.current() == "node:/page/a.mu" &&
+              history.current_scroll() == 137);
     for (std::size_t i = 0; i < PageHistory::MAX_DEPTH + 4; ++i) history.open(std::to_string(i));
     check("browser history is bounded", history.depth() == PageHistory::MAX_DEPTH);
 
@@ -142,6 +153,45 @@ int main(int argc, char** argv) {
           url.path == "/page/repo.mu" && url.fields == "g=reticulum|r=lxmf");
     check("canonical URL preserves link fields for history and reload",
           url.str() == "fedcba9876543210fedcba9876543210:/page/repo.mu`g=reticulum|r=lxmf");
+    check("page fragment is separated from transport request path",
+          Url::parse("fedcba9876543210fedcba9876543210:/page/guide.mu#anchors`mode=full",
+                     url, error) &&
+              url.path == "/page/guide.mu" && url.has_fragment &&
+              url.fragment == "anchors" && url.fields == "mode=full");
+    check("canonical URL retains fragment before link fields",
+          url.str() == "fedcba9876543210fedcba9876543210:/page/guide.mu#anchors`mode=full");
+    Url current_url = url;
+    Url fragment_url;
+    check("fragment-only target inherits the complete current resource",
+          Url::parse("#next-section", fragment_url, error, current_url.destination_hex,
+                     current_url.path, current_url.fields) &&
+              fragment_url.destination_hex == current_url.destination_hex &&
+              fragment_url.path == current_url.path &&
+              fragment_url.fields == current_url.fields && fragment_url.has_fragment &&
+              fragment_url.fragment == "next-section");
+    check("empty fragment is retained for canonical next-heading navigation",
+          Url::parse("#", fragment_url, error, current_url.destination_hex,
+                     current_url.path, current_url.fields) &&
+              fragment_url.has_fragment && fragment_url.fragment.empty());
+    check("fragment navigation keeps transport resource identity",
+          current_url.same_resource(fragment_url));
+    check("fragment navigation is local only with a loaded matching resource",
+          UI::LXMF::NomadNet::should_jump_locally(current_url, fragment_url, true, false) &&
+              !UI::LXMF::NomadNet::should_jump_locally(current_url, fragment_url, false, false));
+    Url other_page;
+    check("fragment on another path still requires transport",
+          Url::parse(":/page/other.mu#next-section", other_page, error,
+                     current_url.destination_hex, current_url.path, current_url.fields) &&
+              !UI::LXMF::NomadNet::should_jump_locally(current_url, other_page, true, false));
+    check("history restoration may reuse the loaded matching resource",
+          UI::LXMF::NomadNet::should_jump_locally(current_url, current_url, true, true));
+    check("fragment names reject non-anchor grammar",
+          !Url::parse("#bad/name", fragment_url, error, current_url.destination_hex,
+                      current_url.path, current_url.fields));
+    check("fragment names are bounded",
+          !Url::parse("#" + std::string(Url::MAX_FRAGMENT_BYTES + 1, 'a'),
+                      fragment_url, error, current_url.destination_hex,
+                      current_url.path, current_url.fields));
     check("wrong destination length rejected", !Url::parse("abcd:/page/index.mu", url, error));
     check("nonhex destination rejected", !Url::parse("zz23456789abcdef0123456789abcdef:/page/index.mu", url, error));
     check("control characters rejected", !Url::parse("0123456789abcdef0123456789abcdef:/page/a\nb", url, error));
@@ -294,6 +344,81 @@ int main(int argc, char** argv) {
     check("compact page preserves document presentation flags",
           compact.has_background() == doc.has_background && compact.background() == doc.background &&
           compact.has_foreground() == doc.has_foreground && compact.foreground() == doc.foreground);
+
+    const auto anchor_doc = parser.parse(
+        "First\n"
+        "`:spot Second\n"
+        "`:spot Duplicate\n"
+        "> Styled `!Heading`! Caf\xC3\xA9\n"
+        "`:only\n"
+        "`:mark!Visible punctuation\n");
+    check("explicit anchors are retained at their zero-width block",
+          anchor_doc.anchors.size() == 4 && anchor_doc.anchors[0].name == "spot" &&
+              anchor_doc.anchors[0].block_index == 1);
+    check("first duplicate anchor declaration wins",
+          anchor_doc.anchors[0].block_index == 1);
+    check("explicit anchor declaration does not render",
+          anchor_doc.blocks[1].runs.size() == 1 && anchor_doc.blocks[1].runs[0].text == " Second");
+    check("anchor grammar stops without consuming punctuation",
+          anchor_doc.blocks[5].runs.size() == 1 &&
+              anchor_doc.blocks[5].runs[0].text == "!Visible punctuation");
+    check("anchor-only declaration remains zero width",
+          anchor_doc.anchors[2].name == "only" && anchor_doc.anchors[2].block_index == 4 &&
+              anchor_doc.blocks[4].runs.empty());
+    check("heading slug strips Micron formatting and non-ASCII text",
+          anchor_doc.anchors[1].name == "styled-heading-caf" &&
+              anchor_doc.anchors[1].block_index == 3);
+    const auto canonical_slug_doc = parser.parse(
+        "> Hello, World!\n> A___B---C\n> A\xC3\xA9" "B\n"
+        "> `[Label`:/page/target.mu] Link\n"
+        "> `FabcRed `BT123456Blue\n> Bad `Fzzzx Color\n"
+        "> `Fg50Gray`f `Bg25Shade`b\n");
+    check("generated slugs collapse canonical separator runs",
+          canonical_slug_doc.anchors[0].name == "hello-world" &&
+              canonical_slug_doc.anchors[1].name == "a-b-c");
+    check("generated slugs replace a Unicode run with one separator",
+          canonical_slug_doc.anchors[2].name == "a-b");
+    check("generated slugs include canonical link label and target text",
+          canonical_slug_doc.anchors[3].name == "label-page-target-mu-link");
+    check("generated slugs strip valid colors but retain malformed color text",
+          canonical_slug_doc.anchors[4].name == "red-blue" &&
+              canonical_slug_doc.anchors[5].name == "bad-fzzzx-color");
+    check("generated slugs strip grayscale foreground and background modifiers",
+          canonical_slug_doc.anchors[6].name == "gray-shade");
+    check("explicit anchor names preserve canonical case sensitivity",
+          parser.parse("`:Mixed_Name-2 target\n").anchors.front().name == "Mixed_Name-2");
+    const auto empty_anchor_doc = parser.parse("`: visible\n");
+    check("empty anchor declarations are ignored and remain zero width",
+          empty_anchor_doc.anchors.empty() && empty_anchor_doc.blocks.front().runs.front().text == " visible");
+    const std::string long_anchor(DocumentParser::MAX_ANCHOR_NAME_BYTES + 1, 'a');
+    const auto long_anchor_doc = parser.parse("`:" + long_anchor + " visible\n");
+    check("overlong anchors are consumed without retaining a false prefix",
+          long_anchor_doc.anchors.empty() && long_anchor_doc.blocks.front().runs.front().text == " visible" &&
+              long_anchor_doc.has_truncation(TruncationReason::ANCHOR_NAME_BYTES));
+    const auto long_heading_anchor_doc = parser.parse("> " + long_anchor + "\n");
+    check("overlong generated heading slugs do not retain a false prefix",
+          long_heading_anchor_doc.anchors.empty() &&
+              long_heading_anchor_doc.has_truncation(TruncationReason::ANCHOR_NAME_BYTES));
+    std::string many_anchors_source;
+    for (std::size_t i = 0; i <= DocumentParser::MAX_ANCHORS; ++i)
+        many_anchors_source += "`:a" + std::to_string(i) + " x\n";
+    const auto many_anchors_doc = parser.parse(many_anchors_source);
+    check("anchor count is independently bounded",
+          many_anchors_doc.anchors.size() == DocumentParser::MAX_ANCHORS &&
+              many_anchors_doc.has_truncation(TruncationReason::ANCHORS));
+    const auto duplicate_slug_doc = parser.parse(
+        "`:same-heading explicit\n> Same `!Heading`!\n");
+    check("explicit declaration wins over a later generated heading slug",
+          duplicate_slug_doc.anchors.size() == 1 &&
+              duplicate_slug_doc.anchors.front().block_index == 0);
+    CompactPage anchor_page;
+    uint16_t anchor_block = 0;
+    check("compact page retains bounded anchor records",
+          anchor_page.assign(anchor_doc) && anchor_page.anchors().size() == anchor_doc.anchors.size());
+    check("compact anchor lookup resolves exact name to block",
+          anchor_page.find_anchor("styled-heading-caf", anchor_block) && anchor_block == 3);
+    check("compact anchor lookup is case-sensitive and allocation-free",
+          !anchor_page.find_anchor("Styled-Heading-Caf", anchor_block));
 
     auto color_doc = parser.parse(
         "#!bg=123\n#!fg=abc\n"

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -30,6 +30,7 @@ using UI::LXMF::NomadNet::DocumentParser;
 using UI::LXMF::NomadNet::compact_address;
 using UI::LXMF::NomadNet::PageHistory;
 using UI::LXMF::NomadNet::display_text;
+using UI::LXMF::NomadNet::display_codepoint;
 using UI::LXMF::NomadNet::Library;
 using UI::LXMF::NomadNet::ActionMailbox;
 using UI::LXMF::NomadNet::UserAction;
@@ -346,8 +347,37 @@ int main(int argc, char** argv) {
           std::string(link_fields_page.target(0).data(), link_fields_page.target(0).size()) ==
               ":/page/search.mu`q=pyxis");
     check("divider parsed", doc.blocks[3].type == BlockType::DIVIDER);
+    auto divider_doc = parser.parse("-\n-=\n-\x01\n-long\n-─\n-═\n-║\n-🙂");
+    check("canonical divider forms parse as bounded divider metadata",
+          divider_doc.blocks.size() == 8 &&
+              std::all_of(divider_doc.blocks.begin(), divider_doc.blocks.end(),
+                          [](const auto& block) { return block.type == BlockType::DIVIDER; }));
+    check("default and control-character dividers use the canonical line glyph",
+          divider_doc.blocks[0].divider_codepoint == 0x2500 &&
+              divider_doc.blocks[2].divider_codepoint == 0x2500);
+    check("exactly two-character divider forms preserve the authored character",
+          divider_doc.blocks[1].divider_codepoint == '=' &&
+          divider_doc.blocks[4].divider_codepoint == 0x2500 &&
+          divider_doc.blocks[5].divider_codepoint == 0x2550 &&
+          divider_doc.blocks[6].divider_codepoint == 0x2551 &&
+          divider_doc.blocks[7].divider_codepoint == 0x1f642);
+    check("long divider lines retain canonical default-glyph behavior",
+          divider_doc.blocks[3].divider_codepoint == 0x2500);
+    CompactPage divider_page;
+    check("compact page preserves divider glyph metadata without text runs",
+          divider_page.assign(divider_doc) && divider_page.runs().empty() &&
+              divider_page.blocks().size() == divider_doc.blocks.size() &&
+              divider_page.blocks()[1].divider_codepoint == '=' &&
+              divider_page.blocks()[5].divider_codepoint == 0x2550);
+    char divider_utf8[5]{};
+    const std::size_t divider_bytes = display_codepoint(0x2550, divider_utf8);
+    check("supported authored divider glyph is encoded for bounded drawing",
+          divider_bytes == 3 && std::string(divider_utf8, divider_bytes) == "═");
+    const std::size_t fallback_bytes = display_codepoint(0x1f642, divider_utf8);
+    check("unsupported authored divider glyph uses the display fallback",
+          fallback_bytes == 1 && divider_utf8[0] == '?');
     check("literal mode suppresses formatting", doc.blocks[4].runs.size() == 1 &&
-                                                 doc.blocks[4].runs[0].text == "`!literal");
+                                                  doc.blocks[4].runs[0].text == "`!literal");
     bool saw_unsupported = false;
     for (const auto& block : doc.blocks) saw_unsupported = saw_unsupported || block.type == BlockType::UNSUPPORTED;
     check("unsupported structured content has fallback", doc.unsupported && saw_unsupported);

--- a/tests/native/test_app_launcher_nomadnet.cpp
+++ b/tests/native/test_app_launcher_nomadnet.cpp
@@ -194,6 +194,86 @@ int main(int argc, char** argv) {
                                       doc.has_foreground && doc.foreground == 0xabcdef);
     check("heading depth parsed", doc.blocks.size() >= 5 &&
                                   doc.blocks[0].type == BlockType::HEADING && doc.blocks[0].depth == 2);
+    check("heading level one uses the large face",
+          UI::LXMF::NomadNet::heading_uses_large_font(1));
+    check("nested headings use the body-size faces",
+          !UI::LXMF::NomadNet::heading_uses_large_font(2) &&
+              !UI::LXMF::NomadNet::heading_uses_large_font(255));
+    check("empty headings remain layout content",
+          UI::LXMF::NomadNet::block_has_layout_content(BlockType::HEADING, 0));
+    check("dark heading one colors match NomadNet",
+          UI::LXMF::NomadNet::heading_foreground(1) == 0x222222 &&
+              UI::LXMF::NomadNet::heading_background(1) == 0xbbbbbb);
+    check("dark heading two colors match NomadNet",
+          UI::LXMF::NomadNet::heading_foreground(2) == 0x111111 &&
+              UI::LXMF::NomadNet::heading_background(2) == 0x999999);
+    check("dark heading three and deeper colors match NomadNet",
+          UI::LXMF::NomadNet::heading_foreground(3) == 0x000000 &&
+              UI::LXMF::NomadNet::heading_background(3) == 0x777777 &&
+              UI::LXMF::NomadNet::heading_foreground(255) == 0x000000 &&
+              UI::LXMF::NomadNet::heading_background(255) == 0x777777);
+    check("heading indentation follows depth with a bounded cap",
+          UI::LXMF::NomadNet::heading_indent_spaces(1) == 0 &&
+              UI::LXMF::NomadNet::heading_indent_spaces(2) == 2 &&
+              UI::LXMF::NomadNet::heading_indent_spaces(3) == 4 &&
+              UI::LXMF::NomadNet::heading_indent_spaces(255) == 14);
+    check("heading spacing distinguishes canonical levels",
+          UI::LXMF::NomadNet::heading_bottom_spacing(1) == 6 &&
+              UI::LXMF::NomadNet::heading_bottom_spacing(2) == 4 &&
+              UI::LXMF::NomadNet::heading_bottom_spacing(3) == 3 &&
+              UI::LXMF::NomadNet::heading_bottom_spacing(255) == 3);
+    auto authored_heading = parser.parse("> `F0f0green heading`f");
+    CompactPage authored_heading_page;
+    bool authored_heading_assigned = authored_heading_page.assign(authored_heading);
+    bool authored_heading_foreground = false;
+    for (const auto& run : authored_heading_page.runs()) {
+        authored_heading_foreground = authored_heading_foreground ||
+            ((run.style & CompactPage::HAS_FOREGROUND) && run.foreground == 0x00ff00);
+    }
+    check("heading treatment preserves authored foreground",
+          authored_heading_assigned && authored_heading_page.blocks().size() == 1 &&
+              authored_heading_foreground);
+    auto canonical_heading = parser.parse("#!fg=f00\n#!bg=00f\n> plain `F0f0green`f `Bf80orange background`b");
+    CompactPage canonical_heading_page;
+    bool heading_defaults_override_page = false;
+    bool authored_heading_fg_override = false;
+    bool authored_heading_bg_override = false;
+    if (canonical_heading_page.assign(canonical_heading)) {
+        for (const auto& run : canonical_heading_page.runs()) {
+            const auto run_text = canonical_heading_page.text(run);
+            const std::string run_string(run_text.data(), run_text.size());
+            if (run_string.find("plain") != std::string::npos) {
+                heading_defaults_override_page =
+                    UI::LXMF::NomadNet::resolve_effective_foreground(
+                        canonical_heading_page, run, 1, 0xffffff) == 0x222222 &&
+                    UI::LXMF::NomadNet::resolve_effective_background(
+                        canonical_heading_page, run, 1, 0x000000) == 0xbbbbbb;
+            }
+            if (run_string.find("green") != std::string::npos) {
+                authored_heading_fg_override =
+                    UI::LXMF::NomadNet::resolve_effective_foreground(
+                        canonical_heading_page, run, 1, 0xffffff) == 0x00ff00;
+            }
+            if (run_string.find("orange background") != std::string::npos) {
+                authored_heading_bg_override =
+                    UI::LXMF::NomadNet::resolve_effective_background(
+                        canonical_heading_page, run, 1, 0x000000) == 0xff8800;
+            }
+        }
+    }
+    check("heading defaults override page colors", heading_defaults_override_page);
+    check("authored heading foreground overrides heading default", authored_heading_fg_override);
+    check("authored heading background overrides heading default", authored_heading_bg_override);
+    CompactPage::RunRecord unstyled_heading_run{};
+    check("heading focus contrast uses heading background instead of page background",
+          UI::LXMF::NomadNet::resolve_focus_border(
+              canonical_heading_page, unstyled_heading_run, 0x000000, 1) == 0x000000);
+    auto empty_heading = parser.parse(">\nbody");
+    CompactPage empty_heading_page;
+    check("empty heading survives compact conversion for its solid band",
+          empty_heading_page.assign(empty_heading) && !empty_heading_page.blocks().empty() &&
+              empty_heading_page.blocks()[0].type == BlockType::HEADING &&
+              empty_heading_page.blocks()[0].run_count == 0);
     check("inline runs are styled", doc.blocks[1].runs.size() >= 6 &&
                                       doc.blocks[1].runs[1].bold && doc.blocks[1].runs[3].italic);
     bool saw_background = false;
@@ -339,6 +419,8 @@ int main(int argc, char** argv) {
         int16_t y;
         int16_t width;
         int16_t height;
+        uint8_t heading = 0;
+        uint8_t heading_level() const { return heading; }
     };
     const std::vector<FocusFragmentFixture> focus_fragments{
         {3, 7, 10, 20, 28, 16},

--- a/tests/native/test_app_launcher_nomadnet.py
+++ b/tests/native/test_app_launcher_nomadnet.py
@@ -118,6 +118,60 @@ def test_ui_wiring_contract():
     assert "set_save_callback" in manager_cpp
 
 
+def test_nomadnet_anchor_navigation_stays_local_and_uses_layout_checkpoints():
+    document_h = (INCLUDE / "NomadNetDocument.h").read_text()
+    document = (INCLUDE / "NomadNetDocument.cpp").read_text()
+    compact_h = (INCLUDE / "NomadNetCompactPage.h").read_text()
+    screen_h = (INCLUDE / "NomadNetScreen.h").read_text()
+    screen = (INCLUDE / "NomadNetScreen.cpp").read_text()
+    manager_h = (INCLUDE / "UIManager.h").read_text()
+    manager = (INCLUDE / "UIManager.cpp").read_text()
+
+    assert "MAX_ANCHORS = 128" in document_h
+    assert "MAX_ANCHOR_NAME_BYTES = 64" in document_h
+    assert "add_anchor(doc, line.substr(name_start" in document
+    assert "add_anchor(doc, heading_slug(heading)" in document
+    assert "const ExternalVector<AnchorRecord>& anchors()" in compact_h
+    assert "bool find_anchor(" in compact_h
+
+    assert "bool jump_to_anchor(const std::string& name);" in screen_h
+    assert "int32_t logical_scroll() const" in screen_h
+    jump = screen[screen.index("bool NomadNetScreen::jump_to_anchor("):
+                  screen.index("void NomadNetScreen::draw_page")]
+    assert "_page.find_anchor(name,block_index)" in jump
+    assert "_layout_checkpoints" in jump
+    assert "scroll_to_logical(target,LV_ANIM_OFF)" in jump
+
+    open_page = manager[manager.index("void UIManager::nomad_open("):
+                        manager.index("void UIManager::nomad_reload()")]
+    assert "_nomad_url.path,_nomad_url.fields" in open_page
+    assert "NomadNet::should_jump_locally" in open_page
+    local = open_page[open_page.index("NomadNet::should_jump_locally"):
+                      open_page.index("RouterLock router_lock")]
+    assert "_nomadnet_screen->jump_to_anchor(parsed.fragment)" in local
+    assert "if(!resolved&&parsed.fragment.empty())return;" in local
+    assert "_nomad_history.open(parsed.str(),add_history,current_scroll)" in local
+    assert "nomad_send_request" not in local
+    assert "begin_navigation" not in local
+
+    request = manager[manager.index("void UIManager::nomad_send_request()"):
+                      manager.index("void UIManager::nomad_update()")]
+    assert "_nomad_url.path.data()" in request
+    assert "fragment" not in request
+
+    response = manager[manager.index("case NomadNet::AsyncMailbox::Kind::RESPONSE:"):
+                       manager.index("case NomadNet::AsyncMailbox::Kind::NONE:")]
+    assert "_nomadnet_screen->set_page(document)" in response
+    assert "_nomadnet_screen->jump_to_anchor(_nomad_url.fragment)" in response
+    assert "_nomadnet_screen->restore_logical_scroll(_nomad_pending_scroll)" in response
+    assert "if(page_applied&&_nomad_pending_scroll>=0)" in response
+    assert "else if(page_applied&&_nomad_url.has_fragment)" in response
+    assert (response.index("_nomadnet_screen->restore_logical_scroll(_nomad_pending_scroll)") <
+            response.index("_nomadnet_screen->jump_to_anchor(_nomad_url.fragment)"))
+    assert "Unknown anchor: #" in response
+    assert "int32_t _nomad_pending_scroll" in manager_h
+
+
 def test_nomadnet_page_body_uses_one_compact_custom_viewport():
     screen_h = (INCLUDE / "NomadNetScreen.h").read_text()
     screen = (INCLUDE / "NomadNetScreen.cpp").read_text()

--- a/tests/native/test_app_launcher_nomadnet.py
+++ b/tests/native/test_app_launcher_nomadnet.py
@@ -511,6 +511,34 @@ def test_nomadnet_uses_real_jetbrains_mono_nl_faces_at_each_size():
     assert "?1:0,LV_TEXT_FLAG_NONE" not in browser_cpp
 
 
+def test_nomadnet_heading_layout_uses_retained_depth_without_overwriting_colors():
+    browser_cpp = (INCLUDE / "NomadNetScreen.cpp").read_text()
+    layout = browser_cpp[
+        browser_cpp.index("bool NomadNetScreen::layout_page()") :
+        browser_cpp.index("void NomadNetScreen::draw_page(")
+    ]
+
+    assert "heading_uses_large_font(block.depth)" in layout
+    assert "heading_indent_spaces(block.depth)" in layout
+    assert "heading_bottom_spacing(block.depth)" in layout
+    assert "heading_display_level(block.depth)" in layout
+    assert "whitespace&&x==indent&&!heading" in layout
+    assert "run.foreground=" not in layout
+    assert "run.background=" not in layout
+
+    draw = browser_cpp[
+        browser_cpp.index("void NomadNetScreen::draw_page(") :
+        browser_cpp.index("void NomadNetScreen::select_link(")
+    ]
+    assert "fragment.heading_starts_band()" in draw
+    assert "content_area.x2" in draw
+    assert "heading_background(fragment.heading_level())" in draw
+    assert "resolve_effective_foreground(" in draw
+    assert draw.index("fragment.heading_starts_band()") < draw.index(
+        "run.style&NomadNet::CompactPage::HAS_BACKGROUND"
+    )
+
+
 def test_nomadnet_page_fonts_do_not_leak_into_navigation_widgets():
     browser_cpp = (INCLUDE / "NomadNetScreen.cpp").read_text()
     constructor = browser_cpp[
@@ -564,7 +592,8 @@ def test_nomadnet_draw_preserves_authored_colors_for_links_and_focus():
         browser_cpp.index("void NomadNetScreen::select_link(")
     ]
 
-    assert "dsc.color=lv_color_hex(NomadNet::resolve_foreground(_page,run,Theme::TEXT_PRIMARY));" in draw
+    assert "dsc.color=lv_color_hex(NomadNet::resolve_effective_foreground(" in draw
+    assert "_page,run,fragment.heading_level(),Theme::TEXT_PRIMARY" in draw
     assert "run.link_index>=0?Theme::primaryLight()" not in draw
     assert "selected?Theme::primaryPressed()" not in draw
     assert "bg.bg_color=lv_color_hex(run.background)" in draw
@@ -575,11 +604,13 @@ def test_nomadnet_draw_preserves_authored_colors_for_links_and_focus():
 def test_nomadnet_bold_body_text_keeps_body_font_metrics():
     browser_cpp = (INCLUDE / "NomadNetScreen.cpp").read_text()
     fonts = INCLUDE.parent / "Fonts"
-    layout = browser_cpp[browser_cpp.index("const bool large=") : browser_cpp.index(
-        "const lv_font_t* font=page_run_font", browser_cpp.index("const bool large=")
+    layout_start = browser_cpp.index("const bool heading=")
+    layout = browser_cpp[layout_start : browser_cpp.index(
+        "const lv_font_t* font=page_run_font", layout_start
     )]
 
     assert "block.type==NomadNet::BlockType::HEADING" in layout
+    assert "large_heading=heading&&NomadNet::heading_uses_large_font(block.depth)" in layout
     assert "NomadNet::CompactPage::BOLD" not in layout
 
     for size in (12, 16):

--- a/tests/native/test_app_launcher_nomadnet.py
+++ b/tests/native/test_app_launcher_nomadnet.py
@@ -133,6 +133,8 @@ def test_nomadnet_page_body_uses_one_compact_custom_viewport():
     assert "lv_label_create(_content)" not in set_page
     assert "LV_EVENT_DRAW_MAIN" in screen
     assert "lv_draw_label(" in screen
+    assert "divider_height=static_cast<int16_t>(nomadnet_font_12.line_height)" in screen
+    assert "divider_height=16" not in screen
     assert "commit_line" in screen
     assert "NomadNet::truncation_notice(document)" in set_page
     assert "if(!_page.append_notice(notice))" in set_page


### PR DESCRIPTION
## Summary

Bring the compact Pyxis NomadNet renderer and navigator into cumulative parity with canonical NomadNet behavior for the reviewed slices:

- preserve authored custom divider characters
- support the full `g00`–`g99` grayscale range
- consume unknown modifiers without leaking modifier syntax into rendered content
- match heading size, weight, spacing, and glyph presentation
- generate canonical heading slugs and support same-document anchors, URL fragments, focus/scroll restoration, and fragment-aware history navigation

State tables and forms are intentionally deferred to later focused slices.

## Verification

- Focused NomadNet suite: **27 passed**
- Full host suite: **235 passed, 1 skipped**
- ASan/UBSan suite: **351 passed** on four repeated runs
- `tdeck` firmware build: **75,808 bytes RAM**, **2,808,497 bytes flash**
- Independent exact-candidate review: **PASS**

## Physical acceptance and persistence

The cumulative divider, grayscale, modifier, heading, and anchor behavior was physically exercised and accepted as looking good on the target device.

The exact accepted app0 candidate was installed and read back byte-for-byte after flashing. The flashed application image was 2,808,864 bytes with SHA-256 `346ce298ec937f802a9b963474c309c55162c39c5b9bcf2f839bf9928905bb91`; the app0 read-back matched, and every non-app0 partition was independently verified unchanged, preserving existing device data.
