### PR TITLE
release: ship merged full-flash binary on releases

### DIFF
--- a/.github/workflows/release-firmware.yml
+++ b/.github/workflows/release-firmware.yml
@@ -128,6 +128,20 @@ jobs:
             --version "${PACKAGE_VERSION}" \
             --output "docs/flasher/firmware/pyxis-${VERSION}.pyxis.zip"
 
+      - name: Build merged full-flash binary
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          # Single image with bootloader, partition table, OTA selector, and
+          # application at their fixed offsets for `write_flash 0x0`. First
+          # install / provisioning only — it erases NVS, OTA data, and the
+          # LittleFS partition, so updates must keep using firmware.bin.
+          python tools/merge_pyxis_release.py \
+            --directory docs/flasher/firmware \
+            --version "${VERSION}" \
+            --output "docs/flasher/firmware/pyxis-${VERSION}-merged.bin"
+
       - name: Download existing release assets for GitHub Pages
         if: github.ref == 'refs/heads/main'
         run: |
@@ -277,5 +291,6 @@ jobs:
             docs/flasher/firmware/firmware.bin
             docs/flasher/firmware/pyxis-release.json
             docs/flasher/firmware/*.pyxis.zip
+            docs/flasher/firmware/pyxis-*-merged.bin
           generate_release_notes: true
           draft: true

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The easiest way to get Pyxis running is the [web flasher](https://torlando-tech.
 For esptool (or any other tool that writes raw flash), each release also publishes a **merged binary** (`pyxis-<tag>-merged.bin`) that contains the bootloader, partition table, OTA selector, and application at their fixed offsets. Provision a T-Deck Plus (8 MB flash) with:
 
 ```
-esptool.py --chip esp32s3 erase_flash write_flash 0x0 pyxis-<tag>-merged.bin
+esptool.py --chip esp32s3 erase_flash
+esptool.py --chip esp32s3 write_flash 0x0 pyxis-<tag>-merged.bin
 ```
 
 **Merged binaries are for first install / provisioning.** Flashing one overwrites every flash region, including NVS (settings, identity) and the LittleFS partition (messages, paths, maps). To update an existing device without losing data, flash `firmware.bin` to `0x10000` only, or use the Columba-compatible `pyxis-<tag>.pyxis.zip` update package.

--- a/README.md
+++ b/README.md
@@ -24,5 +24,17 @@ Other features:
 - ~~Will crash in about 5 minutes of normal use (sorry)~~ I had 5d uptime on v0.2.0 with BLE disabled
 - Make LXST voice calls (codec2 only, quality sounds horrible coming out the other end in Columba, needs work)
 
+## Flashing
+
+The easiest way to get Pyxis running is the [web flasher](https://torlando-tech.github.io/pyxis/flasher/), which downloads release firmware from this repository's releases and verifies each image's SHA-256 digest against the release metadata.
+
+For esptool (or any other tool that writes raw flash), each release also publishes a **merged binary** (`pyxis-<tag>-merged.bin`) that contains the bootloader, partition table, OTA selector, and application at their fixed offsets. Provision a T-Deck Plus (8 MB flash) with:
+
+```
+esptool.py --chip esp32s3 erase_flash write_flash 0x0 pyxis-<tag>-merged.bin
+```
+
+**Merged binaries are for first install / provisioning.** Flashing one overwrites every flash region, including NVS (settings, identity) and the LittleFS partition (messages, paths, maps). To update an existing device without losing data, flash `firmware.bin` to `0x10000` only, or use the Columba-compatible `pyxis-<tag>.pyxis.zip` update package.
+
 ## Why "Pyxis"
 Pyxis, latin for "compass," is a [constellation](https://en.wikipedia.org/wiki/Pyxis) in the southern sky depicting a mariner's compass. Small but essential, the compass ensures every message finds its destination - even when the path is uncertain. 

--- a/tests/build_scripts/test_merge_pyxis_release.py
+++ b/tests/build_scripts/test_merge_pyxis_release.py
@@ -1,0 +1,168 @@
+"""Contract tests for the merged full-flash Pyxis release image."""
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "tools/merge_pyxis_release.py"
+WORKFLOW = ROOT / ".github/workflows/release-firmware.yml"
+README = ROOT / "README.md"
+
+FLASH_SIZE = 8 * 1024 * 1024
+OFFSETS = {
+    "bootloader.bin": 0x0,
+    "partitions.bin": 0x8000,
+    "boot_app0.bin": 0xE000,
+    "firmware.bin": 0x10000,
+}
+
+
+def valid_bootloader() -> bytes:
+    return b"\xE9\x03" + b"\xA5" * 512
+
+
+def valid_partitions() -> bytes:
+    return b"\xAA\x50" + b"\x00" * 511
+
+
+def valid_boot_app0() -> bytes:
+    image = bytearray([0xFF] * 0x2000)
+    image[:4] = b"\x01\x00\x00\x00"
+    return bytes(image)
+
+
+def valid_firmware() -> bytes:
+    image = bytearray(0x1000)
+    image[0] = 0xE9
+    image[12:14] = (9).to_bytes(2, "little")
+    return bytes(image)
+
+
+def images() -> dict[str, bytes]:
+    return {
+        "bootloader.bin": valid_bootloader(),
+        "partitions.bin": valid_partitions(),
+        "boot_app0.bin": valid_boot_app0(),
+        "firmware.bin": valid_firmware(),
+    }
+
+
+def write_release_directory(directory: Path, version: str = "v9.9.9", images_: dict | None = None) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    images_ = images_ or images()
+    for name, data in images_.items():
+        (directory / name).write_bytes(data)
+    metadata = {
+        "schema": 1,
+        "version": version,
+        "source_commit": "a" * 40,
+        "environment": "tdeck-release",
+        "chip_family": "ESP32-S3",
+        "flash_size": FLASH_SIZE,
+        "persistence_safe": True,
+        "images": {
+            name: {
+                "file": name,
+                "offset": OFFSETS[name],
+                "size": len(images_[name]),
+                "sha256": hashlib.sha256(images_[name]).hexdigest(),
+            }
+            for name in OFFSETS
+        },
+    }
+    (directory / "pyxis-release.json").write_text(json.dumps(metadata))
+    return directory
+
+
+def run_builder(directory: Path, output: Path, version: str = "v9.9.9") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--directory", str(directory), "--version", version, "--output", str(output)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_merged_image_places_assets_at_fixed_offsets_and_pads_erased(tmp_path):
+    directory = write_release_directory(tmp_path / "release")
+    output = tmp_path / "merged.bin"
+    result = run_builder(directory, output)
+    assert result.returncode == 0, result.stderr
+
+    merged = output.read_bytes()
+    assert len(merged) == FLASH_SIZE
+    images_ = images()
+    for name, offset in OFFSETS.items():
+        assert merged[offset : offset + len(images_[name])] == images_[name]
+    # Every byte outside the four images must be erased flash.
+    occupied = sorted(
+        (offset, offset + len(images_[name])) for name, offset in OFFSETS.items()
+    )
+    for index in range(len(merged)):
+        in_image = any(start <= index < end for start, end in occupied)
+        if not in_image:
+            assert merged[index] == 0xFF
+
+
+def test_merged_image_is_byte_for_byte_deterministic(tmp_path):
+    directory = write_release_directory(tmp_path / "release")
+    first = tmp_path / "first.bin"
+    second = tmp_path / "second.bin"
+    assert run_builder(directory, first).returncode == 0
+    assert run_builder(directory, second).returncode == 0
+    assert first.read_bytes() == second.read_bytes()
+
+
+def test_merged_image_reports_sha256_matching_file(tmp_path):
+    directory = write_release_directory(tmp_path / "release")
+    output = tmp_path / "merged.bin"
+    result = run_builder(directory, output)
+    assert result.returncode == 0, result.stderr
+    assert f"merged_sha256={hashlib.sha256(output.read_bytes()).hexdigest()}" in result.stdout
+
+
+def test_builder_rejects_version_mismatch(tmp_path):
+    directory = write_release_directory(tmp_path / "release")
+    result = run_builder(directory, tmp_path / "merged.bin", version="v9.9.10")
+    assert result.returncode != 0
+    assert not (tmp_path / "merged.bin").exists()
+
+
+def test_builder_rejects_tampered_image(tmp_path):
+    images_ = images()
+    images_["firmware.bin"] = b"\xE9" + b"\x00" * 31  # hash in metadata won't match
+    directory = write_release_directory(tmp_path / "release", images_=images_)
+    (tmp_path / "release" / "firmware.bin").write_bytes(b"\xE9" + b"\x00" * 63)
+    result = run_builder(directory, tmp_path / "merged.bin")
+    assert result.returncode != 0
+    assert not (tmp_path / "merged.bin").exists()
+
+
+def test_workflow_builds_and_publishes_merged_binary():
+    workflow = WORKFLOW.read_text()
+
+    assert "Build merged full-flash binary" in workflow
+    assert "python tools/merge_pyxis_release.py" in workflow
+    assert "--directory docs/flasher/firmware" in workflow
+    assert 'pyxis-${VERSION}-merged.bin' in workflow
+    assert "docs/flasher/firmware/pyxis-*-merged.bin" in workflow
+    # The merged build must be gated to tag builds, like the other release artifacts.
+    merged_step = workflow[workflow.index("Build merged full-flash binary") :]
+    assert "if: startsWith(github.ref, 'refs/tags/v')" in merged_step[: merged_step.index("name: Download existing release assets")]
+
+
+def test_readme_documents_merged_binary_with_honest_semantics():
+    readme = README.read_text()
+
+    assert "merged binary" in readme.lower()
+    assert "write_flash 0x0" in readme
+    assert re.search(r"pyxis-<tag>-merged\.bin", readme)
+    # The README must say the merged image wipes persistent data and that
+    # data-preserving updates use firmware.bin.
+    assert "erase_flash" in readme
+    assert "NVS" in readme
+    assert "firmware.bin" in readme

--- a/tools/merge_pyxis_release.py
+++ b/tools/merge_pyxis_release.py
@@ -5,7 +5,8 @@ The merged image places the four release assets at their fixed flash offsets
 inside an erased (0xFF) 8 MiB canvas, so the whole T-Deck Plus flash can be
 provisioned with one write:
 
-    esptool.py --chip esp32s3 erase_flash write_flash 0x0 pyxis-<tag>-merged.bin
+    esptool.py --chip esp32s3 erase_flash
+    esptool.py --chip esp32s3 write_flash 0x0 pyxis-<tag>-merged.bin
 
 This is a first-install/provisioning image: flashing it overwrites every
 region including NVS, OTA data, and the LittleFS ("spiffs") partition.

--- a/tools/merge_pyxis_release.py
+++ b/tools/merge_pyxis_release.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Build a single merged flash image from a validated Pyxis web release.
+
+The merged image places the four release assets at their fixed flash offsets
+inside an erased (0xFF) 8 MiB canvas, so the whole T-Deck Plus flash can be
+provisioned with one write:
+
+    esptool.py --chip esp32s3 erase_flash write_flash 0x0 pyxis-<tag>-merged.bin
+
+This is a first-install/provisioning image: flashing it overwrites every
+region including NVS, OTA data, and the LittleFS ("spiffs") partition.
+Updating an existing device must keep using firmware.bin only (or the
+Columba .pyxis package), which preserves persistent data.
+
+Inputs must already pass tools/validate_pyxis_web_release.py; the validator
+runs again here so a merged image can never be built from unvalidated or
+stale assets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_pyxis_web_release import EXPECTED_OFFSETS, validate_release
+
+
+FLASH_SIZE = 8 * 1024 * 1024
+ERASED = 0xFF
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_merged_image(directory: Path) -> bytes:
+    spans = {}
+    for name, offset in EXPECTED_OFFSETS.items():
+        image = (directory / name).read_bytes()
+        spans[name] = (offset, offset + len(image))
+    for name, (start, end) in spans.items():
+        if end > FLASH_SIZE:
+            raise ValueError(f"{name} exceeds the 8 MiB flash at offset 0x{start:x}")
+        for other, (other_start, other_end) in spans.items():
+            if other != name and start < other_end and other_start < end:
+                raise ValueError(f"{name} overlaps {other}")
+
+    canvas = bytearray([ERASED]) * FLASH_SIZE
+    for name, (start, end) in spans.items():
+        canvas[start:end] = (directory / name).read_bytes()
+    return bytes(canvas)
+
+
+def verify_merged_image(merged: bytes, directory: Path) -> None:
+    if len(merged) != FLASH_SIZE:
+        raise ValueError(f"merged image is {len(merged)} bytes, expected {FLASH_SIZE}")
+    for name, offset in EXPECTED_OFFSETS.items():
+        image = (directory / name).read_bytes()
+        if merged[offset : offset + len(image)] != image:
+            raise ValueError(f"read-back mismatch for {name} at 0x{offset:x}")
+
+    # Regions outside the four images must remain erased flash.
+    occupied = sorted(
+        (offset, offset + len((directory / name).read_bytes()))
+        for name, offset in EXPECTED_OFFSETS.items()
+    )
+    cursor = 0
+    for start, end in occupied:
+        if any(byte != ERASED for byte in merged[cursor:start]):
+            raise ValueError(f"unexpected non-erased bytes in gap before 0x{start:x}")
+        cursor = end
+    if any(byte != ERASED for byte in merged[cursor:]):
+        raise ValueError("unexpected non-erased bytes after the last image")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--directory", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    validate_release(args.directory, args.version)
+
+    merged = build_merged_image(args.directory)
+    verify_merged_image(merged, args.directory)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(merged)
+
+    print(f"merged_image={args.output}")
+    print(f"merged_size={len(merged)}")
+    print(f"merged_sha256={sha256(merged)}")
+    for name, offset in EXPECTED_OFFSETS.items():
+        image = (args.directory / name).read_bytes()
+        print(f"{name} offset=0x{offset:x} size={len(image)} sha256={sha256(image)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Every `v*` tag release now also publishes **`pyxis-<tag>-merged.bin`**: a single 8 MiB image with the bootloader, partition table, OTA selector, and application at their fixed flash offsets on an erased (0xFF) canvas, so a T-Deck Plus can be provisioned with one write:

```
esptool.py --chip esp32s3 erase_flash write_flash 0x0 pyxis-<tag>-merged.bin
```

## Why

Releases already ship the four components plus `pyxis-release.json`, but the layout is a *recipe* the consumer must assemble. The merged binary is the *assembled product*: one download, one SHA-256 to verify, no possibility of mixing assets from different releases or skipping the partition table. It also makes the first-install/provisioning semantics unambiguous (whole-flash image ⇒ erases NVS/LittleFS by construction), while data-preserving updates keep using `firmware.bin` (0x10000) or the Columba `.pyxis` package, unchanged.

## Changes

- `tools/merge_pyxis_release.py` — builds the merged image. Re-runs `validate_pyxis_web_release.py` on the input directory first (offsets, sizes, hashes, version, environment), checks for region overlaps, then read-back-verifies each image at its offset and asserts every gap byte is 0xFF before writing output.
- `.github/workflows/release-firmware.yml` — new tag-gated step after the Columba package build; `pyxis-*-merged.bin` added to the release asset list. No existing steps or assets changed.
- `README.md` — new "Flashing" section with the esptool command and explicit first-install vs. update semantics.
- `tests/build_scripts/test_merge_pyxis_release.py` — 7 contract tests: fixed-offset placement, erased padding, byte-for-byte determinism, reported SHA-256, version-mismatch rejection, tampered-image rejection, workflow/README wiring.

## Verification

- Tool run against the real published v0.3.5 assets: 8 MiB image, all four component hashes match the published `pyxis-release.json` byte-for-byte.
- Cross-checked against esptool v5.3.1's native `merge-bin` output: byte-identical over the shared region (0x0–0x2d2d00); the only difference is 0xFF padding to the full 8 MiB.
- `pytest tests/build_scripts` → 155 passed (148 pre-existing + 7 new).
- Workflow YAML parses cleanly (18 steps, new step correctly tag-gated).

## Out of scope / pending

- Physical acceptance: flashing the merged image to a real T-Deck Plus (boot, running version/slot, first/second reboot). Host-side verification only so far.
- Web flasher and Columba `.pyxis` update paths are untouched.