### PR TITLE
feat: add indexless PMPK/PMAS v3 map pack writer

### DIFF
--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -71,7 +71,7 @@ function fail(message) { throw new MapInstallerError(message); }
 const INSTALL_MARKER_NAME = '.pyxis-installing';
 const INSTALL_MARKER_TTL_MS = 15 * 60 * 1000;
 
-function parseInstallMarker(text) {
+export function parseInstallMarker(text) {
   const parts = String(text).trim().split(' ');
   if (parts.length !== 4 || parts[0] !== 'PYXI' || parts[1] !== '1') return null;
   if (!parts[2] || parts[2].length > 64) return null;
@@ -79,7 +79,7 @@ function parseInstallMarker(text) {
   return {owner: parts[2], epochMs: Number(parts[3])};
 }
 
-function installMarkerIsFresh(epochMs, nowMs = Date.now()) {
+export function installMarkerIsFresh(epochMs, nowMs = Date.now()) {
   if (epochMs > nowMs) return true;
   return nowMs - epochMs <= INSTALL_MARKER_TTL_MS;
 }
@@ -120,8 +120,29 @@ async function acquireInstallMarker(pyxis, owner) {
 }
 
 async function releaseInstallMarker(pyxis, token) {
+  // Compare by owner, not the full token: renewals advance the epoch, so
+  // an exact match would fail once a long install has renewed its marker.
+  // A different owner means a later installer reclaimed our aged marker
+  // and its claim must survive.
+  const ours = parseInstallMarker(token);
   const actual = await readInstallMarker(pyxis);
-  if (actual === token) { try { await pyxis.removeEntry(INSTALL_MARKER_NAME); } catch {} }
+  if (actual !== null && ours) {
+    const current = parseInstallMarker(actual);
+    if (current && current.owner === ours.owner) { try { await pyxis.removeEntry(INSTALL_MARKER_NAME); } catch {} }
+  }
+}
+
+// Heartbeat: renew our marker's epoch during long publications (a full
+// world pack on slow SD storage can outlive the TTL). Best effort; the
+// commit-time revalidation is the backstop.
+export async function renewInstallMarker(pyxis, owner) {
+  try {
+    const token = `PYXI 1 ${owner} ${Date.now()}`;
+    const handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME);
+    const writable = await handle.createWritable({keepExistingData: false});
+    try { await writable.write(textEncoder.encode(token)); await writable.close(); }
+    catch (error) { try { await writable.abort(); } catch {} throw error; }
+  } catch {}
 }
 
 // Commit-time revalidation: the slot/style records were derived by
@@ -135,8 +156,10 @@ async function releaseInstallMarker(pyxis, token) {
 async function verifyActivationState(pyxis, mapSets, styleName, markerToken, state) {
   const marker = await readInstallMarker(pyxis);
   if (marker !== null) {
+    // Compare by owner: our own marker may carry a renewed (newer) epoch.
     const parsed = parseInstallMarker(marker);
-    if (parsed && installMarkerIsFresh(parsed.epochMs) && marker !== markerToken) {
+    const ours = markerToken !== null ? parseInstallMarker(markerToken) : null;
+    if (parsed && installMarkerIsFresh(parsed.epochMs) && (ours === null || parsed.owner !== ours.owner)) {
       fail('Another map installer is running on this card; wait for it to finish and retry');
     }
   }
@@ -837,7 +860,9 @@ async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()
     try{
       await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
       const tiles=await getDirectory(pack,'tiles');
-      for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});}
+      const markerOwner=markerToken?parseInstallMarker(markerToken)?.owner:null;
+      for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});if(markerOwner&&index%25===24)await renewInstallMarker(pyxis,markerOwner);}
+      if(markerOwner&&report.entries.length)await renewInstallMarker(pyxis,markerOwner);
       await writeVerified(pack,'manifest.pmp',manifest);parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
       try{await pack.removeEntry(receiptName);}catch(error){throw new Error(`Map pack is installed and verified, but its ownership receipt could not be removed: ${error.message}`);}
       try{const active=await activateMapSet(pyxis,metadata,markerToken);return{...report,manifestBytes:manifest.length,resumed:false,...active};}

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -68,7 +68,18 @@ function fail(message) { throw new MapInstallerError(message); }
 // installer; older ones are abandoned (crashed builder, closed tab) and are
 // reclaimed. A future epoch (the other writer's clock ahead of ours) counts
 // as fresh: refusing is the safe direction.
-const INSTALL_MARKER_NAME = '.pyxis-installing';
+// Each producer writes ONLY its own marker file -- no producer ever
+// writes a file it does not own, so a stalled installer's renewal can
+// never clobber a claim the other producer just made (the shared-file
+// check-then-act window is gone by construction):
+//   .pyxis-installing-web   this flasher
+//   .pyxis-installing-cli   the CLI builder
+//   .pyxis-installing       legacy shared marker (pre-per-file
+//                           producers); honored -- fresh ones refuse,
+//                           stale ones are reclaimed -- but never
+//                           written
+const INSTALL_MARKER_NAME = '.pyxis-installing-web';
+const CROSS_INSTALL_MARKERS = ['.pyxis-installing-cli', '.pyxis-installing'];
 const INSTALL_MARKER_TTL_MS = 15 * 60 * 1000;
 
 export function parseInstallMarker(text) {
@@ -84,14 +95,35 @@ export function installMarkerIsFresh(epochMs, nowMs = Date.now()) {
   return nowMs - epochMs <= INSTALL_MARKER_TTL_MS;
 }
 
-async function readInstallMarker(pyxis) {
-  let handle; try { handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME); }
+async function readInstallMarker(pyxis, name = INSTALL_MARKER_NAME) {
+  let handle; try { handle = await pyxis.getFileHandle(name); }
   catch (error) { if (error?.name === 'NotFoundError') return null; throw error; }
   return new TextDecoder('utf-8').decode(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
 }
 
+// Respect the other producers' marker files. A fresh cross marker (the
+// CLI builder's, or the legacy shared one) means a live cross-producer
+// installer: refuse. A stale or malformed one is an abandoned install;
+// reclaim it only when reclaim is true (at acquire). Fresh cross
+// markers are never touched.
+async function checkCrossInstallers(pyxis, reclaim) {
+  for (const name of CROSS_INSTALL_MARKERS) {
+    const raw = await readInstallMarker(pyxis, name);
+    if (raw === null) continue;
+    const parsed = parseInstallMarker(raw);
+    if (parsed && installMarkerIsFresh(parsed.epochMs)) {
+      fail('Another map installer is already running on this card; wait for it to finish and retry');
+    }
+    if (reclaim) { try { await pyxis.removeEntry(name); } catch {} }
+  }
+}
+
 async function acquireInstallMarker(pyxis, owner) {
   const token = `PYXI 1 ${owner} ${Date.now()}`;
+  // Check the cross producers first: a fresh foreign marker refuses the
+  // install up front, and stale cross markers (dead CLI run, old
+  // producer) are reclaimed so they cannot block a legitimate install.
+  await checkCrossInstallers(pyxis, true);
   const existing = await readInstallMarker(pyxis);
   if (existing !== null) {
     const parsed = parseInstallMarker(existing);
@@ -135,19 +167,25 @@ async function releaseInstallMarker(pyxis, token) {
 // Heartbeat: renew our marker's epoch during long publications (a full
 // world pack on slow SD storage can outlive the TTL).
 //
-// The renewal is ownership-checked, never a blind overwrite: if the
+// The renewal is ownership-checked, never a blind overwrite: if our own
 // marker no longer carries OUR owner (it aged out and another producer
 // legitimately reclaimed it, was deleted, or is corrupt), our claim is
 // void and the install aborts. Overwriting a foreign claim would steal
 // the card mid-install; the (possibly partially published) pack stays
 // device-harmless and the user retries after the other installer
 // finishes.
+//
+// The cross producers are re-checked on every renewal too: if the other
+// installer acquired DURING our install (a gap the acquire-time check
+// cannot cover), the heartbeat detects it and aborts instead of
+// continuing a conflicting publication.
 export async function renewInstallMarker(pyxis, owner) {
   const current = await readInstallMarker(pyxis);
   const parsed = current ? parseInstallMarker(current) : null;
   if (!parsed || parsed.owner !== owner) {
     fail('The map-install marker was reclaimed during installation; wait for the other installer to finish and retry');
   }
+  await checkCrossInstallers(pyxis, false);
   const token = `PYXI 1 ${owner} ${Date.now()}`;
   const handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME);
   const writable = await handle.createWritable({keepExistingData: false});
@@ -164,6 +202,9 @@ export async function renewInstallMarker(pyxis, owner) {
 // converges (a pack no record names is device-harmless: the firmware only
 // reads packs enumerated in the active selection).
 async function verifyActivationState(pyxis, mapSets, styleName, markerToken, state) {
+  // Cross producers: a fresh marker in the CLI/legacy files means the
+  // other installer started after we acquired.
+  await checkCrossInstallers(pyxis, false);
   const marker = await readInstallMarker(pyxis);
   if (marker !== null) {
     // Compare by owner: our own marker may carry a renewed (newer) epoch.
@@ -792,17 +833,22 @@ async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
 }
 
 async function prepareActiveMapSet(pyxis,metadata){
-  const slots=await Promise.all([readSelection(pyxis,'active-pack.0'),readSelection(pyxis,'active-pack.1')]);
-  if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
-  // Raw slot bytes at derivation time: the commit-time revalidation in
-  // activateMapSet aborts if they change before the record writes.
+  // Raw slot bytes at derivation time. The commit-time revalidation in
+  // activateMapSet aborts if they change before the record writes -- so
+  // the derivation below decodes FROM these exact bytes. Decoding a
+  // separate read (readSelection) would let a concurrent swap between
+  // the two reads derive a record from stale state that the raw
+  // snapshot no longer matches.
   const slotBytes=[];for(let index=0;index<2;index+=1){let raw;try{raw=new Uint8Array(await (await (await pyxis.getFileHandle(`active-pack.${index}`)).getFile()).arrayBuffer());}catch(error){if(error?.name==='NotFoundError')raw=null;else throw error;}slotBytes.push(raw);}
+  const slots=slotBytes.map(raw=>{if(raw===null)return null;try{return decodeActiveSelection(raw);}catch{return null;}});
+  if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
   const valid=slots.filter(Boolean);const highest=Math.max(0,...valid.map(slot=>slot.generation));if(highest===0xffffffff)fail('Active selection generation is exhausted');
   const current=valid.sort((left,right)=>right.generation-left.generation)[0];
   const mapSets=await getDirectory(pyxis,'map-sets');const styleName=`${metadata.mapSetId}.pmas`;
-  const installed=await readStyleSelection(mapSets,styleName);
-  if(installed&&(![2,3].includes(installed.version)||installed.mapSetId!==metadata.mapSetId||installed.attribution!==metadata.attribution))fail('Installed style record does not match selected map set');
   let styleBytes=null;try{styleBytes=new Uint8Array(await (await (await mapSets.getFileHandle(styleName)).getFile()).arrayBuffer());}catch(error){if(error?.name!=='NotFoundError')throw error;}
+  let installed=null;
+  if(styleBytes!==null){try{installed=decodeActiveSelection(styleBytes);}catch{fail(`Installed style record is invalid: ${styleName}`);}}
+  if(installed&&(![2,3].includes(installed.version)||installed.mapSetId!==metadata.mapSetId||installed.attribution!==metadata.attribution))fail('Installed style record does not match selected map set');
   const composition=installed||([2,3].includes(current?.version)&&current.mapSetId===metadata.mapSetId?current:null);
   let packs=[];
   if(composition){

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -58,6 +58,106 @@ async function withInstallLock(rootDirectory, operation) {
 export class MapInstallerError extends Error {}
 function fail(message) { throw new MapInstallerError(message); }
 
+// Cross-producer install marker. The CLI builder (tools/maps/build_map_pack.py)
+// claims the same well-known file with the same token format before it
+// publishes or activates. The browser holds a Web Locks name, which the CLI's
+// flock cannot see, and the CLI holds a flock, which this tab cannot see:
+// neither lock coordinates across producers, so the on-disk marker is the
+// one shared coordination primitive. A marker contains: PYXI 1 <owner>
+// <epoch_ms>. A marker written within INSTALL_MARKER_TTL_MS is a live
+// installer; older ones are abandoned (crashed builder, closed tab) and are
+// reclaimed. A future epoch (the other writer's clock ahead of ours) counts
+// as fresh: refusing is the safe direction.
+const INSTALL_MARKER_NAME = '.pyxis-installing';
+const INSTALL_MARKER_TTL_MS = 15 * 60 * 1000;
+
+function parseInstallMarker(text) {
+  const parts = String(text).trim().split(' ');
+  if (parts.length !== 4 || parts[0] !== 'PYXI' || parts[1] !== '1') return null;
+  if (!parts[2] || parts[2].length > 64) return null;
+  if (!/^\d+$/.test(parts[3])) return null;
+  return {owner: parts[2], epochMs: Number(parts[3])};
+}
+
+function installMarkerIsFresh(epochMs, nowMs = Date.now()) {
+  if (epochMs > nowMs) return true;
+  return nowMs - epochMs <= INSTALL_MARKER_TTL_MS;
+}
+
+async function readInstallMarker(pyxis) {
+  let handle; try { handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME); }
+  catch (error) { if (error?.name === 'NotFoundError') return null; throw error; }
+  return new TextDecoder('utf-8').decode(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
+}
+
+async function acquireInstallMarker(pyxis, owner) {
+  const token = `PYXI 1 ${owner} ${Date.now()}`;
+  const existing = await readInstallMarker(pyxis);
+  if (existing !== null) {
+    const parsed = parseInstallMarker(existing);
+    if (parsed && installMarkerIsFresh(parsed.epochMs)) {
+      fail('Another map installer is already running on this card; wait for it to finish and retry');
+    }
+    // Stale or malformed: reclaim, then claim fresh below.
+    try { await pyxis.removeEntry(INSTALL_MARKER_NAME); } catch {}
+  }
+  let handle;
+  try { handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME, {create: true, exclusive: true}); }
+  catch (error) {
+    if (error && error.name === 'FileExistsError') {
+      fail('Another map installer is already running on this card; wait for it to finish and retry');
+    }
+    throw error;
+  }
+  const writable = await handle.createWritable({keepExistingData: false});
+  try { await writable.write(textEncoder.encode(token)); await writable.close(); }
+  catch (error) { try { await writable.abort(); } catch {} throw error; }
+  // Read-back: a foreign content means we lost a simultaneous claim race.
+  // Never delete a foreign marker -- our claim is void.
+  const actual = await readInstallMarker(pyxis);
+  if (actual !== token) fail('The map-install marker was contested during acquisition; wait and retry');
+  return token;
+}
+
+async function releaseInstallMarker(pyxis, token) {
+  const actual = await readInstallMarker(pyxis);
+  if (actual === token) { try { await pyxis.removeEntry(INSTALL_MARKER_NAME); } catch {} }
+}
+
+// Commit-time revalidation: the slot/style records were derived by
+// prepareActiveMapSet; a cross-producer installer may have committed new
+// activation state since. Re-reading the raw bytes immediately before the
+// record writes and aborting on any change guarantees this publication never
+// overwrites a newer record with one derived from stale state. The
+// already-published pack is kept; a retry re-derives from the new state and
+// converges (a pack no record names is device-harmless: the firmware only
+// reads packs enumerated in the active selection).
+async function verifyActivationState(pyxis, mapSets, styleName, markerToken, state) {
+  const marker = await readInstallMarker(pyxis);
+  if (marker !== null) {
+    const parsed = parseInstallMarker(marker);
+    if (parsed && installMarkerIsFresh(parsed.epochMs) && marker !== markerToken) {
+      fail('Another map installer is running on this card; wait for it to finish and retry');
+    }
+  }
+  const sameRecord = (actual, expected) =>
+    (actual === null && expected === null) ||
+    (actual !== null && expected !== null && equalBytes(actual, expected));
+  for (let index = 0; index < 2; index += 1) {
+    const name = `active-pack.${index}`;
+    let actual; try { actual = new Uint8Array(await (await (await pyxis.getFileHandle(name)).getFile()).arrayBuffer()); }
+    catch (error) { if (error?.name === 'NotFoundError') actual = null; else throw error; }
+    if (!sameRecord(actual, state.slotBytes[index])) {
+      fail('Active map-set records changed during installation; wait for the other installer to finish and retry');
+    }
+  }
+  let styleActual; try { styleActual = new Uint8Array(await (await (await mapSets.getFileHandle(styleName)).getFile()).arrayBuffer()); }
+  catch (error) { if (error?.name === 'NotFoundError') styleActual = null; else throw error; }
+  if (!sameRecord(styleActual, state.styleBytes)) {
+    fail('Installed style record changed during installation; wait for the other installer to finish and retry');
+  }
+}
+
 const MUI_STYLE_PROFILES = Object.freeze({
   'osm-bright': Object.freeze({label:'OSM Bright',attribution:'(c) OpenMapTiles (c) OpenStreetMap contributors',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause'}),
   'dark-matter': Object.freeze({label:'Dark Matter',attribution:'(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO',license:'OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)'}),
@@ -661,11 +761,15 @@ async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
 async function prepareActiveMapSet(pyxis,metadata){
   const slots=await Promise.all([readSelection(pyxis,'active-pack.0'),readSelection(pyxis,'active-pack.1')]);
   if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
+  // Raw slot bytes at derivation time: the commit-time revalidation in
+  // activateMapSet aborts if they change before the record writes.
+  const slotBytes=[];for(let index=0;index<2;index+=1){let raw;try{raw=new Uint8Array(await (await (await pyxis.getFileHandle(`active-pack.${index}`)).getFile()).arrayBuffer());}catch(error){if(error?.name==='NotFoundError')raw=null;else throw error;}slotBytes.push(raw);}
   const valid=slots.filter(Boolean);const highest=Math.max(0,...valid.map(slot=>slot.generation));if(highest===0xffffffff)fail('Active selection generation is exhausted');
   const current=valid.sort((left,right)=>right.generation-left.generation)[0];
   const mapSets=await getDirectory(pyxis,'map-sets');const styleName=`${metadata.mapSetId}.pmas`;
   const installed=await readStyleSelection(mapSets,styleName);
   if(installed&&(![2,3].includes(installed.version)||installed.mapSetId!==metadata.mapSetId||installed.attribution!==metadata.attribution))fail('Installed style record does not match selected map set');
+  let styleBytes=null;try{styleBytes=new Uint8Array(await (await (await mapSets.getFileHandle(styleName)).getFile()).arrayBuffer());}catch(error){if(error?.name!=='NotFoundError')throw error;}
   const composition=installed||([2,3].includes(current?.version)&&current.mapSetId===metadata.mapSetId?current:null);
   let packs=[];
   if(composition){
@@ -675,11 +779,12 @@ async function prepareActiveMapSet(pyxis,metadata){
   packs.unshift({packId:metadata.packId});
   const target=!slots[0]?'active-pack.0':!slots[1]?'active-pack.1':slots[0].generation<=slots[1].generation?'active-pack.0':'active-pack.1';
   const record=encodeActiveMapSet({generation:highest+1,mapSetId:metadata.mapSetId,attribution:metadata.attribution,packs});
-  return {target,record,packs,mapSets,styleName};
+  return {target,record,packs,mapSets,styleName,slotBytes,styleBytes};
 }
 
-async function activateMapSet(pyxis,metadata){
-  const {target,record,mapSets,styleName}=await prepareActiveMapSet(pyxis,metadata);
+async function activateMapSet(pyxis,metadata,markerToken=null){
+  const {target,record,mapSets,styleName,slotBytes,styleBytes}=await prepareActiveMapSet(pyxis,metadata);
+  await verifyActivationState(pyxis,mapSets,styleName,markerToken,{slotBytes,styleBytes});
   await writeVerified(mapSets,styleName,record);const installed=decodeActiveSelection(await fileBytes(mapSets,styleName));
   if(installed.version!==3||installed.mapSetId!==metadata.mapSetId||installed.packs[0].packId!==metadata.packId)fail('Style map-set verification failed');
   await writeVerified(pyxis,target,record);const selected=decodeActiveSelection(await fileBytes(pyxis,target));
@@ -713,26 +818,38 @@ async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()
   const report=await inspectMuiZip(archive,{onProgress});
   if(report.styleId&&report.styleId!==metadata.mapSetId)fail('MUI ZIP style does not match the selected map set');
   const manifest=serializeIndexlessManifest(metadata,report.minZoom,report.maxZoom,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
-  await prepareActiveMapSet(pyxis,metadata);const packs=await getDirectory(pyxis,'packs');
-  let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
-  if(existing){
-    let empty=true;for await(const _entry of existing.entries()){empty=false;break;}
-    if(!empty){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
-  }
-  const pack=existing||await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
+  // Claim the cross-producer install marker (shared on-disk token with the
+  // CLI builder; the Web Locks name above cannot coordinate with it) before
+  // any mutation of the card: a refusal here must not create packs/ or
+  // map-sets/. The marker is held until every activation record write
+  // completes; the commit-time revalidation in activateMapSet is the safety
+  // net if it is bypassed or outlived.
+  const markerToken=await acquireInstallMarker(pyxis,`web-${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`);
   try{
-    await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
-    const tiles=await getDirectory(pack,'tiles');
-    for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});}
-    await writeVerified(pack,'manifest.pmp',manifest);parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
-    try{await pack.removeEntry(receiptName);}catch(error){throw new Error(`Map pack is installed and verified, but its ownership receipt could not be removed: ${error.message}`);}
-    try{const active=await activateMapSet(pyxis,metadata);return{...report,manifestBytes:manifest.length,resumed:false,...active};}
-    catch(error){throw new Error(`Map pack is installed and verified, but activation failed; retry with the same ZIP and pack ID: ${error.message}`);}
-  }catch(error){
-    if(!published&&!(await removeOwnedPack(packs,metadata.packId,pack,receiptName,receipt,report.entries))){
-      throw new Error(`${error.message}; the incomplete pack could not be safely removed because its ownership receipt was missing or cleanup failed`);
+    await prepareActiveMapSet(pyxis,metadata);
+    const packs=await getDirectory(pyxis,'packs');
+    let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
+    if(existing){
+      let empty=true;for await(const _entry of existing.entries()){empty=false;break;}
+      if(!empty){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata,markerToken);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
     }
-    throw error;
+    const pack=existing||await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
+    try{
+      await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
+      const tiles=await getDirectory(pack,'tiles');
+      for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});}
+      await writeVerified(pack,'manifest.pmp',manifest);parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
+      try{await pack.removeEntry(receiptName);}catch(error){throw new Error(`Map pack is installed and verified, but its ownership receipt could not be removed: ${error.message}`);}
+      try{const active=await activateMapSet(pyxis,metadata,markerToken);return{...report,manifestBytes:manifest.length,resumed:false,...active};}
+      catch(error){throw new Error(`Map pack is installed and verified, but activation failed; retry with the same ZIP and pack ID: ${error.message}`);}
+    }catch(error){
+      if(!published&&!(await removeOwnedPack(packs,metadata.packId,pack,receiptName,receipt,report.entries))){
+        throw new Error(`${error.message}; the incomplete pack could not be safely removed because its ownership receipt was missing or cleanup failed`);
+      }
+      throw error;
+    }
+  }finally{
+    await releaseInstallMarker(pyxis,markerToken);
   }
 }
 

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -133,16 +133,26 @@ async function releaseInstallMarker(pyxis, token) {
 }
 
 // Heartbeat: renew our marker's epoch during long publications (a full
-// world pack on slow SD storage can outlive the TTL). Best effort; the
-// commit-time revalidation is the backstop.
+// world pack on slow SD storage can outlive the TTL).
+//
+// The renewal is ownership-checked, never a blind overwrite: if the
+// marker no longer carries OUR owner (it aged out and another producer
+// legitimately reclaimed it, was deleted, or is corrupt), our claim is
+// void and the install aborts. Overwriting a foreign claim would steal
+// the card mid-install; the (possibly partially published) pack stays
+// device-harmless and the user retries after the other installer
+// finishes.
 export async function renewInstallMarker(pyxis, owner) {
-  try {
-    const token = `PYXI 1 ${owner} ${Date.now()}`;
-    const handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME);
-    const writable = await handle.createWritable({keepExistingData: false});
-    try { await writable.write(textEncoder.encode(token)); await writable.close(); }
-    catch (error) { try { await writable.abort(); } catch {} throw error; }
-  } catch {}
+  const current = await readInstallMarker(pyxis);
+  const parsed = current ? parseInstallMarker(current) : null;
+  if (!parsed || parsed.owner !== owner) {
+    fail('The map-install marker was reclaimed during installation; wait for the other installer to finish and retry');
+  }
+  const token = `PYXI 1 ${owner} ${Date.now()}`;
+  const handle = await pyxis.getFileHandle(INSTALL_MARKER_NAME);
+  const writable = await handle.createWritable({keepExistingData: false});
+  try { await writable.write(textEncoder.encode(token)); await writable.close(); }
+  catch (error) { try { await writable.abort(); } catch {} throw error; }
 }
 
 // Commit-time revalidation: the slot/style records were derived by

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -901,6 +901,22 @@ async function activateMapSet(pyxis,metadata,markerToken=null){
   await verifyActivationState(pyxis,mapSets,styleName,markerToken,{slotBytes,styleBytes});
   await writeVerified(mapSets,styleName,record);const installed=decodeActiveSelection(await fileBytes(mapSets,styleName));
   if(installed.version!==3||installed.mapSetId!==metadata.mapSetId||installed.packs[0].packId!==metadata.packId)fail('Style map-set verification failed');
+  // FINAL revalidation immediately before the slot write (round 13):
+  // the check above can sit a long time before the slot write (a
+  // stalled card slows the style write and read-back), so the claim
+  // may have expired in between -- a cross-producer could then
+  // legitimately reclaim it and commit, and our slot write would
+  // clobber its newer record. The slot record IS the active selection
+  // (what the device reads), so this is the clobber point: the slot is
+  // CAS'd against the derivation snapshot and the style is compared
+  // against the record we JUST wrote (a self-check that catches a
+  // cross-producer style write landing after ours). A missing/
+  // foreign/expired claim or any mismatch aborts before the slot byte
+  // is written; an abort here leaves either our own (newer) style
+  // record over the old slot (the documented style-first worst case,
+  // completed by the retry or device re-activation) or the cross
+  // producer's consistent pair.
+  await verifyActivationState(pyxis,mapSets,styleName,markerToken,{slotBytes,styleBytes:record});
   await writeVerified(pyxis,target,record);const selected=decodeActiveSelection(await fileBytes(pyxis,target));
   if(selected.version!==3||selected.mapSetId!==metadata.mapSetId||selected.packs[0].packId!==metadata.packId)fail('Active map-set verification failed');
   return {selectionFile:target,styleFile:styleName,enabledPacks:selected.packs.map(pack=>pack.packId)};

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -100,13 +100,22 @@ async function readInstallMarker(pyxis, name = INSTALL_MARKER_NAME) {
   catch (error) { if (error?.name === 'NotFoundError') return null; throw error; }
   return new TextDecoder('utf-8').decode(new Uint8Array(await (await handle.getFile()).arrayBuffer()));
 }
+export {readInstallMarker};
 
 // Respect the other producers' marker files. A fresh cross marker (the
 // CLI builder's, or the legacy shared one) means a live cross-producer
 // installer: refuse. A stale or malformed one is an abandoned install;
 // reclaim it only when reclaim is true (at acquire). Fresh cross
 // markers are never touched.
-async function checkCrossInstallers(pyxis, reclaim) {
+//
+// Reclaim is conditional: the file is re-read immediately before
+// deletion and a token that became fresh after the original check (the
+// owner renewed while we were deciding) aborts the reclaim instead of
+// deleting a live claim. A sub-millisecond renewal can still land
+// between that final read and the removeEntry; the owner's commit-time
+// verification requires its own marker, so such an overlap aborts on
+// its side instead of proceeding.
+export async function checkCrossInstallers(pyxis, reclaim) {
   for (const name of CROSS_INSTALL_MARKERS) {
     const raw = await readInstallMarker(pyxis, name);
     if (raw === null) continue;
@@ -114,7 +123,14 @@ async function checkCrossInstallers(pyxis, reclaim) {
     if (parsed && installMarkerIsFresh(parsed.epochMs)) {
       fail('Another map installer is already running on this card; wait for it to finish and retry');
     }
-    if (reclaim) { try { await pyxis.removeEntry(name); } catch {} }
+    if (reclaim) {
+      const confirm = await readInstallMarker(pyxis, name);
+      const confirmParsed = confirm !== null ? parseInstallMarker(confirm) : null;
+      if (confirmParsed && installMarkerIsFresh(confirmParsed.epochMs)) {
+        fail('Another map installer is already running on this card; wait for it to finish and retry');
+      }
+      try { await pyxis.removeEntry(name); } catch {}
+    }
   }
 }
 
@@ -201,16 +217,29 @@ export async function renewInstallMarker(pyxis, owner) {
 // already-published pack is kept; a retry re-derives from the new state and
 // converges (a pack no record names is device-harmless: the firmware only
 // reads packs enumerated in the active selection).
-async function verifyActivationState(pyxis, mapSets, styleName, markerToken, state) {
+export async function verifyActivationState(pyxis, mapSets, styleName, markerToken, state) {
   // Cross producers: a fresh marker in the CLI/legacy files means the
   // other installer started after we acquired.
   await checkCrossInstallers(pyxis, false);
   const marker = await readInstallMarker(pyxis);
-  if (marker !== null) {
-    // Compare by owner: our own marker may carry a renewed (newer) epoch.
+  if (markerToken !== null) {
+    // Our own marker is REQUIRED: a missing file means the claim was
+    // reclaimed from under us (a cross-reclaimer raced our last
+    // renewal) and the activation would proceed alongside the new
+    // holder. Abort instead.
+    const ours = parseInstallMarker(markerToken);
+    if (marker === null) {
+      fail('The install claim was reclaimed during installation; wait for the other installer to finish and retry');
+    }
     const parsed = parseInstallMarker(marker);
-    const ours = markerToken !== null ? parseInstallMarker(markerToken) : null;
-    if (parsed && installMarkerIsFresh(parsed.epochMs) && (ours === null || parsed.owner !== ours.owner)) {
+    if (!parsed || parsed.owner !== ours.owner) {
+      fail('The map-install marker was reclaimed during installation; wait for the other installer to finish and retry');
+    }
+  } else if (marker !== null) {
+    // No token was acquired (resume path without a marker): only a
+    // FRESH marker in our own file is a live foreign claim.
+    const parsed = parseInstallMarker(marker);
+    if (parsed && installMarkerIsFresh(parsed.epochMs)) {
       fail('Another map installer is running on this card; wait for it to finish and retry');
     }
   }

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -235,6 +235,12 @@ export async function verifyActivationState(pyxis, mapSets, styleName, markerTok
     if (!parsed || parsed.owner !== ours.owner) {
       fail('The map-install marker was reclaimed during installation; wait for the other installer to finish and retry');
     }
+    if (!installMarkerIsFresh(parsed.epochMs)) {
+      // The owner matches but the claim has aged out: a cross-producer
+      // is entitled to reclaim it right now, so committing against the
+      // pre-reclaim state would race the new holder. Abort instead.
+      fail('The install claim expired during installation; wait for the other installer to finish and retry');
+    }
   } else if (marker !== null) {
     // No token was acquired (resume path without a marker): only a
     // FRESH marker in our own file is a live foreign claim.

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1130,3 +1130,154 @@ def test_indexed_png_fast_path_accepts_in_range_and_rejects_out_of_range(tmp_pat
     put_tile(source_bad, 0, 0, 0, bad)
     with pytest.raises(tool.PackError, match="palette index out of range"):
         tool.build_map_pack(source_bad, tmp_path / "sd-bad", **metadata())
+
+
+def test_fresh_foreign_install_marker_is_refused_before_any_publication(
+        tmp_path: Path) -> None:
+    # A live cross-producer installer (the web flasher holds a Web Locks
+    # name, which this process's flock cannot see) is announced by a fresh
+    # on-disk marker in pyxis-map/. The builder must refuse up front,
+    # before staging tiles or publishing.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    (sd / "pyxis-map/.pyxis-installing").write_text(
+        "PYXI 1 web-deadbeef " + str(int(__import__("time").time() * 1000)))
+    with pytest.raises(tool.PackError, match="already running"):
+        tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+    # Nothing was staged, published, or activated: no pack, no
+    # records. The empty packs/ directory is created before the
+    # marker check and is harmless (the firmware reads only fixed
+    # named paths). The foreign marker is left in place: the other
+    # installer is live.
+    assert not (sd / "pyxis-map/packs/pack-a").exists()
+    assert not (sd / "pyxis-map/active-pack.0").exists()
+    assert not (sd / "pyxis-map/map-sets").exists()
+    # The foreign marker was not touched: the other installer is live.
+    assert (sd / "pyxis-map/.pyxis-installing").is_file()
+
+
+def test_stale_install_marker_is_reclaimed_and_released(tmp_path: Path) -> None:
+    # An abandoned installer (crashed builder, closed tab) leaves a stale
+    # marker. The builder reclaims it, installs, and releases it on the
+    # happy path.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    stale = int(__import__("time").time() * 1000) - 24 * 3600 * 1000
+    (sd / "pyxis-map/.pyxis-installing").write_text(f"PYXI 1 cli-{stale:x} {stale}")
+    tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+    assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    assert (sd / "pyxis-map/active-pack.0").is_file()
+    # The builder released its own marker; nothing is left behind.
+    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+
+
+def test_release_never_deletes_a_foreign_marker(tmp_path: Path) -> None:
+    # If a later installer reclaimed the marker after ours outlasted the
+    # TTL, release must leave the foreign claim alone.
+    tool = load_tool()
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    pyxis_fd = os.open(str(sd / "pyxis-map"), os.O_RDONLY)
+    try:
+        token = tool._acquire_install_marker(pyxis_fd)
+        # A later installer overwrote our claim.
+        foreign = "PYXI 1 web-cafebabe " + str(int(__import__("time").time() * 1000))
+        (sd / "pyxis-map/.pyxis-installing").write_text(foreign)
+        tool._release_install_marker(pyxis_fd, token)
+        assert (sd / "pyxis-map/.pyxis-installing").read_text() == foreign
+    finally:
+        os.close(pyxis_fd)
+
+
+def test_commit_time_revalidation_aborts_and_retry_converges(tmp_path: Path) -> None:
+    # Commit-time revalidation: if a cross-producer installer commits new
+    # activation state after our records were derived, the publication is
+    # aborted before any record write. The published pack is kept (device-
+    # harmless while no record names it) and a retry converges the records.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    real_activate = tool.activate_map_set
+    real_verify = tool._verify_activation_state_at
+
+    def racing_activate(pyxis_fd, **kwargs):
+        # One-shot: fires only on the first (aborted) run.
+        if raced["fired"]:
+            real_activate(pyxis_fd, **kwargs)
+            return
+        raced["fired"] = True
+        # Derivation happens inside the real activate_map_set (raw slot and
+        # style bytes are read there); run it once so the snapshot is
+        # taken, then simulate a concurrent cross-producer commit landing
+        # between that read and the commit-time revalidation. A real
+        # installer commits both records (style first, slot second), so the
+        # simulated competitor does the same.
+        real_activate(pyxis_fd, **kwargs)
+        assert tool._read_selection_at(pyxis_fd, "active-pack.1") is None
+        record2 = tool.encode_active_map_set(
+            generation=2, map_set_id="osm-bright",
+            attribution=policy["attribution"], pack_ids=["other-pack", "raced-pack"])
+        map_sets_fd = tool._mkdir_open(pyxis_fd, "map-sets")[0]
+        try:
+            tool._write_atomic_at(map_sets_fd, "osm-bright.pmas", record2)
+            tool._write_atomic_at(pyxis_fd, "active-pack.0", record2)
+        finally:
+            os.close(map_sets_fd)
+        # Now run the commit-time revalidation for real: it must see the
+        # changed slot bytes (our derivation snapshot had both slots empty)
+        # and abort before any record write.
+        map_sets_fd = tool._mkdir_open(pyxis_fd, "map-sets")[0]
+        token = tool._read_selection_at(pyxis_fd, tool._INSTALL_MARKER_NAME).decode("ascii")
+        try:
+            real_verify(pyxis_fd, map_sets_fd,
+                        slot_raw=[None, None], style_raw=None,
+                        style_name="osm-bright.pmas", marker_token=token)
+            raise AssertionError("revalidation accepted a changed slot")
+        finally:
+            os.close(map_sets_fd)
+
+    raced = {"fired": False}
+
+    tool.activate_map_set = racing_activate
+    try:
+        with pytest.raises(tool.PackError, match="changed during installation"):
+            tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+    finally:
+        tool.activate_map_set = real_activate
+    # The pack was published but no record was written by this run: the
+    # card holds exactly the raced installer's consistent gen-2 records
+    # (style first, slot second -- no split state from this aborted run).
+    assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    raced_record = tool.encode_active_map_set(
+        generation=2, map_set_id="osm-bright",
+        attribution=policy["attribution"], pack_ids=["other-pack", "raced-pack"])
+    assert (sd / "pyxis-map/active-pack.0").read_bytes() == raced_record
+    assert (sd / "pyxis-map/map-sets/osm-bright.pmas").read_bytes() == raced_record
+    assert not (sd / "pyxis-map/active-pack.1").exists()
+    # No marker is left behind.
+    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    # Retry: the pack verifies, records converge, and the new selection
+    # includes both packs with pack-a at the front.
+    result = tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                 attribution=policy["attribution"], source=policy["source"],
+                                 license=policy["license"], style="osm-bright", activate=True)
+    record3 = tool.decode_active_selection((sd / "pyxis-map/active-pack.1").read_bytes())
+    assert record3["generation"] == 3
+    assert record3["packs"] == ["pack-a", "other-pack", "raced-pack"]
+    assert Path(result) == sd / "pyxis-map" / "packs" / "pack-a"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1134,32 +1134,38 @@ def test_indexed_png_fast_path_accepts_in_range_and_rejects_out_of_range(tmp_pat
 
 def test_fresh_foreign_install_marker_is_refused_before_any_publication(
         tmp_path: Path) -> None:
-    # A live cross-producer installer (the web flasher holds a Web Locks
-    # name, which this process's flock cannot see) is announced by a fresh
-    # on-disk marker in pyxis-map/. The builder must refuse up front,
-    # before staging tiles or publishing.
+    # A live cross-producer installer (the web flasher holds a Web
+    # Locks name, which this process's flock cannot see) is announced
+    # by a fresh on-disk marker in pyxis-map/. The builder must refuse
+    # up front, before staging tiles or publishing. Both cross files
+    # are covered: the flasher's own file and the legacy shared one.
     tool = load_tool()
     source = tmp_path / "xyz"
     put_tile(source, 1, 0, 0)
     policy = tool.STYLE_POLICIES["osm-bright"]
-    sd = tmp_path / "sd"
-    (sd / "pyxis-map").mkdir(parents=True)
-    (sd / "pyxis-map/.pyxis-installing").write_text(
-        "PYXI 1 web-deadbeef " + str(int(__import__("time").time() * 1000)))
-    with pytest.raises(tool.PackError, match="already running"):
-        tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
-                            attribution=policy["attribution"], source=policy["source"],
-                            license=policy["license"], style="osm-bright", activate=True)
-    # Nothing was staged, published, or activated: no pack, no
-    # records. The empty packs/ directory is created before the
-    # marker check and is harmless (the firmware reads only fixed
-    # named paths). The foreign marker is left in place: the other
-    # installer is live.
-    assert not (sd / "pyxis-map/packs/pack-a").exists()
-    assert not (sd / "pyxis-map/active-pack.0").exists()
-    assert not (sd / "pyxis-map/map-sets").exists()
-    # The foreign marker was not touched: the other installer is live.
-    assert (sd / "pyxis-map/.pyxis-installing").is_file()
+    now_ms = int(__import__("time").time() * 1000)
+    for marker_name in ("web-deadbeef", "web-legacy"):
+        sd = tmp_path / f"sd-{marker_name}"
+        (sd / "pyxis-map").mkdir(parents=True)
+        marker_path = (sd / "pyxis-map" /
+                       (".pyxis-installing-web" if marker_name == "web-deadbeef"
+                        else ".pyxis-installing"))
+        marker_path.write_text(f"PYXI 1 {marker_name} {now_ms}")
+        with pytest.raises(tool.PackError, match="already running"):
+            tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+        # Nothing was staged, published, or activated: no pack, no
+        # records. The empty packs/ directory is created before the
+        # marker check and is harmless (the firmware reads only fixed
+        # named paths). The foreign marker is left in place: the other
+        # installer is live.
+        assert not (sd / "pyxis-map/packs/pack-a").exists()
+        assert not (sd / "pyxis-map/active-pack.0").exists()
+        assert not (sd / "pyxis-map/map-sets").exists()
+        # The foreign marker was not touched: the other installer is live.
+        assert marker_path.is_file()
+        assert marker_path.read_text() == f"PYXI 1 {marker_name} {now_ms}"
 
 
 def test_stale_install_marker_is_reclaimed_and_released(tmp_path: Path) -> None:
@@ -1173,14 +1179,14 @@ def test_stale_install_marker_is_reclaimed_and_released(tmp_path: Path) -> None:
     sd = tmp_path / "sd"
     (sd / "pyxis-map").mkdir(parents=True)
     stale = int(__import__("time").time() * 1000) - 24 * 3600 * 1000
-    (sd / "pyxis-map/.pyxis-installing").write_text(f"PYXI 1 cli-{stale:x} {stale}")
+    (sd / "pyxis-map/.pyxis-installing-cli").write_text(f"PYXI 1 cli-{stale:x} {stale}")
     tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
                         attribution=policy["attribution"], source=policy["source"],
                         license=policy["license"], style="osm-bright", activate=True)
     assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
     assert (sd / "pyxis-map/active-pack.0").is_file()
     # The builder released its own marker; nothing is left behind.
-    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
 
 
 def test_release_never_deletes_a_foreign_marker(tmp_path: Path) -> None:
@@ -1194,9 +1200,9 @@ def test_release_never_deletes_a_foreign_marker(tmp_path: Path) -> None:
         token = tool._acquire_install_marker(pyxis_fd)
         # A later installer overwrote our claim.
         foreign = "PYXI 1 web-cafebabe " + str(int(__import__("time").time() * 1000))
-        (sd / "pyxis-map/.pyxis-installing").write_text(foreign)
+        (sd / "pyxis-map/.pyxis-installing-cli").write_text(foreign)
         tool._release_install_marker(pyxis_fd, token)
-        assert (sd / "pyxis-map/.pyxis-installing").read_text() == foreign
+        assert (sd / "pyxis-map/.pyxis-installing-cli").read_text() == foreign
     finally:
         os.close(pyxis_fd)
 
@@ -1271,7 +1277,7 @@ def test_commit_time_revalidation_aborts_and_retry_converges(tmp_path: Path) -> 
     assert (sd / "pyxis-map/map-sets/osm-bright.pmas").read_bytes() == raced_record
     assert not (sd / "pyxis-map/active-pack.1").exists()
     # No marker is left behind.
-    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
     # Retry: the pack verifies, records converge, and the new selection
     # includes both packs with pack-a at the front.
     result = tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
@@ -1303,7 +1309,7 @@ def test_marker_is_renewed_during_long_publication_and_released_by_owner(
 
     def counting_renew(pyxis_fd, owner):
         original_renew(pyxis_fd, owner)
-        raw = (sd / "pyxis-map" / ".pyxis-installing").read_text()
+        raw = (sd / "pyxis-map" / ".pyxis-installing-cli").read_text()
         parts = raw.strip().split(" ")
         assert parts[0] == "PYXI" and parts[1] == "1" and parts[2] == owner
         renewals.append((owner, int(parts[3])))
@@ -1325,7 +1331,7 @@ def test_marker_is_renewed_during_long_publication_and_released_by_owner(
     # though renewals advanced the epoch past the acquired token.
     assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
     assert (sd / "pyxis-map/active-pack.0").is_file()
-    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
 
 
 def test_long_publication_marker_stays_live_past_ttl(
@@ -1354,12 +1360,12 @@ def test_long_publication_marker_stays_live_past_ttl(
     sd = tmp_path / "sd"
     (sd / "pyxis-map").mkdir(parents=True)
     stale = now_ms - 16 * 60 * 1000
-    (sd / "pyxis-map/.pyxis-installing").write_text(f"PYXI 1 cli-crash {stale}")
+    (sd / "pyxis-map/.pyxis-installing-cli").write_text(f"PYXI 1 cli-crash {stale}")
     tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
                         attribution=policy["attribution"], source=policy["source"],
                         license=policy["license"], style="osm-bright", activate=True)
     assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
-    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
     # Sanity on the TTL constant the boundary above used.
     assert ttl_ms == 900 * 1000
 
@@ -1379,27 +1385,98 @@ def test_marker_renewal_refuses_to_steal_reclaimed_claim(
     pyxis_fd = os.open(str(pyxis), os.O_RDONLY | os.O_DIRECTORY)
     try:
         # Producer B reclaims after our (producer A) marker aged out.
-        (pyxis / ".pyxis-installing").write_text(
+        (pyxis / ".pyxis-installing-cli").write_text(
             f"PYXI 1 cli-other {int(__import__('time').time() * 1000)}\n")
         # Renewing as a DIFFERENT owner must abort...
         with pytest.raises(tool.PackError, match="reclaimed during installation"):
             tool._renew_install_marker(pyxis_fd, "cli-us")
         # ...and must leave B's claim untouched.
-        raw = (pyxis / ".pyxis-installing").read_text().strip().split(" ")
+        raw = (pyxis / ".pyxis-installing-cli").read_text().strip().split(" ")
         assert raw[2] == "cli-other"
         # Renewing as the SAME owner is allowed and advances the epoch.
         before = int(raw[3])
         tool._renew_install_marker(pyxis_fd, "cli-other")
-        after = (pyxis / ".pyxis-installing").read_text().strip().split(" ")
+        after = (pyxis / ".pyxis-installing-cli").read_text().strip().split(" ")
         assert int(after[3]) >= before
         # A missing or corrupt marker is also refused (claim void), never
         # overwritten.
-        (pyxis / ".pyxis-installing").unlink()
+        (pyxis / ".pyxis-installing-cli").unlink()
         with pytest.raises(tool.PackError, match="reclaimed during installation"):
             tool._renew_install_marker(pyxis_fd, "cli-other")
-        assert not (pyxis / ".pyxis-installing").exists()
-        (pyxis / ".pyxis-installing").write_text("garbage\n")
+        assert not (pyxis / ".pyxis-installing-cli").exists()
+        (pyxis / ".pyxis-installing-cli").write_text("garbage\n")
         with pytest.raises(tool.PackError, match="reclaimed during installation"):
             tool._renew_install_marker(pyxis_fd, "cli-other")
     finally:
         os.close(pyxis_fd)
+
+
+def test_stale_cross_marker_is_reclaimed_at_acquire(tmp_path: Path) -> None:
+    # Round 11 (Greptile): an abandoned cross-producer install (a dead
+    # flasher tab or a legacy builder) leaves a stale marker in the
+    # other producer's file. The builder reclaims it at acquire so it
+    # cannot block a legitimate install, and its own file is released
+    # on completion.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    for legacy in (True, False):
+        sd = tmp_path / ("sd-legacy" if legacy else "sd-web")
+        (sd / "pyxis-map").mkdir(parents=True)
+        name = ".pyxis-installing" if legacy else ".pyxis-installing-web"
+        (sd / "pyxis-map" / name).write_text(
+            f"PYXI 1 web-crash {int(__import__('time').time() * 1000) - 16 * 60 * 1000}")
+        tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+        assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+        # The stale cross marker was reclaimed and our own released.
+        assert not (sd / "pyxis-map" / name).exists()
+        assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
+
+
+def test_fresh_cross_marker_during_install_aborts_at_renewal(
+        tmp_path: Path) -> None:
+    # Round 11 (Greptile): the acquire-time cross check cannot see an
+    # installer that starts DURING our install. The per-tile renewal
+    # re-checks the cross producers, so a fresh web marker that appears
+    # mid-publication aborts the install before any record is written --
+    # instead of continuing a conflicting publication.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    for x in range(30):
+        put_tile(source, 5, x, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    marker_path = sd / "pyxis-map" / ".pyxis-installing-web"
+
+    real_copy = tool.copy_tile
+    counts = {"n": 0}
+
+    def racing_copy(source_fd, tile, stage_fd, budget):
+        counts["n"] += 1
+        if counts["n"] == 12:
+            # The web flasher claims the card mid-publication.
+            marker_path.write_text(
+                f"PYXI 1 web-racer {int(__import__('time').time() * 1000)}")
+        return real_copy(source_fd, tile, stage_fd, budget)
+
+    tool.copy_tile = racing_copy
+    try:
+        with pytest.raises(tool.PackError, match="already running"):
+            tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+    finally:
+        tool.copy_tile = real_copy
+    # The abort happened before activation: no records (the empty
+    # map-sets/ directory is created up front and is harmless, like
+    # packs/), and the racer's marker is untouched (the other installer
+    # is live).
+    assert not (sd / "pyxis-map/active-pack.0").exists()
+    assert not (sd / "pyxis-map/map-sets/osm-bright.pmas").exists()
+    assert "web-racer" in marker_path.read_text()
+    # Our own claim is released even on the abort.
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -873,10 +873,13 @@ def test_activation_conflicting_slots_rejected_before_publishing(tmp_path: Path)
 
 
 def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
-    # A run interrupted between the style-record and slot-record commits
-    # leaves a published pack with stale records; re-running the same
-    # source must verify the existing pack and converge both records
-    # (Greploop round 3).
+    # A run interrupted between the slot-record and style-record commits
+    # leaves a published, ACTIVE pack (slot committed) with a missing style
+    # record. The firmware keeps serving tiles from the authoritative slot
+    # and tolerates the missing style record (MapStyleCatalog::discover
+    # synthesizes the candidate from the slot); re-running the same source
+    # verifies the existing pack and converges the style record
+    # (Greploop round 3 + round 4: slot-first ordering).
     tool = load_tool()
     policy = tool.STYLE_POLICIES["osm-bright"]
     sd = tmp_path / "sd"
@@ -888,12 +891,12 @@ def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
     interrupted = {"done": False}
 
     def interrupted_renameat2(oldfd, oldpath, newfd, newpath, flags):
-        # Interrupt only the slot-record replacement (flags 0, newpath is
-        # an active-pack slot). Pack staging (flags 1) and the style-record
-        # commit (flags 0, newpath osm-bright.pmas) must proceed so the
-        # failure lands between the two record commits.
-        if not interrupted["done"] and flags == 0 and newpath in (b"active-pack.0",
-                                                                  b"active-pack.1"):
+        # Interrupt only the style-record replacement (flags 0, newpath is
+        # the .pmas). Pack staging (flags 1) and the slot-record commit
+        # (flags 0, newpath an active-pack slot) must proceed so the
+        # failure lands between the two record commits, leaving the map
+        # active but the style record stale.
+        if not interrupted["done"] and flags == 0 and newpath.endswith(b".pmas"):
             interrupted["done"] = True
             raise OSError("injected interruption between record commits")
         return real_renameat2(oldfd, oldpath, newfd, newpath, flags)
@@ -908,53 +911,80 @@ def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
     finally:
         monkeypatch.undo()
 
-    # The pack published; the style record committed; the slot did not.
+    # The pack published and the authoritative slot committed; the style
+    # record did not. The map is therefore active, not broken.
     assert (sd / "pyxis-map/packs/resume-pack/manifest.pmp").is_file()
     style_path = sd / "pyxis-map/map-sets/osm-bright.pmas"
-    assert style_path.is_file()
-    assert not (sd / "pyxis-map/active-pack.0").exists()
-    assert not (sd / "pyxis-map/active-pack.1").exists()
+    assert not style_path.exists()
+    assert (sd / "pyxis-map/active-pack.0").read_bytes() is not None
 
     # Retry with the same source: the pack verifies byte-identical and
-    # the records converge.
+    # converges the style record. The retry writes the free slot
+    # (active-pack.1) at a higher generation than the interrupted first run
+    # left in active-pack.0, and the style record matches the authoritative
+    # (highest-generation) slot.
     result = tool.build_map_pack(source, sd, pack_id="resume-pack", name="R",
                                  attribution=policy["attribution"], source=policy["source"],
                                  license=policy["license"], style="osm-bright", activate=True)
     assert result == sd / "pyxis-map/packs/resume-pack"
-    slot_data = (sd / "pyxis-map/active-pack.0").read_bytes()
-    decoded = tool.decode_active_selection(slot_data)
-    assert decoded["packs"][0] == "resume-pack"
-    assert tool.decode_active_selection(style_path.read_bytes()) == decoded
-    assert not (sd / "pyxis-map/.pyxis-install-owner").exists()
+    slot0 = tool.decode_active_selection((sd / "pyxis-map/active-pack.0").read_bytes())
+    slot1 = tool.decode_active_selection((sd / "pyxis-map/active-pack.1").read_bytes())
+    authoritative = slot1 if slot1["generation"] > slot0["generation"] else slot0
+    style = tool.decode_active_selection(style_path.read_bytes())
+    assert style == authoritative
+    assert style["packs"][0] == "resume-pack"
+
+
+def _flock_holder(path: str) -> subprocess.Popen:
+    # Spawn a subprocess that takes an exclusive flock on the lock file and
+    # signals readiness over stdout. This is the only way to exercise a real
+    # concurrent lock holder: flock is a per-process kernel state, so a fake
+    # pid in a file cannot hold it.
+    code = (
+        "import fcntl, os, sys, time\n"
+        "fd = os.open(sys.argv[1], os.O_RDWR | os.O_CREAT, 0o644)\n"
+        "fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)\n"
+        "sys.stdout.write('ready\\n')\n"
+        "sys.stdout.flush()\n"
+        "time.sleep(60)\n"
+    )
+    return subprocess.Popen([sys.executable, "-c", code, path],
+                            stdout=subprocess.PIPE, text=True)
 
 
 def test_concurrent_activation_is_serialized_by_lock(tmp_path: Path) -> None:
     # A second builder cannot activate while the first holds the install
-    # lock; a crashed builder's stale lock is reclaimed (Greploop round 3).
+    # flock; when the holder exits, the kernel releases the lock and the
+    # build proceeds (Greploop round 3 + round 4: lock must be a real,
+    # race-free kernel primitive, not a pid file).
     tool = load_tool()
     policy = tool.STYLE_POLICIES["osm-bright"]
     sd = tmp_path / "sd"
     (sd / "pyxis-map").mkdir(parents=True)
+    lock_file = sd / "pyxis-map/.pyxis-install.lock"
     source = tmp_path / "xyz"
     put_tile(source, 1, 0, 0)
 
-    # Live lock holder: own pid in the lock file blocks the second build.
-    (sd / "pyxis-map/.pyxis-install-owner").write_bytes(str(os.getpid()).encode("ascii"))
-    with pytest.raises(tool.PackError, match="already running"):
-        tool.build_map_pack(source, sd, pack_id="locked-pack", name="L",
-                            attribution=policy["attribution"], source=policy["source"],
-                            license=policy["license"], style="osm-bright", activate=True)
-    assert not (sd / "pyxis-map/packs/locked-pack").exists()
+    holder = _flock_holder(str(lock_file))
+    try:
+        assert holder.stdout.readline().strip() == "ready"
+        with pytest.raises(tool.PackError, match="already running"):
+            tool.build_map_pack(source, sd, pack_id="locked-pack", name="L",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+        assert not (sd / "pyxis-map/packs/locked-pack").exists()
+    finally:
+        holder.terminate()
+        holder.wait()
 
-    # Stale lock: owner pid is dead, so it is reclaimed and the build proceeds.
-    (sd / "pyxis-map/.pyxis-install-owner").write_bytes(b"4294000000")
-    assert not tool._pid_alive(4294000000)
+    # Holder exited: the kernel released the flock, so the build now proceeds.
     result = tool.build_map_pack(source, sd, pack_id="locked-pack", name="L",
                                  attribution=policy["attribution"], source=policy["source"],
                                  license=policy["license"], style="osm-bright", activate=True)
     assert (sd / "pyxis-map/packs/locked-pack/manifest.pmp").is_file()
     assert (sd / "pyxis-map/active-pack.0").is_file()
-    assert not (sd / "pyxis-map/.pyxis-install-owner").exists()
+    # The lock file is persistent (never unlinked) -- see _install_lock_at.
+    assert lock_file.exists()
 
 
 def test_existing_pack_rejects_different_source(tmp_path: Path) -> None:

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import struct
 import subprocess
 import sys
+import time
 import zlib
 
 import pytest
@@ -1480,3 +1481,82 @@ def test_fresh_cross_marker_during_install_aborts_at_renewal(
     assert "web-racer" in marker_path.read_text()
     # Our own claim is released even on the abort.
     assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
+
+
+def test_cross_reclaim_refuses_when_owner_renews_between_check_and_delete(
+        tmp_path: Path) -> None:
+    # Round 12 (Greptile): reclamation is check-then-act. If the
+    # cross-installer renews while we are deciding, the delete would
+    # clobber a live claim. The conditional re-read must see the fresh
+    # token and abort instead of deleting.
+    tool = load_tool()
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    (sd / "pyxis-map").mkdir()
+    marker = sd / "pyxis-map/.pyxis-installing-web"
+    marker.write_text(f"PYXI 1 web-owner {int(time.time() * 1000) - 16 * 60 * 1000}\n")
+
+    real_read = tool._read_selection_at
+
+    def racing_read(parent_fd, name, _calls=[0]):
+        if name == ".pyxis-installing-web":
+            _calls[0] += 1
+            if _calls[0] == 2:
+                marker.write_text(f"PYXI 1 web-owner {int(time.time() * 1000)}\n")
+        return real_read(parent_fd, name)
+
+    tool._read_selection_at = racing_read
+    try:
+        pyxis_fd = os.open(str(sd / "pyxis-map"), os.O_RDONLY | os.O_DIRECTORY)
+    except OSError:
+        pyxis_fd = os.open(str(sd / "pyxis-map"), os.O_RDONLY)
+    try:
+        with pytest.raises(tool.PackError, match="another map installer is already running"):
+            tool._check_cross_installers(pyxis_fd, reclaim=True)
+        assert marker.exists()
+        assert tool._marker_is_fresh(
+            tool._parse_marker(marker.read_bytes())[1])
+    finally:
+        os.close(pyxis_fd)
+        tool._read_selection_at = real_read
+
+
+def test_commit_abort_when_own_marker_was_reclaimed(
+        tmp_path: Path) -> None:
+    # Round 12 (Greptile): a missing own marker at commit time means our
+    # claim was reclaimed from under us. Verification must abort, not
+    # proceed with the activation writes.
+    tool = load_tool()
+    sd = tmp_path / "sd"
+    sd.mkdir()
+    (sd / "pyxis-map").mkdir()
+    (sd / "pyxis-map/map-sets").mkdir()
+    token = "PYXI 1 cli-self 12345"
+    pyxis_fd = os.open(str(sd / "pyxis-map"), os.O_RDONLY | os.O_DIRECTORY)
+    map_sets_fd = os.open(str(sd / "pyxis-map/map-sets"), os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        # No marker file exists at all: the claim was reclaimed.
+        with pytest.raises(tool.PackError, match="reclaimed during installation"):
+            tool._verify_activation_state_at(
+                pyxis_fd, map_sets_fd,
+                slot_raw=[None, None], style_raw=None,
+                style_name="osm-bright.pmas", marker_token=token)
+        # A foreign owner in our own file: also an abort.
+        (sd / "pyxis-map/.pyxis-installing-cli").write_text(token.replace("cli-self", "cli-other") + "\n")
+        with pytest.raises(tool.PackError, match="reclaimed during installation"):
+            tool._verify_activation_state_at(
+                pyxis_fd, map_sets_fd,
+                slot_raw=[None, None], style_raw=None,
+                style_name="osm-bright.pmas", marker_token=token)
+        # Our own marker (any epoch: renewals advance it): passes the
+        # marker check; the slot/style re-reads against identical state
+        # still pass.
+        (sd / "pyxis-map/.pyxis-installing-cli").write_text(
+            f"PYXI 1 cli-self {int(time.time() * 1000)}\n")
+        tool._verify_activation_state_at(
+            pyxis_fd, map_sets_fd,
+            slot_raw=[None, None], style_raw=None,
+            style_name="osm-bright.pmas", marker_token=token)
+    finally:
+        os.close(pyxis_fd)
+        os.close(map_sets_fd)

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -900,13 +900,16 @@ def test_activation_exhausted_generation_rejected_before_publishing(tmp_path: Pa
 
 
 def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
-    # A run interrupted between the slot-record and style-record commits
-    # leaves a published, ACTIVE pack (slot committed) with a missing style
-    # record. The firmware keeps serving tiles from the authoritative slot
-    # and tolerates the missing style record (MapStyleCatalog::discover
-    # synthesizes the candidate from the slot); re-running the same source
-    # verifies the existing pack and converges the style record
-    # (Greploop round 3 + round 4: slot-first ordering).
+    # A run interrupted between the style-record commit and the slot-record
+    # commit leaves the style record current but the active slot not yet
+    # committed. Both recovery paths then converge forward: the CLI retry
+    # (this test) re-runs activation against the verified pack, and the
+    # firmware's device-side style re-activation
+    # (MapStyleCatalog::activate) resequences the current style record into
+    # the slot. The style record must never be older than the slot, because
+    # the device-side path would otherwise reseed the slot from stale
+    # composition and drop a newly installed pack (Greploop rounds 3-6:
+    # the web flasher's style-first order).
     tool = load_tool()
     policy = tool.STYLE_POLICIES["osm-bright"]
     sd = tmp_path / "sd"
@@ -918,12 +921,12 @@ def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
     interrupted = {"done": False}
 
     def interrupted_renameat2(oldfd, oldpath, newfd, newpath, flags):
-        # Interrupt only the style-record replacement (flags 0, newpath is
-        # the .pmas). Pack staging (flags 1) and the slot-record commit
-        # (flags 0, newpath an active-pack slot) must proceed so the
-        # failure lands between the two record commits, leaving the map
-        # active but the style record stale.
-        if not interrupted["done"] and flags == 0 and newpath.endswith(b".pmas"):
+        # Interrupt only the slot-record replacement (flags 0, newpath an
+        # active-pack slot). Pack staging (flags 1) and the style-record
+        # commit (flags 0, newpath the .pmas) must proceed so the failure
+        # lands between the two record commits: style record current, slot
+        # not yet committed.
+        if not interrupted["done"] and flags == 0 and newpath.startswith(b"active-pack"):
             interrupted["done"] = True
             raise OSError("injected interruption between record commits")
         return real_renameat2(oldfd, oldpath, newfd, newpath, flags)
@@ -938,28 +941,25 @@ def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
     finally:
         monkeypatch.undo()
 
-    # The pack published and the authoritative slot committed; the style
-    # record did not. The map is therefore active, not broken.
+    # The pack published and the style record committed; the slot did not.
+    # The style record is current (never older than the slot), so no
+    # recovery path can reseed the slot from stale data.
     assert (sd / "pyxis-map/packs/resume-pack/manifest.pmp").is_file()
     style_path = sd / "pyxis-map/map-sets/osm-bright.pmas"
-    assert not style_path.exists()
-    assert (sd / "pyxis-map/active-pack.0").read_bytes() is not None
+    assert style_path.exists()
+    style = tool.decode_active_selection(style_path.read_bytes())
+    assert style["packs"][0] == "resume-pack"
+    assert not (sd / "pyxis-map/active-pack.0").exists()
 
-    # Retry with the same source: the pack verifies byte-identical and
-    # converges the style record. The retry writes the free slot
-    # (active-pack.1) at a higher generation than the interrupted first run
-    # left in active-pack.0, and the style record matches the authoritative
-    # (highest-generation) slot.
+    # Retry with the same source: the pack verifies byte-identical and the
+    # slot converges to the style record's composition.
     result = tool.build_map_pack(source, sd, pack_id="resume-pack", name="R",
                                  attribution=policy["attribution"], source=policy["source"],
                                  license=policy["license"], style="osm-bright", activate=True)
     assert result == sd / "pyxis-map/packs/resume-pack"
-    slot0 = tool.decode_active_selection((sd / "pyxis-map/active-pack.0").read_bytes())
-    slot1 = tool.decode_active_selection((sd / "pyxis-map/active-pack.1").read_bytes())
-    authoritative = slot1 if slot1["generation"] > slot0["generation"] else slot0
-    style = tool.decode_active_selection(style_path.read_bytes())
-    assert style == authoritative
-    assert style["packs"][0] == "resume-pack"
+    slot = tool.decode_active_selection((sd / "pyxis-map/active-pack.0").read_bytes())
+    assert slot == tool.decode_active_selection(style_path.read_bytes())
+    assert slot["packs"][0] == "resume-pack"
 
 
 def _flock_holder(path: str) -> subprocess.Popen:

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -872,6 +872,115 @@ def test_activation_conflicting_slots_rejected_before_publishing(tmp_path: Path)
     assert not (sd / "pyxis-map/packs/conflict-pack").exists()
 
 
+def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
+    # A run interrupted between the style-record and slot-record commits
+    # leaves a published pack with stale records; re-running the same
+    # source must verify the existing pack and converge both records
+    # (Greploop round 3).
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+
+    real_renameat2 = tool._renameat2
+    interrupted = {"done": False}
+
+    def interrupted_renameat2(oldfd, oldpath, newfd, newpath, flags):
+        # Interrupt only the slot-record replacement (flags 0, newpath is
+        # an active-pack slot). Pack staging (flags 1) and the style-record
+        # commit (flags 0, newpath osm-bright.pmas) must proceed so the
+        # failure lands between the two record commits.
+        if not interrupted["done"] and flags == 0 and newpath in (b"active-pack.0",
+                                                                  b"active-pack.1"):
+            interrupted["done"] = True
+            raise OSError("injected interruption between record commits")
+        return real_renameat2(oldfd, oldpath, newfd, newpath, flags)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(tool, "_renameat2", interrupted_renameat2)
+    try:
+        with pytest.raises(tool.PackError, match="cannot atomically replace"):
+            tool.build_map_pack(source, sd, pack_id="resume-pack", name="R",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+    finally:
+        monkeypatch.undo()
+
+    # The pack published; the style record committed; the slot did not.
+    assert (sd / "pyxis-map/packs/resume-pack/manifest.pmp").is_file()
+    style_path = sd / "pyxis-map/map-sets/osm-bright.pmas"
+    assert style_path.is_file()
+    assert not (sd / "pyxis-map/active-pack.0").exists()
+    assert not (sd / "pyxis-map/active-pack.1").exists()
+
+    # Retry with the same source: the pack verifies byte-identical and
+    # the records converge.
+    result = tool.build_map_pack(source, sd, pack_id="resume-pack", name="R",
+                                 attribution=policy["attribution"], source=policy["source"],
+                                 license=policy["license"], style="osm-bright", activate=True)
+    assert result == sd / "pyxis-map/packs/resume-pack"
+    slot_data = (sd / "pyxis-map/active-pack.0").read_bytes()
+    decoded = tool.decode_active_selection(slot_data)
+    assert decoded["packs"][0] == "resume-pack"
+    assert tool.decode_active_selection(style_path.read_bytes()) == decoded
+    assert not (sd / "pyxis-map/.pyxis-install-owner").exists()
+
+
+def test_concurrent_activation_is_serialized_by_lock(tmp_path: Path) -> None:
+    # A second builder cannot activate while the first holds the install
+    # lock; a crashed builder's stale lock is reclaimed (Greploop round 3).
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+
+    # Live lock holder: own pid in the lock file blocks the second build.
+    (sd / "pyxis-map/.pyxis-install-owner").write_bytes(str(os.getpid()).encode("ascii"))
+    with pytest.raises(tool.PackError, match="already running"):
+        tool.build_map_pack(source, sd, pack_id="locked-pack", name="L",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+    assert not (sd / "pyxis-map/packs/locked-pack").exists()
+
+    # Stale lock: owner pid is dead, so it is reclaimed and the build proceeds.
+    (sd / "pyxis-map/.pyxis-install-owner").write_bytes(b"4294000000")
+    assert not tool._pid_alive(4294000000)
+    result = tool.build_map_pack(source, sd, pack_id="locked-pack", name="L",
+                                 attribution=policy["attribution"], source=policy["source"],
+                                 license=policy["license"], style="osm-bright", activate=True)
+    assert (sd / "pyxis-map/packs/locked-pack/manifest.pmp").is_file()
+    assert (sd / "pyxis-map/active-pack.0").is_file()
+    assert not (sd / "pyxis-map/.pyxis-install-owner").exists()
+
+
+def test_existing_pack_rejects_different_source(tmp_path: Path) -> None:
+    # Resume is only allowed for a byte-identical republish; a different
+    # source must fail before touching the pack or the records.
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    tool.build_map_pack(source, sd, pack_id="dup-pack", name="D",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"])
+    pack_before = (sd / "pyxis-map/packs/dup-pack/manifest.pmp").read_bytes()
+
+    different = tmp_path / "xyz2"
+    put_tile(different, 1, 0, 1)  # different tile -> different manifest
+    with pytest.raises(tool.PackError, match="does not match this source"):
+        tool.build_map_pack(different, sd, pack_id="dup-pack", name="D",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+    assert (sd / "pyxis-map/packs/dup-pack/manifest.pmp").read_bytes() == pack_before
+    assert not (sd / "pyxis-map/map-sets").exists()
+
+
 def test_decode_selection_handles_v1_and_v2(tmp_path: Path) -> None:
     tool = load_tool()
     # v1: 48 bytes, magic, version 1, len 48, generation, then id at 12..44

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -586,3 +586,265 @@ def test_post_commit_close_failure_is_typed_as_published(tmp_path: Path,
         tool.build_map_pack(source, output, **metadata())
     assert caught.value.published is True
     assert (output / "pyxis-map/packs/local-pack").is_dir()
+
+
+# --- PMPK v3 (indexless) + PMAS v3 (active map set) -------------------------
+
+def test_indexless_manifest_matches_js_flasher_byte_for_byte() -> None:
+    tool = load_tool()
+    fixture = bytes.fromhex(
+        "504d504b03001000d0000000000000001f776f726c642d6f736d2d6272696768742d7a30"
+        "2d7a392d323032363038303116576f726c64204f534d20427269676874207a302d7a392f"
+        "286329204f70656e4d617054696c657320286329204f70656e5374726565744d61702063"
+        "6f6e7472696275746f7273274f7865642773204d61702054696c6520446f776e6c6f6164"
+        "657220284f534d2042726967687429264f534d204f44624c3b207374796c652043432d"
+        "42592d342e302f4253442d332d436c6175736500096f460100e9a28313"
+    )
+    actual = tool.serialize_indexless_manifest(
+        pack_id="world-osm-bright-z0-z9-20260801",
+        name="World OSM Bright z0-z9",
+        attribution="(c) OpenMapTiles (c) OpenStreetMap contributors",
+        source="Oxed's Map Tile Downloader (OSM Bright)",
+        license="OSM ODbL; style CC-BY-4.0/BSD-3-Clause",
+        min_zoom=0,
+        max_zoom=9,
+        tile_count=83567,
+    )
+    assert actual == fixture
+    parsed = tool.parse_manifest(actual)
+    assert parsed["format_version"] == 3
+    assert parsed["tile_count"] == 83567
+    assert parsed["min_zoom"] == 0
+    assert parsed["max_zoom"] == 9
+    assert parsed["extents"] == [] and parsed["row_spans"] == []
+
+
+def test_indexless_manifest_rejects_bad_ranges() -> None:
+    tool = load_tool()
+    base = dict(pack_id="p", name="P", attribution="A", source="S", license="L")
+    with pytest.raises(tool.PackError, match="range or tile count"):
+        tool.serialize_indexless_manifest(min_zoom=3, max_zoom=1, tile_count=1, **base)
+    with pytest.raises(tool.PackError, match="range or tile count"):
+        tool.serialize_indexless_manifest(min_zoom=0, max_zoom=23, tile_count=1, **base)
+    with pytest.raises(tool.PackError, match="range or tile count"):
+        tool.serialize_indexless_manifest(min_zoom=0, max_zoom=2, tile_count=0, **base)
+
+
+def test_pmas_v3_matches_js_flasher_byte_for_byte() -> None:
+    tool = load_tool()
+    fixture = bytes.fromhex(
+        "504d415303007500070000000a6f736d2d6272696768742f286329204f70656e4d6170"
+        "54696c657320286329204f70656e5374726565744d617020636f6e7472696275746f72"
+        "73021f776f726c642d6f736d2d6272696768742d7a302d7a392d323032363038303108"
+        "76697267696e69619e5ec1bc"
+    )
+    actual = tool.encode_active_map_set(
+        generation=7,
+        map_set_id="osm-bright",
+        attribution="(c) OpenMapTiles (c) OpenStreetMap contributors",
+        pack_ids=["world-osm-bright-z0-z9-20260801", "virginia"],
+    )
+    assert actual == fixture
+    parsed = tool.parse_active_map_set(actual)
+    assert parsed["format_version"] == 3
+    assert parsed["generation"] == 7
+    assert parsed["map_set_id"] == "osm-bright"
+    assert parsed["packs"] == ["world-osm-bright-z0-z9-20260801", "virginia"]
+
+
+def test_pmas_rejects_duplicates_and_zero_generation() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="duplicate"):
+        tool.encode_active_map_set(generation=1, map_set_id="s", attribution="a",
+                                   pack_ids=["p", "p"])
+    with pytest.raises(tool.PackError, match="generation"):
+        tool.encode_active_map_set(generation=0, map_set_id="s", attribution="a",
+                                   pack_ids=["p"])
+    with pytest.raises(tool.PackError, match="packs"):
+        tool.encode_active_map_set(generation=1, map_set_id="s", attribution="a",
+                                   pack_ids=[])
+
+
+def test_style_install_emits_indexless_v3_and_is_validated(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    # Deliberately sparse: not a rectangle and not antimeridian, so v1 would fail.
+    for x, y in ((0, 0), (0, 3), (1, 1), (2, 2), (3, 0)):
+        put_tile(source, 2, x, y)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    built = tool.build_map_pack(
+        source, tmp_path / "sd", pack_id="world-osm-bright-z0-z9-20260801",
+        name="World OSM Bright z0-z9",
+        attribution=policy["attribution"], source=policy["source"],
+        license=policy["license"], style="osm-bright",
+    )
+    parsed = tool.validate_pack(built)
+    assert parsed["format_version"] == 3
+    assert parsed["tile_count"] == 5
+    assert parsed["min_zoom"] == 2 and parsed["max_zoom"] == 2
+
+
+def test_style_policy_mismatch_is_rejected(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    with pytest.raises(tool.PackError, match="style policy"):
+        tool.build_map_pack(source, tmp_path / "sd", pack_id="p", name="P",
+                            attribution="wrong", source="wrong", license="wrong",
+                            style="osm-bright")
+
+
+def test_sparse_beyond_span_cap_falls_back_to_indexless_v3(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    # Every zoom is a single column (x = 0) with an even-y (noncontiguous)
+    # set, so no zoom is a rectangle and the sparse path is required:
+    #   zoom 10: 512 tiles (even y), 512 single-tile row spans
+    #   zoom 9:  256 tiles (even y), 256 spans
+    # 768 row spans > MAX_ROW_SPANS (512), so v2 cannot represent it and the
+    # builder must fall back to an indexless v3 pack.
+    for y in range(0, 1024, 2):
+        put_tile(source, 10, 0, y)
+    for y in range(0, 512, 2):
+        put_tile(source, 9, 0, y)
+    built = tool.build_map_pack(source, tmp_path / "sd", sparse=True, **metadata())
+    parsed = tool.validate_pack(built)
+    assert parsed["format_version"] == 3
+    assert parsed["tile_count"] == 768
+    assert parsed["min_zoom"] == 9 and parsed["max_zoom"] == 10
+
+
+def test_activation_publishes_pmas_and_is_idempotent_reorder(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+    active = (sd / "pyxis-map/active-pack.0").read_bytes()
+    record = tool.decode_active_selection(active)
+    assert record["format_version"] == 3
+    assert record["generation"] == 1
+    assert record["map_set_id"] == "osm-bright"
+    assert record["packs"] == ["pack-a"]
+    style_record = (sd / "pyxis-map/map-sets/osm-bright.pmas").read_bytes()
+    assert style_record == active
+
+    # A second pack of the same style moves to the front, generation bumps.
+    source2 = tmp_path / "xyz2"
+    put_tile(source2, 1, 1, 1)
+    tool.build_map_pack(source2, sd, pack_id="pack-b", name="B",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+    # Generation 2 goes into the other slot.
+    active2 = (sd / "pyxis-map/active-pack.1").read_bytes()
+    record2 = tool.decode_active_selection(active2)
+    assert record2["generation"] == 2
+    assert record2["packs"] == ["pack-b", "pack-a"]
+    # The old slot keeps its record; the firmware picks the higher generation.
+    assert (sd / "pyxis-map/active-pack.0").read_bytes() == active
+    assert (sd / "pyxis-map/map-sets/osm-bright.pmas").read_bytes() == active2
+
+
+def test_activation_requires_style(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    with pytest.raises(tool.PackError, match="requires --style"):
+        tool.build_map_pack(source, tmp_path / "sd", **metadata(), activate=True)
+
+
+def test_decode_selection_handles_v1_and_v2(tmp_path: Path) -> None:
+    tool = load_tool()
+    # v1: 48 bytes, magic, version 1, len 48, generation, then id at 12..44
+    pack = b"v1pack"
+    v1 = bytearray(b"PMAS")
+    v1 += bytes([1, 0])
+    v1 += struct.pack("<H", 48)
+    v1 += struct.pack("<I", 5)
+    v1 += bytes([len(pack)])
+    v1 += pack
+    v1 += bytes(44 - len(v1))
+    v1 += struct.pack("<I", zlib.crc32(bytes(v1)))
+    got = tool.decode_active_selection(bytes(v1))
+    assert got["format_version"] == 1
+    assert got["packs"] == ["v1pack"]
+    assert got["generation"] == 5
+
+    # v2: magic, version 2, reserved 0, len, generation, then
+    # map-set id, attribution, pack count, and one pack with one span.
+    v2 = bytearray(b"PMAS")
+    v2 += bytes([2, 0])
+    body = bytearray()
+    body += bytes([6]) + b"mapset"   # map_set_id (identifier grammar: 3+ chars)
+    body += bytes([1]) + b"a"        # attribution
+    body += bytes([1])               # pack count
+    body += bytes([2]) + b"p1"       # pack id
+    body += struct.pack("<H", 1)     # span count
+    body += bytes([1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0])  # one span z1 y0 x0..1
+    total = 12 + len(body) + 4
+    v2 += struct.pack("<H", total)
+    v2 += struct.pack("<I", 9)
+    v2 += body
+    v2 += struct.pack("<I", zlib.crc32(bytes(v2)))
+    got2 = tool.decode_active_selection(bytes(v2))
+    assert got2["format_version"] == 2
+    assert got2["packs"] == ["p1"]
+    assert got2["generation"] == 9
+
+
+def test_unfilter_fast_path_matches_slow_path() -> None:
+    tool = load_tool()
+    import random as _random
+    _random.seed(1234)
+    # All-None-filter decode must equal the generic predictor loop output.
+    rows = bytearray()
+    for _ in range(256):
+        rows += b"\x00" + bytes(_random.getrandbits(8) for _ in range(768))
+    fast = tool._unfilter_png_rows(bytes(rows), 768, 3, "fast")
+    slow = tool._unfilter_png_rows(bytes(rows), 768, 3, "slow")
+    assert fast == slow
+    # A mixed-filter image must still take the correct generic path.
+    mixed = bytearray(rows)
+    mixed[0] = 2  # Up filter on first row: value == above (zero row) => same pixels
+    assert tool._unfilter_png_rows(bytes(mixed), 768, 3, "mixed") == fast
+
+
+def test_metadata_json_is_ignored_but_validated(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    (source / "metadata.json").write_text('{"maxZoom": 0}', encoding="utf-8")
+    built = tool.build_map_pack(source, tmp_path / "sd", **metadata())
+    parsed = tool.validate_pack(built)
+    assert parsed["tile_count"] == 1
+    assert not (built / "tiles/metadata.json").exists()
+
+    bad = tmp_path / "xyz-bad"
+    put_tile(bad, 0, 0, 0)
+    (bad / "metadata.json").write_text("not json", encoding="utf-8")
+    with pytest.raises(tool.PackError, match="metadata.json is not valid JSON"):
+        tool.build_map_pack(bad, tmp_path / "sd-bad", **metadata())
+
+
+def test_indexed_png_fast_path_accepts_in_range_and_rejects_out_of_range(tmp_path: Path) -> None:
+    tool = load_tool()
+    # 8-bit indexed, 2-entry palette, indices 0/1 only -> in range, must pass.
+    good = png_chunks([(b"IHDR", ihdr(color_type=3)), (b"PLTE", b"\x00\x00\x00" * 2),
+                       (b"IDAT", zlib.compress(b"".join(b"\x00" + b"\x01\x00" * 128 for _ in range(256)))),
+                       (b"IEND", b"")])
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0, good)
+    built = tool.build_map_pack(source, tmp_path / "sd", **metadata())
+    assert tool.validate_pack(built)["tile_count"] == 1
+
+    # Same tile but one pixel uses index 5 (>= 2 entries) -> must be rejected.
+    bad = png_chunks([(b"IHDR", ihdr(color_type=3)), (b"PLTE", b"\x00\x00\x00" * 2),
+                      (b"IDAT", zlib.compress(b"".join(b"\x00" + (b"\x05" + b"\x01" * 255) for _ in range(256)))),
+                      (b"IEND", b"")])
+    source_bad = tmp_path / "xyz-bad"
+    put_tile(source_bad, 0, 0, 0, bad)
+    with pytest.raises(tool.PackError, match="palette index out of range"):
+        tool.build_map_pack(source_bad, tmp_path / "sd-bad", **metadata())

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1281,3 +1281,84 @@ def test_commit_time_revalidation_aborts_and_retry_converges(tmp_path: Path) -> 
     assert record3["generation"] == 3
     assert record3["packs"] == ["pack-a", "other-pack", "raced-pack"]
     assert Path(result) == sd / "pyxis-map" / "packs" / "pack-a"
+
+
+def test_marker_is_renewed_during_long_publication_and_released_by_owner(
+        tmp_path: Path) -> None:
+    # Round 9: a publication can outlive the marker TTL (a full world pack
+    # on slow SD storage). The builder must renew its marker's epoch
+    # during the tile loop so the claim never ages out, and release must
+    # still work afterwards: release compares the owner, not the full
+    # token, because renewals advance the epoch.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    for x in range(30):
+        put_tile(source, 5, x, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+
+    renewals: list[tuple[str, int]] = []
+    original_renew = tool._renew_install_marker
+
+    def counting_renew(pyxis_fd, owner):
+        original_renew(pyxis_fd, owner)
+        raw = (sd / "pyxis-map" / ".pyxis-installing").read_text()
+        parts = raw.strip().split(" ")
+        assert parts[0] == "PYXI" and parts[1] == "1" and parts[2] == owner
+        renewals.append((owner, int(parts[3])))
+
+    tool._renew_install_marker = counting_renew
+    try:
+        tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+    finally:
+        tool._renew_install_marker = original_renew
+    # 30 tiles: one in-loop renewal at tile index 24 plus the final
+    # renewal after the last tile.
+    assert len(renewals) == 2, f"expected 2 renewals, got {len(renewals)}"
+    # The renewal kept our owner identity (release below depends on it).
+    owner = renewals[0][0]
+    assert owner.startswith("cli-")
+    # The install completed and the builder released its own marker even
+    # though renewals advanced the epoch past the acquired token.
+    assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    assert (sd / "pyxis-map/active-pack.0").is_file()
+    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+
+
+def test_long_publication_marker_stays_live_past_ttl(
+        tmp_path: Path) -> None:
+    # Round 9 (the actual race): a marker whose epoch has aged past the
+    # TTL is reclaimable ONLY if its owner stopped renewing (crashed).
+    # A live installer's heartbeat keeps the on-disk epoch fresh, so a
+    # second producer must refuse it. The observable contract:
+    #   stale + never renewed   -> reclaimed (abandoned install);
+    #   stale + renewed to now  -> refused (live installer).
+    # The second case is exactly what the tile-loop renewal produces: the
+    # on-disk epoch is always the last renewal, which is fresh by
+    # construction. Verify the decision boundary directly.
+    tool = load_tool()
+    now_ms = int(__import__("time").time() * 1000)
+    ttl_ms = tool._INSTALL_MARKER_TTL_SECONDS * 1000
+    # Aged 16 minutes: past the TTL.
+    assert not tool._marker_is_fresh(now_ms - 16 * 60 * 1000)
+    # Renewed just now (live owner's heartbeat): fresh again.
+    assert tool._marker_is_fresh(now_ms)
+    # And the reclaim path really keys off the on-disk epoch: a marker
+    # aged past the TTL with no renewals is reclaimable end-to-end.
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    stale = now_ms - 16 * 60 * 1000
+    (sd / "pyxis-map/.pyxis-installing").write_text(f"PYXI 1 cli-crash {stale}")
+    tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+    assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    assert not (sd / "pyxis-map/.pyxis-installing").exists()
+    # Sanity on the TTL constant the boundary above used.
+    assert ttl_ms == 900 * 1000

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -872,6 +872,33 @@ def test_activation_conflicting_slots_rejected_before_publishing(tmp_path: Path)
     assert not (sd / "pyxis-map/packs/conflict-pack").exists()
 
 
+def test_activation_exhausted_generation_rejected_before_publishing(tmp_path: Path) -> None:
+    # When the highest active slot is already at the maximum generation,
+    # activate_map_set rejects the activation. The preflight must reject it
+    # too, BEFORE the new pack is published -- otherwise the failure orphans
+    # the pack (Greploop round 5).
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    exhausted = tool.encode_active_map_set(generation=0xFFFFFFFF,
+                                           map_set_id="osm-bright",
+                                           attribution=policy["attribution"],
+                                           pack_ids=["existing-a"])
+    (sd / "pyxis-map/active-pack.0").write_bytes(exhausted)
+
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    with pytest.raises(tool.PackError, match="generation is exhausted"):
+        tool.build_map_pack(source, sd, pack_id="exhausted-pack", name="E",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+
+    # The exhausted slot is untouched and nothing was published.
+    assert (sd / "pyxis-map/active-pack.0").read_bytes() == exhausted
+    assert not (sd / "pyxis-map/packs/exhausted-pack").exists()
+
+
 def test_interrupted_activation_retry_converges_records(tmp_path: Path) -> None:
     # A run interrupted between the slot-record and style-record commits
     # leaves a published, ACTIVE pack (slot committed) with a missing style

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -756,6 +756,92 @@ def test_activation_requires_style(tmp_path: Path) -> None:
         tool.build_map_pack(source, tmp_path / "sd", **metadata(), activate=True)
 
 
+def _seed_style_pack(tool, tmp_path: Path, sd: Path, index: int, pack_id: str) -> None:
+    source = tmp_path / f"seed{index}"
+    put_tile(source, 1, index % 2, index % 2)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    tool.build_map_pack(source, sd, pack_id=pack_id, name=f"Seed {index}",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+
+
+def test_interrupted_activation_replacement_keeps_previous_records(tmp_path: Path,
+                                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulating a crash between the temp write and its rename must never
+    # truncate the previous style record or active slot (P1: non-atomic
+    # O_TRUNC replacement corrupts style discovery).
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    sd = tmp_path / "sd"
+    tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                        attribution=policy["attribution"], source=policy["source"],
+                        license=policy["license"], style="osm-bright", activate=True)
+    style_path = sd / "pyxis-map/map-sets/osm-bright.pmas"
+    slot_path = sd / "pyxis-map/active-pack.0"
+    style_before = style_path.read_bytes()
+    slot_before = slot_path.read_bytes()
+
+    real_renameat2 = tool._renameat2
+
+    def interrupted_renameat2(fd, src, dst, dirfd, flags):
+        # Interrupt only the record replacement (flags 0); pack staging
+        # (RENAME_NOREPLACE, flags 1) must proceed so the failure lands
+        # after publication, exactly like a crash mid-activation.
+        if flags == 0:
+            raise OSError("injected interruption before rename")
+        return real_renameat2(fd, src, dst, dirfd, flags)
+
+    monkeypatch.setattr(tool, "_renameat2", interrupted_renameat2)
+    source2 = tmp_path / "xyz2"
+    put_tile(source2, 1, 1, 1)
+    with pytest.raises(tool.PackError, match="cannot atomically replace"):
+        tool.build_map_pack(source2, sd, pack_id="pack-b", name="B",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+
+    # Previous records are byte-identical; no staging debris is left behind.
+    assert style_path.read_bytes() == style_before
+    assert slot_path.read_bytes() == slot_before
+    assert tool.decode_active_selection(style_before)["packs"] == ["pack-a"]
+    assert not list((sd / "pyxis-map/map-sets").glob(".osm-bright.pmas.tmp-*"))
+    assert not list((sd / "pyxis-map").glob("active-pack.1.tmp-*"))
+    # The just-published pack stays valid on disk; the failure is confined to
+    # the record publication, which a later run can repair.
+    assert (sd / "pyxis-map/packs/pack-b/manifest.pmp").is_file()
+
+
+def test_activation_ninth_distinct_pack_fails_before_publishing(tmp_path: Path) -> None:
+    # The firmware rejects PMAS records with more than MAX_PACKS entries, so
+    # the writer must validate the inherited composition before the new pack
+    # is permanently published -- otherwise the failure orphans the pack
+    # (P1: activation failure leaves orphan pack).
+    tool = load_tool()
+    assert tool.MAX_ACTIVE_PACKS == 8
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    for index in range(tool.MAX_ACTIVE_PACKS):
+        _seed_style_pack(tool, tmp_path, sd, index, f"seed-{index}")
+    style_path = sd / "pyxis-map/map-sets/osm-bright.pmas"
+    slots = [sd / f"pyxis-map/active-pack.{i}" for i in range(2)]
+    style_before = style_path.read_bytes()
+    slots_before = [slot.read_bytes() for slot in slots]
+    assert tool.decode_active_selection(style_before)["generation"] == tool.MAX_ACTIVE_PACKS
+
+    source = tmp_path / "ninth"
+    put_tile(source, 1, 0, 1)
+    with pytest.raises(tool.PackError, match="pack limit exceeded"):
+        tool.build_map_pack(source, sd, pack_id="ninth-pack", name="Ninth",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+
+    # No record was rewritten and the rejected pack was not published.
+    assert style_path.read_bytes() == style_before
+    assert [slot.read_bytes() for slot in slots] == slots_before
+    assert not (sd / "pyxis-map/packs/ninth-pack").exists()
+
+
 def test_decode_selection_handles_v1_and_v2(tmp_path: Path) -> None:
     tool = load_tool()
     # v1: 48 bytes, magic, version 1, len 48, generation, then id at 12..44

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1571,3 +1571,57 @@ def test_commit_abort_when_own_marker_was_reclaimed(
     finally:
         os.close(pyxis_fd)
         os.close(map_sets_fd)
+
+
+
+
+def test_expired_claim_between_style_and_slot_writes_aborts_before_slot_write(
+        tmp_path: Path) -> None:
+    # Round 13 (Greptile): the pre-write revalidation can sit a long
+    # time before the slot write (a stalled card slows the style
+    # write + read-back). If the claim EXPIRES in that gap, a
+    # cross-producer is entitled to reclaim it and commit, and our
+    # slot write would clobber its newer record. The FINAL
+    # revalidation (immediately before the slot write) must abort
+    # there: the style record may already be written (the documented
+    # style-first point), but the slot byte never lands.
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    real_fresh = tool._own_marker_is_fresh
+    calls = {"n": 0}
+
+    def flaky_fresh(raw):
+        calls["n"] += 1
+        # Call 1 = the pre-style verify (claim fresh); call 2 = the
+        # FINAL pre-slot verify (claim expired in the gap).
+        return calls["n"] == 1
+
+    tool._own_marker_is_fresh = flaky_fresh
+    try:
+        with pytest.raises(tool.PackError, match="expired|reclaimed|another map installer"):
+            tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                attribution=policy["attribution"], source=policy["source"],
+                                license=policy["license"], style="osm-bright", activate=True)
+    finally:
+        tool._own_marker_is_fresh = real_fresh
+    assert calls["n"] >= 2, "the final pre-slot revalidation ran"
+    # The style record was written (style-first); the slot records were
+    # NOT: the abort landed between the two writes, so no active
+    # selection from this run exists -- the card is device-safe (the
+    # device serves its current/absent slot; the newer style record is
+    # completed by the retry).
+    assert (sd / "pyxis-map/map-sets/osm-bright.pmas").is_file()
+    assert not (sd / "pyxis-map/active-pack.0").exists()
+    assert not (sd / "pyxis-map/active-pack.1").exists()
+    assert (sd / "pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    assert not (sd / "pyxis-map/.pyxis-installing-cli").exists()
+    # The retry re-derives and converges on a clean activation.
+    result = tool.build_map_pack(source, sd, pack_id="pack-a", name="A",
+                                 attribution=policy["attribution"], source=policy["source"],
+                                 license=policy["license"], style="osm-bright", activate=True)
+    record = tool.decode_active_selection((sd / "pyxis-map/active-pack.0").read_bytes())
+    assert record["packs"] == ["pack-a"]
+    assert Path(result) == sd / "pyxis-map" / "packs" / "pack-a"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -842,6 +842,36 @@ def test_activation_ninth_distinct_pack_fails_before_publishing(tmp_path: Path) 
     assert not (sd / "pyxis-map/packs/ninth-pack").exists()
 
 
+def test_activation_conflicting_slots_rejected_before_publishing(tmp_path: Path) -> None:
+    # Two active slots at the same generation with different content is a
+    # conflict activate_map_set refuses -- the preflight must refuse it too,
+    # before the new pack is permanently published (Greploop round 2).
+    tool = load_tool()
+    policy = tool.STYLE_POLICIES["osm-bright"]
+    sd = tmp_path / "sd"
+    (sd / "pyxis-map").mkdir(parents=True)
+    slot0 = tool.encode_active_map_set(generation=5, map_set_id="osm-bright",
+                                       attribution=policy["attribution"],
+                                       pack_ids=["existing-a"])
+    slot1 = tool.encode_active_map_set(generation=5, map_set_id="osm-bright",
+                                       attribution=policy["attribution"],
+                                       pack_ids=["existing-b"])
+    (sd / "pyxis-map/active-pack.0").write_bytes(slot0)
+    (sd / "pyxis-map/active-pack.1").write_bytes(slot1)
+
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    with pytest.raises(tool.PackError, match="conflicting active map-set records"):
+        tool.build_map_pack(source, sd, pack_id="conflict-pack", name="C",
+                            attribution=policy["attribution"], source=policy["source"],
+                            license=policy["license"], style="osm-bright", activate=True)
+
+    # The conflicting slots are untouched and nothing was published.
+    assert (sd / "pyxis-map/active-pack.0").read_bytes() == slot0
+    assert (sd / "pyxis-map/active-pack.1").read_bytes() == slot1
+    assert not (sd / "pyxis-map/packs/conflict-pack").exists()
+
+
 def test_decode_selection_handles_v1_and_v2(tmp_path: Path) -> None:
     tool = load_tool()
     # v1: 48 bytes, magic, version 1, len 48, generation, then id at 12..44

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1548,9 +1548,20 @@ def test_commit_abort_when_own_marker_was_reclaimed(
                 pyxis_fd, map_sets_fd,
                 slot_raw=[None, None], style_raw=None,
                 style_name="osm-bright.pmas", marker_token=token)
-        # Our own marker (any epoch: renewals advance it): passes the
-        # marker check; the slot/style re-reads against identical state
-        # still pass.
+        # An EXPIRED own marker (same owner, aged past the TTL): the
+        # claim is no longer protected from reclamation, so committing
+        # would race a reclaiming cross-producer. Abort instead.
+        # (Round 12, Greptile.)
+        (sd / "pyxis-map/.pyxis-installing-cli").write_text(
+            f"PYXI 1 cli-self {int(time.time() * 1000) - 16 * 60 * 1000}\n")
+        with pytest.raises(tool.PackError, match="claim expired during installation"):
+            tool._verify_activation_state_at(
+                pyxis_fd, map_sets_fd,
+                slot_raw=[None, None], style_raw=None,
+                style_name="osm-bright.pmas", marker_token=token)
+        # Our own FRESH marker (renewed just now): passes the marker
+        # check; the slot/style re-reads against identical state still
+        # pass.
         (sd / "pyxis-map/.pyxis-installing-cli").write_text(
             f"PYXI 1 cli-self {int(time.time() * 1000)}\n")
         tool._verify_activation_state_at(

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -1362,3 +1362,44 @@ def test_long_publication_marker_stays_live_past_ttl(
     assert not (sd / "pyxis-map/.pyxis-installing").exists()
     # Sanity on the TTL constant the boundary above used.
     assert ttl_ms == 900 * 1000
+
+
+def test_marker_renewal_refuses_to_steal_reclaimed_claim(
+        tmp_path: Path) -> None:
+    # Round 10 (Greptile): a blind heartbeat would let a stalled installer
+    # steal back a marker that a second producer LEGITIMATELY reclaimed
+    # after our TTL expired. The renewal must be ownership-checked:
+    # foreign owner -> abort (PackError), the foreign claim is left
+    # intact for the other installer to finish.
+    tool = load_tool()
+    card = tmp_path / "sd"
+    card.mkdir()
+    pyxis = card / "pyxis-map"
+    pyxis.mkdir()
+    pyxis_fd = os.open(str(pyxis), os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        # Producer B reclaims after our (producer A) marker aged out.
+        (pyxis / ".pyxis-installing").write_text(
+            f"PYXI 1 cli-other {int(__import__('time').time() * 1000)}\n")
+        # Renewing as a DIFFERENT owner must abort...
+        with pytest.raises(tool.PackError, match="reclaimed during installation"):
+            tool._renew_install_marker(pyxis_fd, "cli-us")
+        # ...and must leave B's claim untouched.
+        raw = (pyxis / ".pyxis-installing").read_text().strip().split(" ")
+        assert raw[2] == "cli-other"
+        # Renewing as the SAME owner is allowed and advances the epoch.
+        before = int(raw[3])
+        tool._renew_install_marker(pyxis_fd, "cli-other")
+        after = (pyxis / ".pyxis-installing").read_text().strip().split(" ")
+        assert int(after[3]) >= before
+        # A missing or corrupt marker is also refused (claim void), never
+        # overwritten.
+        (pyxis / ".pyxis-installing").unlink()
+        with pytest.raises(tool.PackError, match="reclaimed during installation"):
+            tool._renew_install_marker(pyxis_fd, "cli-other")
+        assert not (pyxis / ".pyxis-installing").exists()
+        (pyxis / ".pyxis-installing").write_text("garbage\n")
+        with pytest.raises(tool.PackError, match="reclaimed during installation"):
+            tool._renew_install_marker(pyxis_fd, "cli-other")
+    finally:
+        os.close(pyxis_fd)

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -1011,4 +1011,21 @@ test('commit-time verification aborts when the own marker is missing', async () 
   await assert.rejects(
     verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [null, null], styleBytes: null}),
     MapInstallerError, 'a reclaimed claim must abort the commit');
+  // Round 12 (Greptile): an EXPIRED own marker (same owner, aged past
+  // the TTL) is equally an abort: the claim is reclaimable right now,
+  // so committing would race a reclaiming cross-producer.
+  const writeMarker = async text => {
+    const h = await pyxis.getFileHandle(MARKER, {create: true});
+    const w = await h.createWritable({keepExistingData: false});
+    await w.write(new TextEncoder().encode(text));
+    await w.close();
+  };
+  await writeMarker(`PYXI 1 ${owner} ${Date.now() - 16 * 60 * 1000}`);
+  await assert.rejects(
+    verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [null, null], styleBytes: null}),
+    MapInstallerError, 'an expired claim must abort the commit');
+  // A FRESH own marker (renewed just now) passes the marker check and
+  // the unchanged slot/style re-reads.
+  await writeMarker(token);
+  await verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [null, null], styleBytes: null});
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -13,6 +13,7 @@ import {
   parseSparseManifest,
   resolveMuiStyleProfile,
   suggestMapIdentity,
+  MapInstallerError,
 } from '../../docs/flasher/js/map-installer.js';
 
 const PNG = Buffer.from(
@@ -143,6 +144,13 @@ class MemoryDirectoryHandle {
     const current = this.children.get(name);
     if (current) {
       if (current.kind !== 'file') throw new DOMException('type', 'TypeMismatchError');
+      // File System Access API: exclusive creation of an existing entry
+      // fails (FileExistsError). The install-marker protocol relies on it.
+      if (options.exclusive) {
+        const error = new Error('The file already exists.');
+        error.name = 'FileExistsError';
+        throw error;
+      }
       return current;
     }
     if (!options.create) throw new DOMException('missing', 'NotFoundError');
@@ -712,4 +720,113 @@ test('map-set capacity is checked before a ninth pack is published', async () =>
   await writable.close();
   await assert.rejects(installMuiZip({archive,rootDirectory:root,metadata:{...metadata,packId:'pack-nine',name:'Pack Nine'}}), /active map set/i);
   assert.equal(pyxis.children.has('packs'), false);
+});
+
+
+// --- Cross-producer install marker + commit-time revalidation (Greptile
+// round-7 P1). The CLI builder claims the same on-disk marker token; the
+// Web Locks name alone cannot coordinate with it. ---
+
+const MARKER = '.pyxis-installing';
+
+function freshMarker(owner = 'cli-0') {
+  return new TextEncoder().encode(`PYXI 1 ${owner} ${Date.now()}`);
+}
+
+test('a fresh foreign install marker is refused before any record is written', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const originalMarker = freshMarker('cli-0');
+  const marker = new MemoryFileHandle(MARKER, root.log);
+  marker.bytes = originalMarker;
+  pyxis.children.set(MARKER, marker);
+
+  await assert.rejects(
+    installMuiZip({archive, rootDirectory: root, metadata}),
+    /another map installer is already running/i,
+  );
+  // Nothing was published or activated; the foreign marker is untouched.
+  assert.equal(pyxis.children.has(metadata.packId), false);
+  assert.equal(pyxis.children.has('map-sets'), false);
+  assert.equal(pyxis.children.has('active-pack.0'), false);
+  assert.deepEqual([...marker.bytes], [...originalMarker]);
+});
+
+test('a stale install marker is reclaimed and the marker is released on success', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const marker = new MemoryFileHandle(MARKER, root.log);
+  marker.bytes = new TextEncoder().encode(`PYXI 1 cli-0 ${Date.now() - 24 * 60 * 60 * 1000}`);
+  pyxis.children.set(MARKER, marker);
+
+  const result = await installMuiZip({archive, rootDirectory: root, metadata});
+  assert.equal(result.tileCount, 1);
+  assert.equal(pyxis.children.has(MARKER), false);
+});
+
+test('activation aborts when a cross-producer commit lands before the record writes, then retry converges', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const mapSets = await pyxis.getDirectoryHandle('map-sets', {create: true});
+  const seed = (directory, name, bytes) => {
+    const file = new MemoryFileHandle(name, root.log);
+    file.bytes = bytes;
+    directory.children.set(name, file);
+    return file;
+  };
+  const gen1 = encodeActiveMapSet({generation: 1, mapSetId: metadata.mapSetId, attribution: metadata.attribution, packs: [{packId: 'old'}]});
+  seed(mapSets, `${metadata.mapSetId}.pmas`, gen1);
+  const slot1 = seed(pyxis, 'active-pack.0', gen1);
+
+  // Deterministic seam: active-pack.0 is read plainly (no create) twice per
+  // prepare pass -- once by readSelection, once by the raw slot snapshot --
+  // and the two prepare passes (installMapPack, then activateMapSet) are
+  // followed by the commit-time verifyActivationState re-read. That is the
+  // fifth plain read overall; inject the racer's commit right before it,
+  // i.e. between the snapshot derive and its revalidation.
+  let plainSlotReads = 0;
+  const realGetFileHandle = pyxis.getFileHandle.bind(pyxis);
+  pyxis.getFileHandle = async (name, options) => {
+    if (name === 'active-pack.0' && !(options && options.create)) plainSlotReads += 1;
+    if (name === 'active-pack.0' && !(options && options.create) && plainSlotReads === 5) {
+      const gen2 = encodeActiveMapSet({generation: 2, mapSetId: metadata.mapSetId, attribution: metadata.attribution, packs: [{packId: 'other'}, {packId: 'old'}]});
+      slot1.bytes = gen2;
+      seed(mapSets, `${metadata.mapSetId}.pmas`, gen2);
+    }
+    return realGetFileHandle(name, options);
+  };
+  try {
+    await assert.rejects(
+      installMuiZip({archive, rootDirectory: root, metadata}),
+      /changed during installation/i,
+    );
+    // The raced state is intact (no record was written over it) and our
+    // pack stays published under packs/ -- device-harmless until a record
+    // names it.
+    const packsDir = pyxis.children.get('packs');
+    assert.ok(packsDir, 'packs directory exists');
+    assert.equal(packsDir.children.has(metadata.packId), true);
+    const raced = await decodeActiveSelection(pyxis.children.get('active-pack.0').bytes);
+    assert.equal(raced.generation, 2);
+    assert.deepEqual(raced.packs.map(pack => pack.packId), ['other', 'old']);
+    const racedStyle = await decodeActiveSelection(mapSets.children.get(`${metadata.mapSetId}.pmas`).bytes);
+    assert.equal(racedStyle.generation, 2);
+    assert.equal(pyxis.children.has(MARKER), false, 'marker released even on abort');
+  } finally {
+    pyxis.getFileHandle = realGetFileHandle;
+  }
+  // The retry re-derives from the gen-2 state and converges to generation
+  // 3 in the free slot (the racer's gen-2 record keeps active-pack.0).
+  const retried = await installMuiZip({archive, rootDirectory: root, metadata});
+  assert.equal(retried.tileCount, 1);
+  const finalSlots = ['active-pack.0', 'active-pack.1']
+    .map(name => pyxis.children.get(name))
+    .filter(Boolean)
+    .map(handle => decodeActiveSelection(handle.bytes));
+  const newest = finalSlots.sort((left, right) => right.generation - left.generation)[0];
+  assert.equal(newest.generation, 3);
+  assert.deepEqual(newest.packs.map(pack => pack.packId), [metadata.packId, 'other', 'old']);
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -730,7 +730,7 @@ test('map-set capacity is checked before a ninth pack is published', async () =>
 // round-7 P1). The CLI builder claims the same on-disk marker token; the
 // Web Locks name alone cannot coordinate with it. ---
 
-const MARKER = '.pyxis-installing';
+const MARKER = '.pyxis-installing-web'; // this producer's own marker file
 
 function freshMarker(owner = 'cli-0') {
   return new TextEncoder().encode(`PYXI 1 ${owner} ${Date.now()}`);
@@ -738,22 +738,27 @@ function freshMarker(owner = 'cli-0') {
 
 test('a fresh foreign install marker is refused before any record is written', async () => {
   const archive = storedZip([['2/1/1.png', PNG]]);
-  const root = new MemoryDirectoryHandle('sd');
-  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
-  const originalMarker = freshMarker('cli-0');
-  const marker = new MemoryFileHandle(MARKER, root.log);
-  marker.bytes = originalMarker;
-  pyxis.children.set(MARKER, marker);
+  // Both cross-producer files must refuse: the CLI builder's own file
+  // and the legacy shared marker (old producers). Fresh markers are
+  // never touched: the other installer is live.
+  for (const foreignName of ['.pyxis-installing-cli', '.pyxis-installing']) {
+    const root = new MemoryDirectoryHandle('sd');
+    const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+    const originalMarker = freshMarker('cli-0');
+    const marker = new MemoryFileHandle(foreignName, root.log);
+    marker.bytes = originalMarker;
+    pyxis.children.set(foreignName, marker);
 
-  await assert.rejects(
-    installMuiZip({archive, rootDirectory: root, metadata}),
-    /another map installer is already running/i,
-  );
-  // Nothing was published or activated; the foreign marker is untouched.
-  assert.equal(pyxis.children.has(metadata.packId), false);
-  assert.equal(pyxis.children.has('map-sets'), false);
-  assert.equal(pyxis.children.has('active-pack.0'), false);
-  assert.deepEqual([...marker.bytes], [...originalMarker]);
+    await assert.rejects(
+      installMuiZip({archive, rootDirectory: root, metadata}),
+      /another map installer is already running/i,
+    );
+    // Nothing was published or activated; the foreign marker is untouched.
+    assert.equal(pyxis.children.has(metadata.packId), false);
+    assert.equal(pyxis.children.has('map-sets'), false);
+    assert.equal(pyxis.children.has('active-pack.0'), false);
+    assert.deepEqual([...marker.bytes], [...originalMarker]);
+  }
 });
 
 test('a stale install marker is reclaimed and the marker is released on success', async () => {
@@ -784,17 +789,19 @@ test('activation aborts when a cross-producer commit lands before the record wri
   seed(mapSets, `${metadata.mapSetId}.pmas`, gen1);
   const slot1 = seed(pyxis, 'active-pack.0', gen1);
 
-  // Deterministic seam: active-pack.0 is read plainly (no create) twice per
-  // prepare pass -- once by readSelection, once by the raw slot snapshot --
-  // and the two prepare passes (installMapPack, then activateMapSet) are
-  // followed by the commit-time verifyActivationState re-read. That is the
-  // fifth plain read overall; inject the racer's commit right before it,
-  // i.e. between the snapshot derive and its revalidation.
+  // Deterministic seam: prepareActiveMapSet now snapshots the raw slot
+  // bytes first and derives the decoded records FROM that same snapshot
+  // (round 11: no separate decode read), so active-pack.0 is read
+  // plainly once per prepare pass -- the two prepare passes
+  // (installMapPack, then activateMapSet) are followed by the
+  // commit-time verifyActivationState re-read. That is the third plain
+  // read overall; inject the racer's commit right before it, i.e.
+  // between the snapshot derive and its revalidation.
   let plainSlotReads = 0;
   const realGetFileHandle = pyxis.getFileHandle.bind(pyxis);
   pyxis.getFileHandle = async (name, options) => {
     if (name === 'active-pack.0' && !(options && options.create)) plainSlotReads += 1;
-    if (name === 'active-pack.0' && !(options && options.create) && plainSlotReads === 5) {
+    if (name === 'active-pack.0' && !(options && options.create) && plainSlotReads === 3) {
       const gen2 = encodeActiveMapSet({generation: 2, mapSetId: metadata.mapSetId, attribution: metadata.attribution, packs: [{packId: 'other'}, {packId: 'old'}]});
       slot1.bytes = gen2;
       seed(mapSets, `${metadata.mapSetId}.pmas`, gen2);
@@ -845,14 +852,14 @@ test('renewing a live marker advances the epoch but keeps the owner', async () =
   const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
   const owner = `web-${Date.now().toString(16)}`;
   const token = `PYXI 1 ${owner} ${Date.now() - 16 * 60 * 1000}`; // 16 minutes old: past TTL
-  const handle = await pyxis.getFileHandle('.pyxis-installing', {create: true, exclusive: true});
+  const handle = await pyxis.getFileHandle(MARKER, {create: true, exclusive: true});
   const writable = await handle.createWritable({keepExistingData: false});
   await writable.write(new TextEncoder().encode(token));
   await writable.close();
   assert.equal(installMarkerIsFresh(Date.now() - 16 * 60 * 1000), false, '16 minutes old is past the TTL');
   // The heartbeat rewrites the marker with a fresh epoch, same owner.
   await renewInstallMarker(pyxis, owner);
-  const renewed = await pyxis.getFileHandle('.pyxis-installing');
+  const renewed = await pyxis.getFileHandle(MARKER);
   const text = new TextDecoder('utf-8').decode(new Uint8Array(await (await renewed.getFile()).arrayBuffer()));
   const parsed = parseInstallMarker(text);
   assert.equal(parsed.owner, owner, 'renewal keeps the owner identity');
@@ -870,12 +877,12 @@ test('marker renewal refuses to steal a reclaimed claim', async () => {
   const root = new MemoryDirectoryHandle('sd');
   const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
   const writeMarker = async text => {
-    const writable = await (await pyxis.getFileHandle('.pyxis-installing', {create: true})).createWritable({keepExistingData: false});
+    const writable = await (await pyxis.getFileHandle(MARKER, {create: true})).createWritable({keepExistingData: false});
     await writable.write(new TextEncoder().encode(text));
     await writable.close();
   };
   const readMarker = async () => {
-    let handle = null; try { handle = await pyxis.getFileHandle('.pyxis-installing'); } catch { return null; }
+    let handle = null; try { handle = await pyxis.getFileHandle(MARKER); } catch { return null; }
     const file = await handle.getFile();
     return new TextDecoder('utf-8').decode(new Uint8Array(await file.arrayBuffer()));
   };
@@ -893,9 +900,42 @@ test('marker renewal refuses to steal a reclaimed claim', async () => {
   assert.equal(renewed.owner, 'cli-other');
   assert.ok(installMarkerIsFresh(renewed.epochMs));
   // Missing or corrupt marker: refused, never overwritten.
-  await pyxis.removeEntry('.pyxis-installing');
+  await pyxis.removeEntry(MARKER);
   await assert.rejects(() => renewInstallMarker(pyxis, 'cli-other'));
   assert.equal(await readMarker(), null);
   await writeMarker('garbage');
   await assert.rejects(() => renewInstallMarker(pyxis, 'cli-other'));
+});
+
+
+// --- Round 11 (Greptile): the acquire-time cross check cannot see an
+// installer that starts DURING our install. The per-tile heartbeat
+// re-checks the cross producers, so a fresh CLI marker that appears
+// mid-publication aborts the install before any record is written.
+test('a fresh cross marker during installation aborts at renewal', async () => {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle('sd');
+  let planted = false;
+  await assert.rejects(
+    installMuiZip({
+      archive, rootDirectory: root, metadata,
+      onProgress: state => {
+        if (!planted && state.phase === 'write' && state.completed === 1) {
+          planted = true;
+          const pyxis = root.children.get('pyxis-map');
+          const marker = new MemoryFileHandle('.pyxis-installing-cli', root.log);
+          marker.bytes = freshMarker('cli-racer');
+          pyxis.children.set('.pyxis-installing-cli', marker);
+        }
+      },
+    }),
+    /another map installer is already running/i,
+  );
+  const pyxis = root.children.get('pyxis-map');
+  // Aborted before activation: no records; the racer's marker is
+  // untouched (the other installer is live) and our own claim released.
+  assert.equal(pyxis.children.has('active-pack.0'), false);
+  assert.equal(pyxis.children.has('map-sets/osm-bright.pmas'), false);
+  assert.equal(pyxis.children.has('.pyxis-installing-cli'), true);
+  assert.equal(pyxis.children.has(MARKER), false, 'our marker released on abort');
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -9,8 +9,11 @@ import {
   encodeActiveMapSet,
   getMuiStyleProfile,
   inspectMuiZip,
+  installMarkerIsFresh,
   installMuiZip,
+  parseInstallMarker,
   parseSparseManifest,
+  renewInstallMarker,
   resolveMuiStyleProfile,
   suggestMapIdentity,
   MapInstallerError,
@@ -829,4 +832,30 @@ test('activation aborts when a cross-producer commit lands before the record wri
   const newest = finalSlots.sort((left, right) => right.generation - left.generation)[0];
   assert.equal(newest.generation, 3);
   assert.deepEqual(newest.packs.map(pack => pack.packId), [metadata.packId, 'other', 'old']);
+});
+
+
+// --- Round 9: marker heartbeat. A long publication must renew its own
+// marker so the claim never ages out mid-install; release and
+// commit-time verification must still recognize the owner after the
+// epoch has advanced.
+
+test('renewing a live marker advances the epoch but keeps the owner', async () => {
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const owner = `web-${Date.now().toString(16)}`;
+  const token = `PYXI 1 ${owner} ${Date.now() - 16 * 60 * 1000}`; // 16 minutes old: past TTL
+  const handle = await pyxis.getFileHandle('.pyxis-installing', {create: true, exclusive: true});
+  const writable = await handle.createWritable({keepExistingData: false});
+  await writable.write(new TextEncoder().encode(token));
+  await writable.close();
+  assert.equal(installMarkerIsFresh(Date.now() - 16 * 60 * 1000), false, '16 minutes old is past the TTL');
+  // The heartbeat rewrites the marker with a fresh epoch, same owner.
+  await renewInstallMarker(pyxis, owner);
+  const renewed = await pyxis.getFileHandle('.pyxis-installing');
+  const text = new TextDecoder('utf-8').decode(new Uint8Array(await (await renewed.getFile()).arrayBuffer()));
+  const parsed = parseInstallMarker(text);
+  assert.equal(parsed.owner, owner, 'renewal keeps the owner identity');
+  assert.ok(parsed.epochMs >= Date.now() - 1000, 'renewal refreshes the epoch');
+  assert.ok(installMarkerIsFresh(parsed.epochMs), 'a renewed marker is live again');
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -939,3 +939,76 @@ test('a fresh cross marker during installation aborts at renewal', async () => {
   assert.equal(pyxis.children.has('.pyxis-installing-cli'), true);
   assert.equal(pyxis.children.has(MARKER), false, 'our marker released on abort');
 });
+
+
+// --- Round 12 (Greptile): the cross-marker reclaim is a check-then-act,
+// and the owner can renew in the window. Reclaim must therefore be
+// conditional: a token that became fresh between the original check and
+// the deletion aborts the reclaim (the claim is live again), and the
+// owner's commit-time verification must REQUIRE its own marker -- a
+// missing claim is an abort, not a pass.
+
+import {checkCrossInstallers, readInstallMarker, verifyActivationState} from '../../docs/flasher/js/map-installer.js';
+
+test('reclaim aborts when the owner renews between check and delete', async () => {
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const staleToken = `PYXI 1 cli-owner ${Date.now() - 16 * 60 * 1000}`;
+  const freshToken = `PYXI 1 cli-owner ${Date.now()}`;
+  const writeMarker = async text => {
+    // Overwrite semantics (the seam simulates the owner's renewal
+    // rewrite): no exclusive, since the file already holds the stale
+    // token.
+    const handle = await pyxis.getFileHandle('.pyxis-installing-cli', {create: true});
+    const writable = await handle.createWritable({keepExistingData: false});
+    await writable.write(new TextEncoder().encode(text));
+    await writable.close();
+  };
+  await writeMarker(staleToken);
+  // Deterministic seam: each marker read goes through
+  // pyxis.getFileHandle. The first call is the original check (stale
+  // token); the owner's renewal lands before the second call (the
+  // conditional re-read), which must see the fresh token and abort
+  // instead of deleting.
+  let readCount = 0;
+  const realGet = pyxis.getFileHandle.bind(pyxis);
+  pyxis.getFileHandle = async (name, options) => {
+    // Count plain reads only: the marker writes (create:true) are the
+    // test's own seam writes, not reclaim reads.
+    if (name === '.pyxis-installing-cli' && !options?.create) {
+      readCount += 1;
+      if (readCount === 2) await writeMarker(freshToken);
+    }
+    return realGet(name, options);
+  };
+  const realRemove = pyxis.removeEntry.bind(pyxis);
+  let removed = false;
+  pyxis.removeEntry = async name => { removed = true; return realRemove(name); };
+  try {
+    await assert.rejects(checkCrossInstallers(pyxis, true), MapInstallerError, 'renewal must abort the reclaim');
+    assert.equal(removed, false, 'the renewed live claim must not be deleted');
+    const surviving = await readInstallMarker(pyxis, '.pyxis-installing-cli');
+    assert.equal(surviving, freshToken, 'the renewed token survives the reclaim attempt');
+  } finally {
+    pyxis.removeEntry = realRemove;
+    pyxis.getFileHandle = realGet;
+  }
+});
+
+test('commit-time verification aborts when the own marker is missing', async () => {
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const mapSets = await pyxis.getDirectoryHandle('map-sets', {create: true});
+  const owner = `web-${Date.now().toString(16)}`;
+  const token = `PYXI 1 ${owner} ${Date.now()}`;
+  // The claim existed at acquire time but a cross-reclaimer deleted it
+  // after our last renewal: verify must abort, not proceed.
+  const handle = await pyxis.getFileHandle(MARKER, {create: true, exclusive: true});
+  const writable = await handle.createWritable({keepExistingData: false});
+  await writable.write(new TextEncoder().encode(token));
+  await writable.close();
+  await pyxis.removeEntry(MARKER);
+  await assert.rejects(
+    verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [null, null], styleBytes: null}),
+    MapInstallerError, 'a reclaimed claim must abort the commit');
+});

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -1029,3 +1029,60 @@ test('commit-time verification aborts when the own marker is missing', async () 
   await writeMarker(token);
   await verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [null, null], styleBytes: null});
 });
+
+
+// --- Round 13 (Greptile): the pre-write revalidation sits a long time
+// before the slot write (a stalled card slows the style write +
+// read-back). If the claim expires in that gap, a cross-producer is
+// entitled to reclaim it and commit, and the slot write would clobber
+// its newer record. activateMapSet therefore re-verifies IMMEDIATELY
+// before the slot write: the slot is still CAS'd against the
+// derivation snapshot, and the style is compared against the record
+// that was just written. An expired claim must abort THERE.
+test('an expired claim at the final pre-slot revalidation aborts the slot write', async () => {
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const mapSets = await pyxis.getDirectoryHandle('map-sets', {create: true});
+  const gen1 = encodeActiveMapSet({generation: 1, mapSetId: metadata.mapSetId, attribution: metadata.attribution, packs: [{packId: 'old'}]});
+  const slot1 = await (await pyxis.getFileHandle('active-pack.0', {create: true})).createWritable({keepExistingData: false});
+  await slot1.write(gen1); await slot1.close();
+  const style1 = await (await mapSets.getFileHandle('osm-bright.pmas', {create: true})).createWritable({keepExistingData: false});
+  await style1.write(gen1); await style1.close();
+  const token = `PYXI 1 web-a ${Date.now()}`;
+  await (async text => {
+    const h = await pyxis.getFileHandle(MARKER, {create: true});
+    const w = await h.createWritable({keepExistingData: false});
+    await w.write(new TextEncoder().encode(text)); await w.close();
+  })(token);
+  // First verification (before the style write): fresh claim, unchanged
+  // records -> passes.
+  await verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [gen1, null], styleBytes: gen1});
+  // The style write lands (record = what activateMapSet would write).
+  const record = encodeActiveMapSet({generation: 2, mapSetId: metadata.mapSetId, attribution: metadata.attribution, packs: [{packId: 'new'}, {packId: 'old'}]});
+  const style2 = await (await mapSets.getFileHandle('osm-bright.pmas', {create: true})).createWritable({keepExistingData: false});
+  await style2.write(record); await style2.close();
+  // The gap: the claim expires while the slot write is still pending.
+  await (async text => {
+    const h = await pyxis.getFileHandle(MARKER, {create: true});
+    const w = await h.createWritable({keepExistingData: false});
+    await w.write(new TextEncoder().encode(text)); await w.close();
+  })(`PYXI 1 web-a ${Date.now() - 16 * 60 * 1000}`);
+  // FINAL pre-slot revalidation: slot still CAS'd against the
+  // derivation snapshot, style compared against the record just
+  // written. The expired claim must abort before the slot byte.
+  await assert.rejects(
+    verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [gen1, null], styleBytes: record}),
+    MapInstallerError, 'an expired claim must abort at the final pre-slot revalidation');
+  // The slot record was never written over the old selection.
+  const untouched = await decodeActiveSelection(pyxis.children.get('active-pack.0').bytes);
+  assert.equal(untouched.generation, 1, 'the slot record is untouched');
+  assert.deepEqual(untouched.packs.map(p => p.packId), ['old']);
+  // A fresh claim at the same boundary passes (the style self-check
+  // accepts the record that was just written).
+  await (async text => {
+    const h = await pyxis.getFileHandle(MARKER, {create: true});
+    const w = await h.createWritable({keepExistingData: false});
+    await w.write(new TextEncoder().encode(text)); await w.close();
+  })(token);
+  await verifyActivationState(pyxis, mapSets, 'osm-bright.pmas', token, {slotBytes: [gen1, null], styleBytes: record});
+});

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -859,3 +859,43 @@ test('renewing a live marker advances the epoch but keeps the owner', async () =
   assert.ok(parsed.epochMs >= Date.now() - 1000, 'renewal refreshes the epoch');
   assert.ok(installMarkerIsFresh(parsed.epochMs), 'a renewed marker is live again');
 });
+
+
+// --- Round 10 (Greptile): a heartbeat must never steal back a
+// legitimately reclaimed marker. If our marker aged out and another
+// producer reclaimed it, the renewal aborts and leaves the foreign
+// claim intact; the install then fails and the user retries after the
+// other installer finishes.
+test('marker renewal refuses to steal a reclaimed claim', async () => {
+  const root = new MemoryDirectoryHandle('sd');
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const writeMarker = async text => {
+    const writable = await (await pyxis.getFileHandle('.pyxis-installing', {create: true})).createWritable({keepExistingData: false});
+    await writable.write(new TextEncoder().encode(text));
+    await writable.close();
+  };
+  const readMarker = async () => {
+    let handle = null; try { handle = await pyxis.getFileHandle('.pyxis-installing'); } catch { return null; }
+    const file = await handle.getFile();
+    return new TextDecoder('utf-8').decode(new Uint8Array(await file.arrayBuffer()));
+  };
+  // Producer B reclaims after producer A's marker aged out.
+  await writeMarker(`PYXI 1 cli-other ${Date.now()}`);
+  // A's heartbeat must abort without touching B's claim.
+  await assert.rejects(
+    () => renewInstallMarker(pyxis, 'web-ours'),
+    error => error.message.includes('reclaimed during installation'),
+  );
+  assert.equal(parseInstallMarker(await readMarker()).owner, 'cli-other');
+  // Renewing as the same owner is fine.
+  await renewInstallMarker(pyxis, 'cli-other');
+  const renewed = parseInstallMarker(await readMarker());
+  assert.equal(renewed.owner, 'cli-other');
+  assert.ok(installMarkerIsFresh(renewed.epochMs));
+  // Missing or corrupt marker: refused, never overwritten.
+  await pyxis.removeEntry('.pyxis-installing');
+  await assert.rejects(() => renewInstallMarker(pyxis, 'cli-other'));
+  assert.equal(await readMarker(), null);
+  await writeMarker('garbage');
+  await assert.rejects(() => renewInstallMarker(pyxis, 'cli-other'));
+});

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1435,20 +1435,52 @@ def _acquire_install_marker(pyxis_fd: int) -> str:
     return token
 
 
+def _renew_install_marker(pyxis_fd: int, owner: str) -> None:
+    """Renew our marker's epoch during a long installation (heartbeat).
+
+    A publication can outlive _INSTALL_MARKER_TTL_SECONDS (a full world
+    pack on slow SD storage); without renewals the marker would age out
+    and a second producer could reclaim our live claim. The rewrite
+    keeps our owner identity and advances the epoch; the release path
+    and the commit-time check compare the owner, so renewed markers are
+    still recognized as ours. Best effort: a failed renewal is retried
+    on the next tile and the commit-time marker check is the backstop.
+    """
+    try:
+        token = _marker_token(owner)
+        descriptor = os.open(_INSTALL_MARKER_NAME,
+                             os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC,
+                             dir_fd=pyxis_fd)
+        try:
+            _write_all(descriptor, token.encode("ascii"), _INSTALL_MARKER_NAME)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+    except OSError:
+        pass
+
+
 def _release_install_marker(pyxis_fd: int, token: str) -> None:
     """Remove our install marker -- and only ours.
 
-    If the marker content is not our own token (a later installer
-    reclaimed it after our install outlasted the TTL, or a crashed run
-    left a different claim), deleting it would drop that installer's
-    live claim. Leave it; the TTL reclaims it.
+    Comparison is by owner identity (the token's owner field), not the
+    full token: the epoch changes as we renew (heartbeat), so an exact
+    match would fail once a long install has renewed its marker. If the
+    marker now carries a DIFFERENT owner (a later installer reclaimed
+    it after our marker aged out, or a crashed run left a different
+    claim), deleting it would drop that installer's live claim. Leave
+    it; the TTL reclaims it.
     """
+    our_owner = _parse_marker(token.encode("ascii"))
+    our_owner = our_owner[0] if our_owner is not None else None
     raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
-    if raw == token.encode("ascii"):
-        try:
-            os.unlink(_INSTALL_MARKER_NAME, dir_fd=pyxis_fd)
-        except OSError:
-            pass
+    if raw is not None:
+        current = _parse_marker(raw)
+        if current is not None and current[0] == our_owner:
+            try:
+                os.unlink(_INSTALL_MARKER_NAME, dir_fd=pyxis_fd)
+            except OSError:
+                pass
 
 
 def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
@@ -1468,10 +1500,16 @@ def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
     """
     marker_raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
     if marker_raw is not None:
-        own = marker_token.encode("ascii") if marker_token is not None else None
+        # Compare by owner, not the full token: we renew the marker's
+        # epoch during publication (heartbeat), so our own marker may
+        # carry a newer epoch than the one acquired at install start.
+        own_owner = None
+        if marker_token is not None:
+            parsed_own = _parse_marker(marker_token.encode("ascii"))
+            own_owner = parsed_own[0] if parsed_own is not None else None
         parsed = _parse_marker(marker_raw)
         if parsed is not None and _marker_is_fresh(parsed[1]) \
-                and marker_raw != own:
+                and parsed[0] != own_owner:
             raise PackError("another map installer is running on this card; "
                             "wait for it to finish and retry")
     for index, slot_name in enumerate(("active-pack.0", "active-pack.1")):
@@ -1700,9 +1738,19 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
                     if not resumed:
                         temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
                         copied = 0
-                        for tile in tiles:
+                        # Heartbeat: renew our marker during long
+                        # publications so a full world pack on slow SD
+                        # storage cannot age out and be reclaimed by a
+                        # second producer mid-install (Greptile round 8).
+                        _marker_owner = _parse_marker(marker_token.encode("ascii"))
+                        _marker_owner = _marker_owner[0] if _marker_owner is not None else None
+                        for tile_index, tile in enumerate(tiles):
                             copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
                             copied += tile.size
+                            if _marker_owner is not None and tile_index % 25 == 24:
+                                _renew_install_marker(pyxis_fd, _marker_owner)
+                        if tiles and _marker_owner is not None:
+                            _renew_install_marker(pyxis_fd, _marker_owner)
                         manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL
                                                | os.O_CLOEXEC, 0o644, dir_fd=stage_fd)
                         try:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1410,6 +1410,14 @@ def _check_cross_installers(pyxis_fd: int, *, reclaim: bool) -> None:
     malformed one is an abandoned install; reclaim it only when the
     caller says so (at acquire, where claiming is the intent). Fresh
     foreign markers are never touched.
+
+    Reclaim is conditional: the file is re-read immediately before
+    deletion and a token that became fresh after the original check
+    (the owner renewed while we were deciding) aborts the reclaim
+    instead of deleting a live claim. A sub-microsecond renewal can
+    still land between that final read and the unlink; the owner's
+    commit-time verification requires its own marker, so such an
+    overlap aborts on its side instead of proceeding.
     """
     for name in _CROSS_INSTALL_MARKERS:
         raw = _read_selection_at(pyxis_fd, name)
@@ -1420,6 +1428,11 @@ def _check_cross_installers(pyxis_fd: int, *, reclaim: bool) -> None:
             raise PackError("another map installer is already running on "
                             "this card; wait for it to finish and retry")
         if reclaim:
+            confirm = _read_selection_at(pyxis_fd, name)
+            confirm_parsed = _parse_marker(confirm) if confirm is not None else None
+            if confirm_parsed is not None and _marker_is_fresh(confirm_parsed[1]):
+                raise PackError("another map installer is already running on "
+                                "this card; wait for it to finish and retry")
             _unlink_quietly_at(pyxis_fd, name)
 
 
@@ -1563,22 +1576,34 @@ def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
     is kept; a retry re-derives from the new state and converges (the
     pack is device-harmless while it is not named by any record: the
     firmware only reads packs enumerated in the active selection).
+
+    The own marker is REQUIRED when this install acquired one: a missing
+    own file means the claim was reclaimed from under us (a stale
+    cross-reclaimer raced our last renewal) and the activation would
+    proceed alongside the new holder. Abort instead.
     """
     # Cross producers: a fresh marker in the web/legacy files means the
     # other installer started (or is mid-install) after we acquired.
     _check_cross_installers(pyxis_fd, reclaim=False)
     marker_raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
-    if marker_raw is not None:
-        # Compare by owner, not the full token: we renew the marker's
-        # epoch during publication (heartbeat), so our own marker may
-        # carry a newer epoch than the one acquired at install start.
-        own_owner = None
-        if marker_token is not None:
-            parsed_own = _parse_marker(marker_token.encode("ascii"))
-            own_owner = parsed_own[0] if parsed_own is not None else None
+    if marker_token is not None:
+        parsed_own = _parse_marker(marker_token.encode("ascii"))
+        own_owner = parsed_own[0] if parsed_own is not None else None
+        if marker_raw is None:
+            raise PackError("the install claim was reclaimed during "
+                            "installation; wait for the other installer "
+                            "to finish and retry")
         parsed = _parse_marker(marker_raw)
-        if parsed is not None and _marker_is_fresh(parsed[1]) \
-                and parsed[0] != own_owner:
+        if parsed is None or parsed[0] != own_owner:
+            raise PackError("the map-install marker was reclaimed during "
+                            "installation; wait for the other installer "
+                            "to finish and retry")
+    elif marker_raw is not None:
+        # No token was acquired (resume path without a marker): only a
+        # FRESH marker in our own file is a live foreign claim; a
+        # stale one is an abandoned install we are resuming.
+        parsed = _parse_marker(marker_raw)
+        if parsed is not None and _marker_is_fresh(parsed[1]):
             raise PackError("another map installer is running on this card; "
                             "wait for it to finish and retry")
     for index, slot_name in enumerate(("active-pack.0", "active-pack.1")):

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -5,6 +5,16 @@
 
 Security-sensitive filesystem operations intentionally support Linux only. PNG
 support is intentionally limited to non-interlaced images.
+
+Coverage models:
+- default: PMPK v1 rectangle extents (contiguous rectangles, optional
+  antimeridian splits)
+- --sparse: PMPK v2 row spans for sparse state/polygon coverage, falling
+  back to PMPK v3 indexless records when the coverage exceeds the 512-span
+  cap
+- --style: always emit an indexless PMPK v3 pack using the firmware's
+  canonical style policy metadata; --activate additionally publishes the
+  v3 active map-set record so the device renders the pack immediately
 """
 
 from __future__ import annotations
@@ -13,6 +23,7 @@ import argparse
 import ctypes
 from dataclasses import dataclass
 import errno
+import json
 import os
 from pathlib import Path
 import re
@@ -25,6 +36,8 @@ import zlib
 MAGIC = b"PMPK"
 FORMAT_VERSION = 1
 SPARSE_FORMAT_VERSION = 2
+INDEXLESS_FORMAT_VERSION = 3
+SELECTION_MAGIC = b"PMAS"
 HEADER_SIZE = 16
 EXTENT_SIZE = 26
 ROW_SPAN_SIZE = 13
@@ -35,7 +48,8 @@ DEFAULT_MAX_BYTES = 8 * 1024 * 1024 * 1024
 MAX_VISITED_ENTRIES_BASE = 64
 PACK_ID_RE = re.compile(r"[a-z0-9_-]{1,31}\Z")
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
-_STRING_LIMITS = {"pack_id": 31, "name": 63, "attribution": 127, "source": 127, "license": 63}
+_STRING_LIMITS = {"pack_id": 31, "name": 63, "attribution": 127, "source": 127, "license": 63,
+                  "map_set_id": 31}
 MAX_MANIFEST_BYTES = 7100
 _DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
 _FILE_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC
@@ -203,9 +217,19 @@ def _inflate_block(inflater: Any, block: bytes, decoded: bytearray,
 
 def _unfilter_png_rows(decoded: bytes, row_bytes: int, bytes_per_pixel: int,
                        label: str) -> bytes:
+    stride = row_bytes + 1
+    rows = len(decoded) // stride
+    # Fast path: every row uses the None filter (the common case for
+    # rendered tile PNGs). A single bytes scan is orders of magnitude
+    # cheaper than the per-pixel predictor loop below.
+    filter_bytes = bytes(decoded[offset] for offset in range(0, rows * stride, stride))
+    if filter_bytes == b"\x00" * rows:
+        output = bytearray()
+        for offset in range(0, rows * stride, stride):
+            output.extend(decoded[offset + 1:offset + stride])
+        return bytes(output)
     output = bytearray()
     previous = bytearray(row_bytes)
-    stride = row_bytes + 1
     for offset in range(0, len(decoded), stride):
         filter_type = decoded[offset]
         if filter_type > 4:
@@ -328,14 +352,26 @@ def _validate_png_fd(descriptor: int, label: str, maximum_size: int) -> int:
         raise PackError(f"invalid PNG structure, deflate, or terminal state: {label}")
     pixels = _unfilter_png_rows(bytes(decoded), row_bytes, bytes_per_pixel, label)
     if color_type == 3:
-        for row in range(256):
-            packed = pixels[row * row_bytes:(row + 1) * row_bytes]
-            for column in range(256):
-                bit_offset = column * bit_depth
-                byte = packed[bit_offset // 8]
-                shift = 8 - bit_depth - (bit_offset % 8)
-                if ((byte >> shift) & ((1 << bit_depth) - 1)) >= palette_entries:
-                    raise PackError(f"indexed PNG palette index out of range: {label}")
+        if bit_depth == 8:
+            # Fast path: one C-level scan replaces the 65,536-iteration
+            # per-pixel loop. For 8-bit index PNGs the packed bytes ARE the
+            # indices, so any byte at or above the palette length is invalid.
+            # Single-pass scan via a lookup table: mark every out-of-range
+            # index byte, then reject if any appear.
+            bad = bytearray(256)
+            for index in range(palette_entries, 256):
+                bad[index] = 1
+            if bytes.translate(pixels, bytes(bad)).count(1) > 0:
+                raise PackError(f"indexed PNG palette index out of range: {label}")
+        else:
+            for row in range(256):
+                packed = pixels[row * row_bytes:(row + 1) * row_bytes]
+                for column in range(256):
+                    bit_offset = column * bit_depth
+                    byte = packed[bit_offset // 8]
+                    shift = 8 - bit_depth - (bit_offset % 8)
+                    if ((byte >> shift) & ((1 << bit_depth) - 1)) >= palette_entries:
+                        raise PackError(f"indexed PNG palette index out of range: {label}")
     after = os.fstat(descriptor)
     if _identity(before) != _identity(after):
         raise PackError(f"PNG changed while being validated: {label}")
@@ -371,6 +407,26 @@ def _discover_tiles_fd(source_fd: int, source_label: Path, max_tiles: int, max_b
         zoom_names = (entry.name for entry in os.scandir(source_fd))
         for zoom_name in zoom_names:
             visit()
+            if zoom_name == "metadata.json":
+                # Optional tile-provider metadata (e.g. Oxed's
+                # metadata.json). The manifest carries its own style
+                # metadata, so this file is validated as readable JSON and
+                # otherwise ignored.
+                try:
+                    metadata_fd = os.open(zoom_name, _FILE_FLAGS, dir_fd=source_fd)
+                except OSError as exc:
+                    raise PackError(f"metadata.json is not a regular file: {exc}") from exc
+                try:
+                    metadata_info = os.fstat(metadata_fd)
+                    if not stat.S_ISREG(metadata_info.st_mode) or metadata_info.st_size > 65536:
+                        raise PackError("metadata.json is oversized")
+                    try:
+                        json.loads(os.read(metadata_fd, metadata_info.st_size).decode("utf-8"))
+                    except (UnicodeDecodeError, ValueError) as exc:
+                        raise PackError(f"metadata.json is not valid JSON: {exc}") from exc
+                finally:
+                    os.close(metadata_fd)
+                continue
             zoom = _canonical_number(zoom_name, "zoom")
             if zoom > MAX_ZOOM:
                 raise PackError(f"zoom out of range: {zoom}")
@@ -549,6 +605,27 @@ def serialize_sparse_manifest(*, pack_id: str, name: str, attribution: str, sour
     return bytes(result)
 
 
+def serialize_indexless_manifest(*, pack_id: str, name: str, attribution: str, source: str,
+                                 license: str, min_zoom: int, max_zoom: int,
+                                 tile_count: int) -> bytes:
+    _validate_metadata(pack_id, name, attribution, source, license)
+    if min_zoom < 0 or min_zoom > max_zoom or max_zoom > MAX_ZOOM or tile_count <= 0:
+        raise PackError("indexless manifest range or tile count is invalid")
+    payload = bytearray()
+    for field, value in (("pack_id", pack_id), ("name", name), ("attribution", attribution),
+                         ("source", source), ("license", license)):
+        encoded = _checked_text(field, value)
+        payload.append(len(encoded))
+        payload.extend(encoded)
+    payload.extend((min_zoom, max_zoom))
+    payload.extend(struct.pack("<I", tile_count))
+    length = HEADER_SIZE + len(payload) + 4
+    result = bytearray(struct.pack("<4sBBHII", MAGIC, INDEXLESS_FORMAT_VERSION, 0, HEADER_SIZE, length, 0))
+    result.extend(payload)
+    result.extend(struct.pack("<I", zlib.crc32(result)))
+    return bytes(result)
+
+
 def _validate_manifest_values(extents: list[ZoomExtent], tile_count: int) -> None:
     if not extents or len(extents) > MAX_ZOOM + 1:
         raise PackError("manifest extent count is invalid")
@@ -607,7 +684,8 @@ def parse_manifest(data: bytes) -> dict[str, object]:
     if len(data) < 20 or len(data) > MAX_MANIFEST_BYTES:
         raise PackError("manifest is truncated or oversized")
     magic, version, reserved, header_size, length, reserved_word = struct.unpack("<4sBBHII", data[:16])
-    if magic != MAGIC or version not in (FORMAT_VERSION, SPARSE_FORMAT_VERSION) or \
+    if magic != MAGIC or version not in (FORMAT_VERSION, SPARSE_FORMAT_VERSION,
+                                         INDEXLESS_FORMAT_VERSION) or \
             (reserved, header_size, length, reserved_word) != (0, 16, len(data), 0):
         raise PackError("invalid manifest header")
     if zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
@@ -630,6 +708,18 @@ def parse_manifest(data: bytes) -> dict[str, object]:
         if field == "pack_id" and not PACK_ID_RE.fullmatch(value):
             raise PackError("invalid manifest pack ID")
         values[field] = value
+    if version == INDEXLESS_FORMAT_VERSION:
+        if position + 6 > len(data) - 4:
+            raise PackError("manifest indexless fields are truncated")
+        minimum, maximum = data[position:position + 2]
+        position += 2
+        tile_count = struct.unpack("<I", data[position:position + 4])[0]
+        position += 4
+        if position != len(data) - 4 or minimum > maximum or maximum > MAX_ZOOM or not tile_count:
+            raise PackError("invalid indexless manifest fields")
+        values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
+                      tile_count=tile_count, extents=[], row_spans=[])
+        return values
     if version == FORMAT_VERSION:
         if position + 7 > len(data) - 4:
             raise PackError("manifest fields are truncated")
@@ -673,6 +763,85 @@ def parse_manifest(data: bytes) -> dict[str, object]:
         values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
                       tile_count=tile_count, extents=[], row_spans=row_spans)
     return values
+
+
+def encode_active_map_set(*, generation: int, map_set_id: str, attribution: str,
+                          pack_ids: list[str]) -> bytes:
+    """Serialize a v3 (indexless) PMAS active map-set record.
+
+    Byte-compatible with the web flasher's encodeActiveMapSet and the
+    firmware's ActiveMapSetCodec (PMAS magic, version 3, u16 total length,
+    u32 generation, then length-prefixed map-set ID, attribution, pack
+    count, and ordered pack IDs, trailing CRC-32).
+    """
+    if not 1 <= generation <= 0xFFFFFFFF:
+        raise PackError("active map-set generation is invalid")
+    map_set = _checked_text("map_set_id", map_set_id)
+    credit = _checked_text("attribution", attribution)
+    if not PACK_ID_RE.fullmatch(map_set_id) or len(pack_ids) == 0 or len(pack_ids) > 8:
+        raise PackError("invalid active map-set packs")
+    seen: set[str] = set()
+    encoded_packs: list[bytes] = []
+    for pack_id in pack_ids:
+        identifier = _checked_text("pack_id", pack_id)
+        if not PACK_ID_RE.fullmatch(pack_id) or pack_id in seen:
+            raise PackError("invalid or duplicate active map-set pack")
+        seen.add(pack_id)
+        encoded_packs.append(identifier)
+    length = 12 + 1 + len(map_set) + 1 + len(credit) + 1 + sum(1 + len(item) for item in encoded_packs) + 4
+    result = bytearray(struct.pack("<4sBBHI", SELECTION_MAGIC, INDEXLESS_FORMAT_VERSION, 0, length, generation))
+    result.append(len(map_set)); result.extend(map_set)
+    result.append(len(credit)); result.extend(credit)
+    result.append(len(encoded_packs))
+    for identifier in encoded_packs:
+        result.append(len(identifier)); result.extend(identifier)
+    result.extend(struct.pack("<I", zlib.crc32(result)))
+    return bytes(result)
+
+
+def parse_active_map_set(data: bytes) -> dict[str, object]:
+    if len(data) < 16 or len(data) > 7105:
+        raise PackError("active map-set record length is invalid")
+    magic, version, reserved, length, generation = struct.unpack("<4sBBHI", data[:12])
+    if magic != SELECTION_MAGIC or version != INDEXLESS_FORMAT_VERSION or reserved != 0 \
+            or length != len(data) or generation == 0 \
+            or zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
+        raise PackError("invalid active map-set record")
+    position = 12
+
+    def read_text(label: str, maximum: int, identifier: bool) -> str:
+        nonlocal position
+        if position >= len(data) - 4:
+            raise PackError(f"{label} is truncated")
+        size = data[position]
+        position += 1
+        if size == 0 or size > maximum or position + size > len(data) - 4:
+            raise PackError(f"{label} is invalid")
+        value = data[position:position + size].decode("ascii")
+        position += size
+        if any(byte < 0x20 or byte > 0x7E for byte in value.encode("ascii")) or \
+                (identifier and not PACK_ID_RE.fullmatch(value)):
+            raise PackError(f"{label} is invalid")
+        return value
+
+    map_set_id = read_text("map set ID", 31, True)
+    attribution = read_text("attribution", 127, False)
+    if position >= len(data) - 4:
+        raise PackError("active map-set pack count is truncated")
+    count = data[position]
+    position += 1
+    if count == 0 or count > 8:
+        raise PackError("active map-set pack count is invalid")
+    packs: list[str] = []
+    for _ in range(count):
+        pack_id = read_text("pack ID", 31, True)
+        if pack_id in packs:
+            raise PackError("duplicate active map-set pack")
+        packs.append(pack_id)
+    if position != len(data) - 4:
+        raise PackError("active map-set record has trailing data")
+    return {"format_version": version, "generation": generation, "map_set_id": map_set_id,
+            "attribution": attribution, "packs": packs}
 
 
 def _open_verified_tile(source_fd: int, tile: Tile) -> int:
@@ -752,6 +921,90 @@ def _read_file_at(parent_fd: int, name: str, maximum: int) -> bytes:
         os.close(descriptor)
 
 
+def _read_selection_at(parent_fd: int, name: str) -> bytes | None:
+    try:
+        return _read_file_at(parent_fd, name, 7105)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PackError(f"cannot read {name}: {exc}") from exc
+
+
+def decode_active_selection(data: bytes) -> dict[str, object]:
+    """Decode v1/v2/v3 PMAS active map-set records.
+
+    Byte-compatible with the firmware's ActiveMapSetCodec and the web
+    flasher's decodeActiveSelection. Row spans in v2 records are skipped
+    with bound checks only; this tool never emits spans.
+    """
+    if len(data) < 16 or len(data) > 7105:
+        raise PackError("active map-set record length is invalid")
+    magic, version, reserved, length, generation = struct.unpack("<4sBBHI", data[:12])
+    if magic != SELECTION_MAGIC or version not in (1, 2, 3) or reserved != 0 \
+            or length != len(data) or generation == 0 \
+            or zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
+        raise PackError("invalid active map-set record")
+    end = len(data) - 4
+    if version == 1:
+        if len(data) != 48:
+            raise PackError("invalid v1 active map-set length")
+        size = data[12]
+        if not 1 <= size <= 31:
+            raise PackError("invalid v1 active map-set pack ID")
+        pack_id = data[13:13 + size].decode("ascii")
+        if any(byte != 0 for byte in data[13 + size:end]) or not PACK_ID_RE.fullmatch(pack_id):
+            raise PackError("invalid v1 active map-set record")
+        return {"format_version": 1, "generation": generation, "map_set_id": None,
+                "attribution": None, "packs": [pack_id]}
+    position = 12
+
+    def read_text(label: str, maximum: int, identifier: bool) -> str:
+        nonlocal position
+        if position >= end:
+            raise PackError(f"{label} is truncated")
+        size = data[position]
+        position += 1
+        if size == 0 or size > maximum or position + size > end:
+            raise PackError(f"{label} is invalid")
+        value = data[position:position + size].decode("ascii")
+        position += size
+        if any(byte < 0x20 or byte > 0x7E for byte in value.encode("ascii")) or \
+                (identifier and not PACK_ID_RE.fullmatch(value)):
+            raise PackError(f"{label} is invalid")
+        return value
+
+    map_set_id = read_text("map set ID", 31, True)
+    attribution = read_text("attribution", 127, False)
+    if position >= end:
+        raise PackError("active map-set pack count is truncated")
+    count = data[position]
+    position += 1
+    if count == 0 or count > 8:
+        raise PackError("active map-set pack count is invalid")
+    packs: list[str] = []
+    total_spans = 0
+    for _ in range(count):
+        pack_id = read_text("pack ID", 31, True)
+        if pack_id in packs:
+            raise PackError("duplicate active map-set pack")
+        packs.append(pack_id)
+        if version == 3:
+            continue
+        if position + 2 > end:
+            raise PackError("active map-set span count is truncated")
+        span_count = struct.unpack("<H", data[position:position + 2])[0]
+        position += 2
+        if span_count == 0 or span_count > MAX_ROW_SPANS or total_spans > MAX_ROW_SPANS - span_count \
+                or position + span_count * ROW_SPAN_SIZE > end:
+            raise PackError("active map-set row-span count is invalid")
+        total_spans += span_count
+        position += span_count * ROW_SPAN_SIZE
+    if position != end:
+        raise PackError("active map-set record has trailing data")
+    return {"format_version": version, "generation": generation, "map_set_id": map_set_id,
+            "attribution": attribution, "packs": packs}
+
+
 def _validate_pack_fd(pack_fd: int, label: Path, max_bytes: int) -> dict[str, object]:
     parsed = parse_manifest(_read_file_at(pack_fd, "manifest.pmp", MAX_MANIFEST_BYTES))
     tiles_fd, _ = _open_child_directory(pack_fd, "tiles", f"{label}/tiles")
@@ -762,6 +1015,12 @@ def _validate_pack_fd(pack_fd: int, label: Path, max_bytes: int) -> dict[str, ob
         os.close(tiles_fd)
     if len(tiles) != tile_count:
         raise PackError("emitted tile tree does not match manifest")
+    if parsed["format_version"] == INDEXLESS_FORMAT_VERSION:
+        zooms = sorted({tile.zoom for tile in tiles})
+        if (cast(int, parsed["min_zoom"]), cast(int, parsed["max_zoom"])) != (zooms[0], zooms[-1]) \
+                or zooms != list(range(zooms[0], zooms[-1] + 1)):
+            raise PackError("emitted tile tree does not match indexless manifest")
+        return parsed
     if parsed["format_version"] == FORMAT_VERSION:
         expected_extents = cast(list[ZoomExtent], parsed["extents"])
         extents = calculate_extents(tiles, {item.zoom for item in expected_extents if len(item.intervals) == 2})
@@ -780,6 +1039,110 @@ def validate_pack(pack_directory: Path, max_bytes: int = DEFAULT_MAX_BYTES) -> d
         return _validate_pack_fd(descriptor, Path(pack_directory), max_bytes)
     finally:
         os.close(descriptor)
+
+
+STYLE_POLICIES: dict[str, dict[str, str]] = {
+    "osm-bright": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+        "source": "Oxed's Map Tile Downloader (OSM Bright)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause",
+    },
+    "dark-matter": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "source": "Oxed's Map Tile Downloader (Dark Matter)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+    },
+    "positron": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "source": "Oxed's Map Tile Downloader (Positron)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+    },
+    "toner": {
+        "attribution": "(c) MapTiler (c) OpenStreetMap contributors",
+        "source": "Oxed's Map Tile Downloader (Toner)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)",
+    },
+}
+
+
+def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attribution: str) -> tuple[str, list[str]]:
+    """Publish the v3 active map-set record, mirroring the web flasher.
+
+    pyxis_fd is the open pyxis-map/ directory. Slot and style-record
+    selection follows the flasher's prepareActiveMapSet/activateMapSet:
+    read both slots, reject conflicting same-generation records, resolve
+    the pack list from the installed style record (falling back to the
+    highest-generation slot of the same style), write the style record
+    under map-sets/ and then the chosen active-pack slot, each with fsync
+    plus byte-exact read-back. Returns (slot_name, enabled_packs).
+    """
+    slot_names = ("active-pack.0", "active-pack.1")
+    slots: list[dict[str, object] | None] = [None, None]
+    for index, slot_name in enumerate(slot_names):
+        raw = _read_selection_at(pyxis_fd, slot_name)
+        if raw is not None:
+            slots[index] = decode_active_selection(raw)
+    if slots[0] is not None and slots[1] is not None \
+            and slots[0]["generation"] == slots[1]["generation"] and slots[0] != slots[1]:
+        raise PackError("conflicting active map-set records")
+    valid = [slot for slot in slots if slot is not None]
+    highest = max([0] + [cast(int, slot["generation"]) for slot in valid])
+    if highest == 0xFFFFFFFF:
+        raise PackError("active selection generation is exhausted")
+    current = max(valid, key=lambda slot: cast(int, slot["generation"])) if valid else None
+
+    map_sets_fd, _ = _mkdir_open(pyxis_fd, "map-sets")
+    try:
+        style_name = f"{map_set_id}.pmas"
+        installed: dict[str, object] | None = None
+        installed_raw = _read_selection_at(map_sets_fd, style_name)
+        if installed_raw is not None:
+            installed = decode_active_selection(installed_raw)
+            if installed["format_version"] not in (2, 3) \
+                    or installed["map_set_id"] != map_set_id \
+                    or installed["attribution"] != attribution:
+                raise PackError("installed style record does not match selected map set")
+        composition: dict[str, object] | None = installed
+        if composition is None and current is not None \
+                and current["format_version"] in (2, 3) and current["map_set_id"] == map_set_id:
+            composition = current
+        packs: list[str] = []
+        if composition is not None:
+            if composition["attribution"] != attribution:
+                raise PackError("installed map set attribution does not match")
+            packs = [value for value in cast(list[str], composition["packs"]) if value != pack_id]
+        packs.insert(0, pack_id)
+        record = encode_active_map_set(generation=highest + 1, map_set_id=map_set_id,
+                                       attribution=attribution, pack_ids=packs)
+        _write_verified_at(map_sets_fd, style_name, record)
+        if slots[0] is None:
+            target = slot_names[0]
+        elif slots[1] is None:
+            target = slot_names[1]
+        else:
+            target = slot_names[0] if cast(int, slots[0]["generation"]) <= \
+                    cast(int, slots[1]["generation"]) else slot_names[1]
+        _write_verified_at(pyxis_fd, target, record)
+    finally:
+        os.close(map_sets_fd)
+    return target, packs
+
+
+def _write_verified_at(parent_fd: int, name: str, data: bytes) -> None:
+    try:
+        descriptor = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_CLOEXEC, 0o644,
+                             dir_fd=parent_fd)
+    except OSError as exc:
+        raise PackError(f"cannot write {name}: {exc}") from exc
+    try:
+        _write_all(descriptor, data, name)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    _fsync_directory_fd(parent_fd)
+    actual = _read_file_at(parent_fd, name, len(data))
+    if actual != data:
+        raise PackError(f"read-back verification failed for {name}")
 
 
 def _remove_tree_at(parent_fd: int, name: str) -> None:
@@ -846,13 +1209,22 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
                    attribution: str, source: str, license: str,
                    max_tiles: int = DEFAULT_MAX_TILES, max_bytes: int = DEFAULT_MAX_BYTES,
                    antimeridian_zooms: set[int] | None = None,
-                   sparse: bool = False) -> Path:
+                   sparse: bool = False, style: str | None = None,
+                   activate: bool = False) -> Path:
     if not sys.platform.startswith("linux"):
         raise PackError("secure importer supports Linux hosts only")
     _validate_metadata(pack_id, name, attribution, source, license)
     antimeridian_zooms = set() if antimeridian_zooms is None else set(antimeridian_zooms)
     if any(zoom < 0 or zoom > MAX_ZOOM for zoom in antimeridian_zooms):
         raise PackError("antimeridian zoom is out of range")
+    if style is not None:
+        if style not in STYLE_POLICIES:
+            raise PackError(f"unsupported map style: {style}")
+        policy = STYLE_POLICIES[style]
+        if (attribution, source, license) != (policy["attribution"], policy["source"], policy["license"]):
+            raise PackError("metadata does not match the selected style policy")
+    if activate and style is None:
+        raise PackError("--activate requires --style so the map-set ID is a firmware style policy")
     source_directory = Path(source_directory)
     output_root = Path(output_root)
     target = output_root / "pyxis-map" / "packs" / pack_id
@@ -862,18 +1234,38 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
     committed = False
     try:
         tiles = _discover_tiles_fd(source_fd, source_directory, max_tiles, max_bytes)
-        try:
-            extents = calculate_extents(tiles, antimeridian_zooms)
-        except PackError as exc:
-            if not sparse or antimeridian_zooms or not str(exc).startswith("incomplete rectangle"):
-                raise
-            row_spans = calculate_row_spans(tiles)
-            manifest = serialize_sparse_manifest(pack_id=pack_id, name=name, attribution=attribution,
-                                                 source=source, license=license,
-                                                 row_spans=row_spans, tile_count=len(tiles))
+        zooms = sorted({tile.zoom for tile in tiles})
+        if style is not None:
+            # Style installs always publish indexless v3 packs, mirroring
+            # the web flasher: no row spans, no coverage caps.
+            manifest = serialize_indexless_manifest(pack_id=pack_id, name=name,
+                                                    attribution=attribution, source=source,
+                                                    license=license, min_zoom=zooms[0],
+                                                    max_zoom=zooms[-1], tile_count=len(tiles))
         else:
-            manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
-                                          license=license, extents=extents, tile_count=len(tiles))
+            try:
+                extents = calculate_extents(tiles, antimeridian_zooms)
+            except PackError as exc:
+                if not sparse or antimeridian_zooms or not str(exc).startswith("incomplete rectangle"):
+                    raise
+                try:
+                    row_spans = calculate_row_spans(tiles)
+                    manifest = serialize_sparse_manifest(pack_id=pack_id, name=name,
+                                                         attribution=attribution, source=source,
+                                                         license=license, row_spans=row_spans,
+                                                         tile_count=len(tiles))
+                except PackError as span_exc:
+                    if "row-span limit" not in str(span_exc):
+                        raise
+                    # Sparse coverage beyond the v2 span cap falls back to
+                    # an indexless v3 pack.
+                    manifest = serialize_indexless_manifest(pack_id=pack_id, name=name,
+                                                            attribution=attribution, source=source,
+                                                            license=license, min_zoom=zooms[0],
+                                                            max_zoom=zooms[-1], tile_count=len(tiles))
+            else:
+                manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
+                                              license=license, extents=extents, tile_count=len(tiles))
         output_fd = _open_path(output_root, create=True)
         pyxis_fd, pyxis_identity = _mkdir_open(output_fd, "pyxis-map")
         packs_fd, packs_identity = _mkdir_open(pyxis_fd, "packs")
@@ -905,6 +1297,11 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
                 raise PublishedDurabilityError(target, OSError(
                     f"publication location changed and rollback failed: {cleanup_error}")) from exc
             raise PackError("output directory changed during publication; rolled back") from exc
+        if activate:
+            assert style is not None
+            slot_name, _enabled = activate_map_set(pyxis_fd, pack_id=pack_id,
+                                                   map_set_id=style,
+                                                   attribution=attribution)
         try:
             os.close(stage_fd)
         except OSError as exc:
@@ -943,27 +1340,44 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("output_root", type=Path, help="SD-card root under which pyxis-map/packs is created")
     parser.add_argument("--pack-id", required=True)
     parser.add_argument("--name", required=True)
-    parser.add_argument("--attribution", required=True)
-    parser.add_argument("--source", required=True)
-    parser.add_argument("--license", required=True)
+    parser.add_argument("--attribution")
+    parser.add_argument("--source")
+    parser.add_argument("--license")
     parser.add_argument("--max-tiles", type=int, default=DEFAULT_MAX_TILES)
     parser.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_BYTES)
     parser.add_argument("--antimeridian-zoom", action="append", type=int, default=[])
     parser.add_argument("--sparse", action="store_true",
                         help="explicitly admit sparse state/polygon coverage and emit PMPK v2")
+    parser.add_argument("--style", choices=sorted(STYLE_POLICIES),
+                        help="firmware style policy; supplies canonical attribution/source/license, "
+                             "emits an indexless PMPK v3 pack")
+    parser.add_argument("--activate", action="store_true",
+                        help="also publish the v3 active map-set record (active-pack slot + map-sets/<style>.pmas)")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
+    if arguments.style is not None:
+        policy = STYLE_POLICIES[arguments.style]
+        attribution = arguments.attribution or policy["attribution"]
+        source = arguments.source or policy["source"]
+        license = arguments.license or policy["license"]
+    else:
+        if not (arguments.attribution and arguments.source and arguments.license):
+            print("error: --attribution, --source, and --license are required unless --style is given",
+                  file=sys.stderr)
+            return 2
+        attribution, source, license = arguments.attribution, arguments.source, arguments.license
     try:
         target = build_map_pack(arguments.xyz_directory, arguments.output_root,
                                 pack_id=arguments.pack_id, name=arguments.name,
-                                attribution=arguments.attribution, source=arguments.source,
-                                license=arguments.license, max_tiles=arguments.max_tiles,
+                                attribution=attribution, source=source,
+                                license=license, max_tiles=arguments.max_tiles,
                                 max_bytes=arguments.max_bytes,
                                 antimeridian_zooms=set(arguments.antimeridian_zoom),
-                                sparse=arguments.sparse)
+                                sparse=arguments.sparse, style=arguments.style,
+                                activate=arguments.activate)
     except PublishedDurabilityError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 3

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1388,6 +1388,9 @@ def _preflight_activation(pyxis_fd: int, *, pack_id: str, map_set_id: str, attri
             and slots[0]["generation"] == slots[1]["generation"] and slots[0] != slots[1]:
         raise PackError("conflicting active map-set records")
     valid = [slot for slot in slots if slot is not None]
+    highest = max([0] + [cast(int, slot["generation"]) for slot in valid])
+    if highest == 0xFFFFFFFF:
+        raise PackError("active selection generation is exhausted")
     map_sets_fd, _ = _mkdir_open(pyxis_fd, "map-sets")
     try:
         style_name = f"{map_set_id}.pmas"

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -24,6 +24,7 @@ import contextlib
 import ctypes
 from dataclasses import dataclass
 import errno
+import fcntl
 import json
 import os
 from pathlib import Path
@@ -1126,15 +1127,19 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
     selection follows the flasher's prepareActiveMapSet/activateMapSet:
     read both slots, reject conflicting same-generation records, resolve
     the pack list from the installed style record (falling back to the
-    highest-generation slot of the same style), write the style record
-    under map-sets/ and then the chosen active-pack slot. Both writes go
-    through _write_atomic_at (exclusive temp file, fsync, rename,
-    read-back) so an interrupted activation never truncates or leaves a
-    partial record: a crash mid-write leaves the previous record intact
-    and a retry repairs the slot. The final pack list is validated
-    against the firmware's pack limit before any byte is written, so a
-    rejected activation cannot orphan a just-published pack. Returns
-    (slot_name, enabled_packs).
+    highest-generation slot of the same style), then publish the record to
+    the chosen active-pack slot FIRST and the style record under map-sets/
+    second. Both writes go through _write_atomic_at (exclusive temp file,
+    fsync, rename, read-back) so an interrupted activation never truncates
+    or leaves a partial record: a crash mid-write leaves the previous record
+    intact and a retry repairs the style record. The slot is authoritative
+    in the firmware (tile serving reads only the active slots, and the style
+    catalog tolerates a missing style record), so slot-first ordering means
+    an interruption between the two commits leaves the map ACTIVE with the
+    style record one build stale, rather than dropping the active pack. The
+    final pack list is validated against the firmware's pack limit before any
+    byte is written, so a rejected activation cannot orphan a published pack.
+    Returns (slot_name, enabled_packs).
     """
     slot_names = ("active-pack.0", "active-pack.1")
     slots: list[dict[str, object] | None] = [None, None]
@@ -1177,7 +1182,6 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
                             f"{MAX_ACTIVE_PACKS}; remove an installed pack before activating")
         record = encode_active_map_set(generation=highest + 1, map_set_id=map_set_id,
                                        attribution=attribution, pack_ids=packs)
-        _write_atomic_at(map_sets_fd, style_name, record)
         if slots[0] is None:
             target = slot_names[0]
         elif slots[1] is None:
@@ -1185,7 +1189,17 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
         else:
             target = slot_names[0] if cast(int, slots[0]["generation"]) <= \
                     cast(int, slots[1]["generation"]) else slot_names[1]
+        # Slot first, style record second. The firmware's tile path
+        # (MapTilePack::initialize) reads only the active slots, and its
+        # style catalog (MapStyleCatalog::discover) tolerates a MISSING
+        # style record -- synthesizing the candidate from the active slot --
+        # while aborting only on a CORRUPT one. Because both records carry
+        # the identical PMAS payload, writing the authoritative slot first
+        # makes the worst interruption "map active, style record one build
+        # stale (self-heals on the next activation or retry)" instead of
+        # "no active pack, map unusable until retry".
         _write_atomic_at(pyxis_fd, target, record)
+        _write_atomic_at(map_sets_fd, style_name, record)
     finally:
         os.close(map_sets_fd)
     return target, packs
@@ -1246,19 +1260,7 @@ def _unlink_quietly_at(parent_fd: int, name: str) -> None:
         pass
 
 
-_INSTALL_LOCK_NAME = ".pyxis-install-owner"
-
-
-def _pid_alive(pid: int) -> bool:
-    if pid <= 0 or pid > 0x7FFFFFFF:
-        return False
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    return True
+_INSTALL_LOCK_NAME = ".pyxis-install.lock"
 
 
 @contextlib.contextmanager
@@ -1268,49 +1270,45 @@ def _install_lock_at(pyxis_fd: int):
     The web flasher serializes concurrent installers through the Web Locks
     API; this CLI needs an equivalent because two concurrent --activate
     builds could otherwise both pass the preflight and each clobber the
-    other's records. The lock is a single well-known file in pyxis-map/,
-    so every builder on the card sees it. A lock left behind by a crashed
-    builder is reclaimed when its owner pid is dead; a live owner blocks
-    (pid reuse is resolved conservatively -- block rather than corrupt).
-    The lock file is removed on every exit path.
+    other's records.
+
+    The lock is an advisory fcntl.flock(LOCK_EX | LOCK_NB) on a single
+    well-known file in pyxis-map/, so every builder on the card serializes
+    on the same inode. flock is the race-free primitive here:
+      * acquisition is a single atomic kernel operation, so there is no
+        create-then-write-PID window for a second builder to observe an
+        empty/partial lock and classify it as stale;
+      * the kernel releases the lock when the holder exits or is killed,
+        so a crashed builder cannot wedge the card -- there is no stale
+        lock to reclaim, and no pid-reuse window;
+      * the file is deliberately persistent and never unlinked: unlinking a
+        flock'd file is the classic inode race (a second process would flock
+        a *new* inode and not conflict with the first's held inode). The
+        lock file is invisible to the firmware and flasher, which only read
+        fixed named paths under pyxis-map/ (never a root directory listing).
     """
-    for attempt in range(4):
+    try:
+        descriptor = os.open(_INSTALL_LOCK_NAME,
+                             os.O_RDWR | os.O_CREAT | os.O_CLOEXEC, 0o644,
+                             dir_fd=pyxis_fd)
+    except OSError as exc:
+        raise PackError(f"cannot open the map-install lock: {exc}") from exc
+    try:
         try:
-            descriptor = os.open(_INSTALL_LOCK_NAME,
-                                 os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_CLOEXEC,
-                                 0o644, dir_fd=pyxis_fd)
-            try:
-                _write_all(descriptor, str(os.getpid()).encode("ascii"),
-                           _INSTALL_LOCK_NAME)
-                os.fsync(descriptor)
-            finally:
-                os.close(descriptor)
-            break
-        except FileExistsError:
-            try:
-                raw = _read_file_at(pyxis_fd, _INSTALL_LOCK_NAME, 32)
-            except (PackError, FileNotFoundError):
-                raw = b""
-            owner_pid = 0
-            try:
-                owner_pid = int(raw.decode("ascii"))
-            except ValueError:
-                owner_pid = 0
-            if _pid_alive(owner_pid):
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            if exc.errno in (errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK):
                 raise PackError("another map installer is already running on "
                                 "this card; wait for it to finish and retry") from None
-            _unlink_quietly_at(pyxis_fd, _INSTALL_LOCK_NAME)
-            _fsync_directory_fd(pyxis_fd)
-        except OSError as exc:
             raise PackError(f"cannot acquire the map-install lock: {exc}") from exc
-    else:
-        raise PackError("cannot acquire the map-install lock")
-    _fsync_directory_fd(pyxis_fd)
-    try:
         yield _INSTALL_LOCK_NAME
     finally:
-        _unlink_quietly_at(pyxis_fd, _INSTALL_LOCK_NAME)
-        _fsync_directory_fd(pyxis_fd)
+        # Closing releases the flock. Do NOT unlink: see the docstring.
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(descriptor)
 
 
 def _remove_tree_at(parent_fd: int, name: str) -> None:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -32,6 +32,7 @@ import re
 import stat
 import struct
 import sys
+import time
 from typing import Any, cast, Iterable
 import zlib
 
@@ -1120,7 +1121,8 @@ STYLE_POLICIES: dict[str, dict[str, str]] = {
 }
 
 
-def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attribution: str) -> tuple[str, list[str]]:
+def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attribution: str,
+                     marker_token: str | None = None) -> tuple[str, list[str]]:
     """Publish the v3 active map-set record, mirroring the web flasher.
 
     pyxis_fd is the open pyxis-map/ directory. Slot and style-record
@@ -1141,12 +1143,25 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
     The final pack list is validated against the firmware's pack limit
     before any byte is written, so a rejected activation cannot orphan a
     published pack.
+
+    marker_token is the caller's cross-producer install-marker token (see
+    _acquire_install_marker). When given, the raw slot and style-record
+    bytes are captured when they are first read and re-read immediately
+    before the record writes: if another installer (the web flasher holds
+    a Web Locks name, which this process's flock cannot see) committed new
+    activation state -- or holds a fresh install marker that is not ours --
+    in the meantime, the publication is aborted before any byte is written.
+    The already-published pack is kept; a retry re-derives from the new
+    state and converges, and a pack that no record names is device-harmless
+    (MapTilePack only reads packs enumerated in the active selection).
     Returns (slot_name, enabled_packs).
     """
     slot_names = ("active-pack.0", "active-pack.1")
     slots: list[dict[str, object] | None] = [None, None]
+    slot_raw: list[bytes | None] = [None, None]
     for index, slot_name in enumerate(slot_names):
         raw = _read_selection_at(pyxis_fd, slot_name)
+        slot_raw[index] = raw
         if raw is not None:
             slots[index] = decode_active_selection(raw)
     if slots[0] is not None and slots[1] is not None \
@@ -1191,6 +1206,16 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
         else:
             target = slot_names[0] if cast(int, slots[0]["generation"]) <= \
                     cast(int, slots[1]["generation"]) else slot_names[1]
+        # Commit-time revalidation: the slot/style records were derived
+        # above; a concurrent cross-producer installer (the web flasher's
+        # Web Locks name is invisible to our flock) may have committed new
+        # activation state in the meantime. Re-reading the raw bytes here
+        # and aborting on any change guarantees this publication never
+        # overwrites a newer record with one derived from stale state.
+        # installed_raw is the style record's bytes as first read above.
+        _verify_activation_state_at(pyxis_fd, map_sets_fd, slot_raw=slot_raw,
+                                    style_raw=installed_raw, style_name=style_name,
+                                    marker_token=marker_token)
         # Style record first, active slot second (the web flasher's order).
         # The firmware's device-side style activation
         # (MapStyleCatalog::activate) reads the style record as the source
@@ -1316,6 +1341,149 @@ def _install_lock_at(pyxis_fd: int):
         except OSError:
             pass
         os.close(descriptor)
+
+
+# Cross-producer install marker.
+#
+# The web flasher holds a Web Locks name and this CLI holds an advisory
+# flock: two unrelated locking namespaces, so each lock is invisible to
+# the other producer. The on-disk marker below is the one coordination
+# primitive both producers share -- the flasher writes the same file with
+# the same token format (docs/flasher/js/map-installer.js). A marker is a
+# small file containing: PYXI 1 <owner> <epoch_ms>.
+
+_INSTALL_MARKER_NAME = ".pyxis-installing"
+# A marker written within this window is a live installer. Installations
+# longer than this are treated as abandoned (crashed builder, closed tab)
+# and reclaimed. A future epoch (writer clock ahead of ours) counts as
+# fresh: refusing is the safe direction.
+_INSTALL_MARKER_TTL_SECONDS = 900
+
+
+def _marker_token(owner: str) -> str:
+    return f"PYXI 1 {owner} {int(time.time() * 1000)}"
+
+
+def _parse_marker(raw: bytes) -> tuple[str, int] | None:
+    """Parse a marker token into (owner, epoch_ms); None if malformed."""
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    parts = text.strip().split(" ")
+    if len(parts) != 4 or parts[0] != "PYXI" or parts[1] != "1":
+        return None
+    if not parts[2] or len(parts[2]) > 64 or not parts[3].isdigit():
+        return None
+    return parts[2], int(parts[3])
+
+
+def _marker_is_fresh(epoch_ms: int) -> bool:
+    now_ms = int(time.time() * 1000)
+    if epoch_ms > now_ms:
+        return True
+    return (now_ms - epoch_ms) / 1000.0 <= _INSTALL_MARKER_TTL_SECONDS
+
+
+def _acquire_install_marker(pyxis_fd: int) -> str:
+    """Claim the cross-producer install marker; return our token.
+
+    Protocol (shared with the web flasher):
+      * no marker              -> create it;
+      * fresh foreign marker   -> refuse: another installer is live;
+      * stale or malformed     -> reclaim (unlink, then create).
+    After creation the file is read back and compared to our token: a
+    foreign content means we lost a simultaneous acquire race and we
+    abort. The marker is best-effort coordination -- the safety net is
+    the commit-time revalidation in activate_map_set, which refuses to
+    publish a record over activation state that moved since it was
+    derived.
+    """
+    owner = f"cli-{os.getpid():x}"
+    token = _marker_token(owner)
+    raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    if raw is not None:
+        parsed = _parse_marker(raw)
+        if parsed is not None and _marker_is_fresh(parsed[1]):
+            raise PackError("another map installer is already running on "
+                            "this card; wait for it to finish and retry")
+        # Stale or malformed: reclaim. A malformed marker may be a live
+        # writer mid-write, but the read-back below fails loudly if so,
+        # and commit-time revalidation covers the rest.
+        _unlink_quietly_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    try:
+        descriptor = os.open(_INSTALL_MARKER_NAME,
+                             os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+                             0o644, dir_fd=pyxis_fd)
+    except FileExistsError:
+        raise PackError("another map installer is already running on "
+                        "this card; wait for it to finish and retry") from None
+    except OSError as exc:
+        raise PackError(f"cannot write the map-install marker: {exc}") from exc
+    try:
+        _write_all(descriptor, token.encode("ascii"), _INSTALL_MARKER_NAME)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    actual = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    if actual != token.encode("ascii"):
+        # Someone overwrote (or removed) our marker while we acquired it.
+        # Never delete a foreign marker: our claim is void, abort.
+        raise PackError("the map-install marker was contested during "
+                        "acquisition; wait and retry")
+    _fsync_directory_fd(pyxis_fd)
+    return token
+
+
+def _release_install_marker(pyxis_fd: int, token: str) -> None:
+    """Remove our install marker -- and only ours.
+
+    If the marker content is not our own token (a later installer
+    reclaimed it after our install outlasted the TTL, or a crashed run
+    left a different claim), deleting it would drop that installer's
+    live claim. Leave it; the TTL reclaims it.
+    """
+    raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    if raw == token.encode("ascii"):
+        try:
+            os.unlink(_INSTALL_MARKER_NAME, dir_fd=pyxis_fd)
+        except OSError:
+            pass
+
+
+def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
+                                slot_raw: list[bytes | None],
+                                style_raw: bytes | None, style_name: str,
+                                marker_token: str | None) -> None:
+    """Commit-time revalidation against a concurrent installer.
+
+    Re-reads the install marker and the raw activation records
+    immediately before the record writes. If a cross-producer installer
+    (web flasher or another builder) committed since the records were
+    derived -- or holds a fresh install marker that is not ours -- the
+    activation is aborted before any byte is written. The published pack
+    is kept; a retry re-derives from the new state and converges (the
+    pack is device-harmless while it is not named by any record: the
+    firmware only reads packs enumerated in the active selection).
+    """
+    marker_raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    if marker_raw is not None:
+        own = marker_token.encode("ascii") if marker_token is not None else None
+        parsed = _parse_marker(marker_raw)
+        if parsed is not None and _marker_is_fresh(parsed[1]) \
+                and marker_raw != own:
+            raise PackError("another map installer is running on this card; "
+                            "wait for it to finish and retry")
+    for index, slot_name in enumerate(("active-pack.0", "active-pack.1")):
+        actual = _read_selection_at(pyxis_fd, slot_name)
+        if actual != slot_raw[index]:
+            raise PackError("active map-set records changed during "
+                            "installation; wait for the other installer "
+                            "to finish and retry")
+    actual_style = _read_selection_at(map_sets_fd, style_name)
+    if actual_style != style_raw:
+        raise PackError("installed style record changed during installation; "
+                        "wait for the other installer to finish and retry")
 
 
 def _remove_tree_at(parent_fd: int, name: str) -> None:
@@ -1512,52 +1680,68 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
             assert style is not None
             # Hold the install lock from the preflight through activation:
             # two concurrent builders could otherwise both pass the
-            # preflight and each clobber the other's records.
+            # preflight and each clobber the other's records. The cross-
+            # producer install marker (shared with the web flasher, which
+            # holds a Web Locks name this flock cannot see) is claimed for
+            # the same span and released on every exit path.
             with _install_lock_at(pyxis_fd):
-                _preflight_activation(pyxis_fd, pack_id=pack_id, map_set_id=style,
-                                      attribution=attribution)
-                if not resumed:
-                    temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
-                    copied = 0
-                    for tile in tiles:
-                        copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
-                        copied += tile.size
-                    manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL
-                                           | os.O_CLOEXEC, 0o644, dir_fd=stage_fd)
-                    try:
-                        _write_all(manifest_fd, manifest, "manifest.pmp")
-                        os.fsync(manifest_fd)
-                    finally:
-                        os.close(manifest_fd)
-                    _fsync_directory_fd(stage_fd)
-                    _validate_pack_fd(stage_fd, target, max_bytes)
-                    _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity,
-                                         packs_identity)
-                    _rename_noreplace(packs_fd, temporary, pack_id, target)
-                    committed = True
-                    try:
-                        _verify_output_chain(output_root, output_fd, pyxis_fd,
-                                             pyxis_identity, packs_identity)
-                    except BaseException as exc:
+                # Claim the cross-producer install marker FIRST, before any
+                # staging or publication: a live web-flasher install (which
+                # holds a Web Locks name this flock cannot see) is announced
+                # by its marker, and refusing up front avoids the wasted
+                # tile copies and -- more importantly -- avoids publishing a
+                # pack that activation would then have to abandon. Stale or
+                # malformed markers (crashed builder, closed tab) are
+                # reclaimed here; ours is released on every exit path.
+                marker_token = _acquire_install_marker(pyxis_fd)
+                try:
+                    _preflight_activation(pyxis_fd, pack_id=pack_id, map_set_id=style,
+                                          attribution=attribution)
+                    if not resumed:
+                        temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
+                        copied = 0
+                        for tile in tiles:
+                            copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
+                            copied += tile.size
+                        manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                                               | os.O_CLOEXEC, 0o644, dir_fd=stage_fd)
                         try:
-                            _remove_tree_at(packs_fd, pack_id)
-                            _fsync_directory_fd(packs_fd)
-                            committed = False
-                        except BaseException as cleanup_error:
-                            raise PublishedDurabilityError(target, OSError(
-                                f"publication location changed and rollback failed: "
-                                f"{cleanup_error}")) from exc
-                        raise PackError("output directory changed during publication; "
-                                        "rolled back") from exc
-                    try:
-                        os.close(stage_fd)
-                    except OSError as exc:
+                            _write_all(manifest_fd, manifest, "manifest.pmp")
+                            os.fsync(manifest_fd)
+                        finally:
+                            os.close(manifest_fd)
+                        _fsync_directory_fd(stage_fd)
+                        _validate_pack_fd(stage_fd, target, max_bytes)
+                        _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity,
+                                             packs_identity)
+                        _rename_noreplace(packs_fd, temporary, pack_id, target)
+                        committed = True
+                        try:
+                            _verify_output_chain(output_root, output_fd, pyxis_fd,
+                                                 pyxis_identity, packs_identity)
+                        except BaseException as exc:
+                            try:
+                                _remove_tree_at(packs_fd, pack_id)
+                                _fsync_directory_fd(packs_fd)
+                                committed = False
+                            except BaseException as cleanup_error:
+                                raise PublishedDurabilityError(target, OSError(
+                                    f"publication location changed and rollback failed: "
+                                    f"{cleanup_error}")) from exc
+                            raise PackError("output directory changed during publication; "
+                                            "rolled back") from exc
+                        try:
+                            os.close(stage_fd)
+                        except OSError as exc:
+                            stage_fd = -1
+                            raise PublishedDurabilityError(target, exc) from exc
                         stage_fd = -1
-                        raise PublishedDurabilityError(target, exc) from exc
-                    stage_fd = -1
-                slot_name, _enabled = activate_map_set(pyxis_fd, pack_id=pack_id,
-                                                       map_set_id=style,
-                                                       attribution=attribution)
+                    slot_name, _enabled = activate_map_set(pyxis_fd, pack_id=pack_id,
+                                                           map_set_id=style,
+                                                           attribution=attribution,
+                                                           marker_token=marker_token)
+                finally:
+                    _release_install_marker(pyxis_fd, marker_token)
         else:
             temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
             copied = 0

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -43,6 +43,7 @@ EXTENT_SIZE = 26
 ROW_SPAN_SIZE = 13
 MAX_ROW_SPANS = 512
 MAX_ZOOM = 22
+MAX_ACTIVE_PACKS = 8  # firmware ActiveMapSetCodec::MAX_PACKS
 DEFAULT_MAX_TILES = 100_000
 DEFAULT_MAX_BYTES = 8 * 1024 * 1024 * 1024
 MAX_VISITED_ENTRIES_BASE = 64
@@ -778,8 +779,8 @@ def encode_active_map_set(*, generation: int, map_set_id: str, attribution: str,
         raise PackError("active map-set generation is invalid")
     map_set = _checked_text("map_set_id", map_set_id)
     credit = _checked_text("attribution", attribution)
-    if not PACK_ID_RE.fullmatch(map_set_id) or len(pack_ids) == 0 or len(pack_ids) > 8:
-        raise PackError("invalid active map-set packs")
+    if not PACK_ID_RE.fullmatch(map_set_id) or not pack_ids or len(pack_ids) > MAX_ACTIVE_PACKS:
+        raise PackError(f"invalid active map-set packs (limit {MAX_ACTIVE_PACKS})")
     seen: set[str] = set()
     encoded_packs: list[bytes] = []
     for pack_id in pack_ids:
@@ -1073,8 +1074,14 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
     read both slots, reject conflicting same-generation records, resolve
     the pack list from the installed style record (falling back to the
     highest-generation slot of the same style), write the style record
-    under map-sets/ and then the chosen active-pack slot, each with fsync
-    plus byte-exact read-back. Returns (slot_name, enabled_packs).
+    under map-sets/ and then the chosen active-pack slot. Both writes go
+    through _write_atomic_at (exclusive temp file, fsync, rename,
+    read-back) so an interrupted activation never truncates or leaves a
+    partial record: a crash mid-write leaves the previous record intact
+    and a retry repairs the slot. The final pack list is validated
+    against the firmware's pack limit before any byte is written, so a
+    rejected activation cannot orphan a just-published pack. Returns
+    (slot_name, enabled_packs).
     """
     slot_names = ("active-pack.0", "active-pack.1")
     slots: list[dict[str, object] | None] = [None, None]
@@ -1112,9 +1119,12 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
                 raise PackError("installed map set attribution does not match")
             packs = [value for value in cast(list[str], composition["packs"]) if value != pack_id]
         packs.insert(0, pack_id)
+        if len(packs) > MAX_ACTIVE_PACKS:
+            raise PackError(f"active map-set pack limit exceeded: {len(packs)} > "
+                            f"{MAX_ACTIVE_PACKS}; remove an installed pack before activating")
         record = encode_active_map_set(generation=highest + 1, map_set_id=map_set_id,
                                        attribution=attribution, pack_ids=packs)
-        _write_verified_at(map_sets_fd, style_name, record)
+        _write_atomic_at(map_sets_fd, style_name, record)
         if slots[0] is None:
             target = slot_names[0]
         elif slots[1] is None:
@@ -1122,7 +1132,7 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
         else:
             target = slot_names[0] if cast(int, slots[0]["generation"]) <= \
                     cast(int, slots[1]["generation"]) else slot_names[1]
-        _write_verified_at(pyxis_fd, target, record)
+        _write_atomic_at(pyxis_fd, target, record)
     finally:
         os.close(map_sets_fd)
     return target, packs
@@ -1143,6 +1153,61 @@ def _write_verified_at(parent_fd: int, name: str, data: bytes) -> None:
     actual = _read_file_at(parent_fd, name, len(data))
     if actual != data:
         raise PackError(f"read-back verification failed for {name}")
+
+
+def _write_atomic_at(parent_fd: int, name: str, data: bytes) -> None:
+    """Atomically replace ``name`` with ``data`` using an exclusive temp file.
+
+    Writes to a per-process temp name, fsyncs it, then renameat()s it over
+    the destination. Because rename is atomic, a crash at any point leaves
+    either the old record (temp not yet renamed) or the new record (rename
+    done) in place -- never a truncated or partial one. The temp file is
+    created with O_EXCL so concurrent activations cannot clobber each
+    other's staging. Activation correctness depends on atomicity, so an
+    unsupported host fails closed.
+    """
+    if _renameat2 is None:
+        raise PackError("atomic record replacement unsupported on this host")
+    marker = os.getpid()
+    for attempt in range(256):
+        temp_name = f".{name}.tmp-{marker:x}-{attempt:02x}"
+        try:
+            descriptor = os.open(temp_name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+                                 0o600, dir_fd=parent_fd)
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise PackError(f"cannot write {name}: {exc}") from exc
+        break
+    else:
+        raise PackError(f"cannot allocate temporary record file for {name}")
+    try:
+        _write_all(descriptor, data, name)
+        os.fsync(descriptor)
+    except Exception as exc:
+        os.close(descriptor)
+        _unlink_quietly_at(parent_fd, temp_name)
+        raise PackError(f"cannot write {name}: {exc}") from exc
+    os.close(descriptor)
+    try:
+        result = _renameat2(parent_fd, os.fsencode(temp_name), parent_fd, os.fsencode(name), 0)
+        if result != 0:
+            error = ctypes.get_errno()
+            raise OSError(error, os.strerror(error), name)
+        _fsync_directory_fd(parent_fd)
+    except Exception as exc:
+        _unlink_quietly_at(parent_fd, temp_name)
+        raise PackError(f"cannot atomically replace {name}: {exc}") from exc
+    actual = _read_file_at(parent_fd, name, len(data))
+    if actual != data:
+        raise PackError(f"read-back verification failed for {name}")
+
+
+def _unlink_quietly_at(parent_fd: int, name: str) -> None:
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except OSError:
+        pass
 
 
 def _remove_tree_at(parent_fd: int, name: str) -> None:
@@ -1203,6 +1268,46 @@ def _verify_output_chain(output_root: Path, root_fd: int, pyxis_fd: int, pyxis_i
         raise PackError(f"output directory changed before publication: {exc}") from exc
     if _identity(pyxis_info)[:3] != pyxis_identity[:3] or _identity(packs_info)[:3] != packs_identity[:3]:
         raise PackError("output directory changed before publication")
+
+
+def _preflight_activation(pyxis_fd: int, *, pack_id: str, map_set_id: str, attribution: str) -> None:
+    """Reject an activation whose inherited composition exceeds the limit.
+
+    Runs before any tile is staged or the pack is published, so a rejected
+    activation leaves the card exactly as it was found -- no published pack,
+    no rewritten record. Mirrors the composition rules in activate_map_set.
+    """
+    slot_names = ("active-pack.0", "active-pack.1")
+    slots: list[dict[str, object] | None] = [None, None]
+    for index, slot_name in enumerate(slot_names):
+        raw = _read_selection_at(pyxis_fd, slot_name)
+        if raw is not None:
+            slots[index] = decode_active_selection(raw)
+    valid = [slot for slot in slots if slot is not None]
+    map_sets_fd, _ = _mkdir_open(pyxis_fd, "map-sets")
+    try:
+        style_name = f"{map_set_id}.pmas"
+        installed_raw = _read_selection_at(map_sets_fd, style_name)
+        installed = decode_active_selection(installed_raw) if installed_raw is not None else None
+        if installed is not None:
+            if installed["format_version"] not in (2, 3) or installed["map_set_id"] != map_set_id \
+                    or installed["attribution"] != attribution:
+                raise PackError("installed style record does not match selected map set")
+        composition = installed
+        if composition is None and valid:
+            current = max(valid, key=lambda slot: cast(int, slot["generation"]))
+            if current["format_version"] in (2, 3) and current["map_set_id"] == map_set_id:
+                composition = current
+        if composition is not None:
+            if composition["attribution"] != attribution:
+                raise PackError("installed map set attribution does not match")
+            packs = [value for value in cast(list[str], composition["packs"]) if value != pack_id]
+            packs.insert(0, pack_id)
+            if len(packs) > MAX_ACTIVE_PACKS:
+                raise PackError(f"active map-set pack limit exceeded: {len(packs)} > "
+                                f"{MAX_ACTIVE_PACKS}; remove an installed pack before activating")
+    finally:
+        os.close(map_sets_fd)
 
 
 def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, name: str,
@@ -1269,6 +1374,10 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
         output_fd = _open_path(output_root, create=True)
         pyxis_fd, pyxis_identity = _mkdir_open(output_fd, "pyxis-map")
         packs_fd, packs_identity = _mkdir_open(pyxis_fd, "packs")
+        if activate:
+            assert style is not None
+            _preflight_activation(pyxis_fd, pack_id=pack_id, map_set_id=style,
+                                  attribution=attribution)
         temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
         copied = 0
         for tile in tiles:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1231,6 +1231,30 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
         # builder retry completes the new activation. Both records carry
         # the identical PMAS payload.
         _write_atomic_at(map_sets_fd, style_name, record)
+        # FINAL revalidation immediately before the slot write (round
+        # 13): the check above can sit a long time before the slot
+        # write (the style write and the slot write are each atomic,
+        # but a stalled card can delay either one), so the claim may
+        # have expired in between -- a cross-producer could then
+        # legitimately reclaim it and commit, and our slot write would
+        # clobber its newer record. The slot record IS the active
+        # selection (what the device reads), so THIS is the clobber
+        # point and the freshness + CAS boundary belongs here. The
+        # slot is still CAS'd against the derivation snapshot; the
+        # style is compared against the record we JUST wrote -- a
+        # self-check that catches a cross-producer style write that
+        # landed after ours (same-generation split state), because
+        # installed_raw is stale after our own style write. A missing/
+        # foreign/expired claim or any mismatch aborts before the slot
+        # byte is written. An abort here leaves either our own
+        # (newer) style record over the old slot, or the cross
+        # producer's consistent pair -- both device-safe: the first is
+        # the documented style-first worst case that the next retry or
+        # device style re-activation completes, the second is already
+        # converged.
+        _verify_activation_state_at(pyxis_fd, map_sets_fd, slot_raw=slot_raw,
+                                    style_raw=record, style_name=style_name,
+                                    marker_token=marker_token)
         _write_atomic_at(pyxis_fd, target, record)
     finally:
         os.close(map_sets_fd)
@@ -1561,6 +1585,19 @@ def _release_install_marker(pyxis_fd: int, token: str) -> None:
                 pass
 
 
+def _own_marker_is_fresh(raw: bytes) -> bool:
+    """Freshness check for OUR OWN marker at a commit boundary.
+
+    Isolated from _marker_is_fresh (which also serves cross-producer
+    checks) so tests can model claim expiry inside the two-record
+    commit without disturbing the cross checks.
+    """
+    parsed = _parse_marker(raw)
+    if parsed is None:
+        return False
+    return _marker_is_fresh(parsed[1])
+
+
 def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
                                 slot_raw: list[bytes | None],
                                 style_raw: bytes | None, style_name: str,
@@ -1598,7 +1635,7 @@ def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
             raise PackError("the map-install marker was reclaimed during "
                             "installation; wait for the other installer "
                             "to finish and retry")
-        if not _marker_is_fresh(parsed[1]):
+        if not _own_marker_is_fresh(marker_raw):
             # The owner matches but the claim has aged out: a
             # cross-producer is entitled to reclaim it right now, so
             # committing against the pre-reclaim state would race the

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1343,16 +1343,33 @@ def _install_lock_at(pyxis_fd: int):
         os.close(descriptor)
 
 
-# Cross-producer install marker.
+# Cross-producer install markers.
 #
 # The web flasher holds a Web Locks name and this CLI holds an advisory
 # flock: two unrelated locking namespaces, so each lock is invisible to
-# the other producer. The on-disk marker below is the one coordination
-# primitive both producers share -- the flasher writes the same file with
-# the same token format (docs/flasher/js/map-installer.js). A marker is a
-# small file containing: PYXI 1 <owner> <epoch_ms>.
+# the other producer. The on-disk marker files below are the one
+# coordination primitive both producers share. Each producer writes
+# ONLY its own marker file -- no producer ever writes a file it does
+# not own, so a stalled installer's renewal can never clobber a claim
+# the other producer just made (the shared-file check-then-act window
+# is gone by construction):
+#
+#   .pyxis-installing-cli   this builder
+#   .pyxis-installing-web   the web flasher
+#   .pyxis-installing       legacy shared marker (pre-per-file
+#                           producers); honored -- fresh ones refuse,
+#                           stale ones are reclaimed -- but never
+#                           written
+#
+# A marker is a small file containing: PYXI 1 <owner> <epoch_ms>.
 
-_INSTALL_MARKER_NAME = ".pyxis-installing"
+_INSTALL_MARKER_NAME = ".pyxis-installing-cli"
+_WEB_INSTALL_MARKER_NAME = ".pyxis-installing-web"
+_LEGACY_INSTALL_MARKER_NAME = ".pyxis-installing"
+# Cross-producer files this producer must respect: refuse when fresh,
+# reclaim when stale.
+_CROSS_INSTALL_MARKERS = (_WEB_INSTALL_MARKER_NAME,
+                          _LEGACY_INSTALL_MARKER_NAME)
 # A marker written within this window is a live installer. Installations
 # longer than this are treated as abandoned (crashed builder, closed tab)
 # and reclaimed. A future epoch (writer clock ahead of ours) counts as
@@ -1385,6 +1402,27 @@ def _marker_is_fresh(epoch_ms: int) -> bool:
     return (now_ms - epoch_ms) / 1000.0 <= _INSTALL_MARKER_TTL_SECONDS
 
 
+def _check_cross_installers(pyxis_fd: int, *, reclaim: bool) -> None:
+    """Respect the other producers' marker files.
+
+    A FRESH foreign marker (the web flasher's, or the legacy shared
+    one) means a live cross-producer installer: refuse. A stale or
+    malformed one is an abandoned install; reclaim it only when the
+    caller says so (at acquire, where claiming is the intent). Fresh
+    foreign markers are never touched.
+    """
+    for name in _CROSS_INSTALL_MARKERS:
+        raw = _read_selection_at(pyxis_fd, name)
+        if raw is None:
+            continue
+        parsed = _parse_marker(raw)
+        if parsed is not None and _marker_is_fresh(parsed[1]):
+            raise PackError("another map installer is already running on "
+                            "this card; wait for it to finish and retry")
+        if reclaim:
+            _unlink_quietly_at(pyxis_fd, name)
+
+
 def _acquire_install_marker(pyxis_fd: int) -> str:
     """Claim the cross-producer install marker; return our token.
 
@@ -1398,9 +1436,15 @@ def _acquire_install_marker(pyxis_fd: int) -> str:
     the commit-time revalidation in activate_map_set, which refuses to
     publish a record over activation state that moved since it was
     derived.
+
+    The other producers' marker files are checked first: a fresh
+    cross-producer marker refuses the install up front, and stale
+    cross markers (crashed flasher tab, dead legacy builder) are
+    reclaimed so they cannot block a legitimate install.
     """
     owner = f"cli-{os.getpid():x}"
     token = _marker_token(owner)
+    _check_cross_installers(pyxis_fd, reclaim=True)
     raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
     if raw is not None:
         parsed = _parse_marker(raw)
@@ -1465,6 +1509,11 @@ def _renew_install_marker(pyxis_fd: int, owner: str) -> None:
         raise PackError("the map-install marker was reclaimed during "
                         "installation; wait for the other installer to "
                         "finish and retry")
+    # The cross producers are re-checked on every renewal too: if the
+    # other installer acquired DURING our install (a gap the
+    # acquire-time check cannot cover), the heartbeat detects it and
+    # aborts instead of continuing a conflicting publication.
+    _check_cross_installers(pyxis_fd, reclaim=False)
     token = _marker_token(owner)
     descriptor = os.open(_INSTALL_MARKER_NAME,
                          os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC,
@@ -1505,15 +1554,19 @@ def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
                                 marker_token: str | None) -> None:
     """Commit-time revalidation against a concurrent installer.
 
-    Re-reads the install marker and the raw activation records
+    Re-reads the install markers and the raw activation records
     immediately before the record writes. If a cross-producer installer
     (web flasher or another builder) committed since the records were
-    derived -- or holds a fresh install marker that is not ours -- the
+    derived -- or holds a fresh install marker that is not ours, in
+    this producer's own file or in the cross producers' files -- the
     activation is aborted before any byte is written. The published pack
     is kept; a retry re-derives from the new state and converges (the
     pack is device-harmless while it is not named by any record: the
     firmware only reads packs enumerated in the active selection).
     """
+    # Cross producers: a fresh marker in the web/legacy files means the
+    # other installer started (or is mid-install) after we acquired.
+    _check_cross_installers(pyxis_fd, reclaim=False)
     marker_raw = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
     if marker_raw is not None:
         # Compare by owner, not the full token: we renew the marker's

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1138,23 +1138,6 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
     return target, packs
 
 
-def _write_verified_at(parent_fd: int, name: str, data: bytes) -> None:
-    try:
-        descriptor = os.open(name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_CLOEXEC, 0o644,
-                             dir_fd=parent_fd)
-    except OSError as exc:
-        raise PackError(f"cannot write {name}: {exc}") from exc
-    try:
-        _write_all(descriptor, data, name)
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-    _fsync_directory_fd(parent_fd)
-    actual = _read_file_at(parent_fd, name, len(data))
-    if actual != data:
-        raise PackError(f"read-back verification failed for {name}")
-
-
 def _write_atomic_at(parent_fd: int, name: str, data: bytes) -> None:
     """Atomically replace ``name`` with ``data`` using an exclusive temp file.
 

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1598,6 +1598,16 @@ def _verify_activation_state_at(pyxis_fd: int, map_sets_fd: int, *,
             raise PackError("the map-install marker was reclaimed during "
                             "installation; wait for the other installer "
                             "to finish and retry")
+        if not _marker_is_fresh(parsed[1]):
+            # The owner matches but the claim has aged out: a
+            # cross-producer is entitled to reclaim it right now, so
+            # committing against the pre-reclaim state would race the
+            # new holder. Aborting on a live (fresh) claim boundary is
+            # the safe direction; the pack stays published and a retry
+            # re-derives after the other installer finishes.
+            raise PackError("the install claim expired during "
+                            "installation; wait for the other installer "
+                            "to finish and retry")
     elif marker_raw is not None:
         # No token was acquired (resume path without a marker): only a
         # FRESH marker in our own file is a live foreign claim; a

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1128,17 +1128,19 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
     read both slots, reject conflicting same-generation records, resolve
     the pack list from the installed style record (falling back to the
     highest-generation slot of the same style), then publish the record to
-    the chosen active-pack slot FIRST and the style record under map-sets/
+    the style record under map-sets/ first and the chosen active-pack slot
     second. Both writes go through _write_atomic_at (exclusive temp file,
     fsync, rename, read-back) so an interrupted activation never truncates
-    or leaves a partial record: a crash mid-write leaves the previous record
-    intact and a retry repairs the style record. The slot is authoritative
-    in the firmware (tile serving reads only the active slots, and the style
-    catalog tolerates a missing style record), so slot-first ordering means
-    an interruption between the two commits leaves the map ACTIVE with the
-    style record one build stale, rather than dropping the active pack. The
-    final pack list is validated against the firmware's pack limit before any
-    byte is written, so a rejected activation cannot orphan a published pack.
+    or leaves a partial record: a crash mid-write leaves the previous
+    record intact and a retry (or the device's own style re-activation)
+    completes the activation. The style record is written first because the
+    firmware's device-side style activation (MapStyleCatalog::activate)
+    resequences the style record's composition into the active slot, so the
+    style record must never be older than the slot -- otherwise a stale
+    style record would reseed the slot and drop a newly installed pack.
+    The final pack list is validated against the firmware's pack limit
+    before any byte is written, so a rejected activation cannot orphan a
+    published pack.
     Returns (slot_name, enabled_packs).
     """
     slot_names = ("active-pack.0", "active-pack.1")
@@ -1189,17 +1191,22 @@ def activate_map_set(pyxis_fd: int, *, pack_id: str, map_set_id: str, attributio
         else:
             target = slot_names[0] if cast(int, slots[0]["generation"]) <= \
                     cast(int, slots[1]["generation"]) else slot_names[1]
-        # Slot first, style record second. The firmware's tile path
-        # (MapTilePack::initialize) reads only the active slots, and its
-        # style catalog (MapStyleCatalog::discover) tolerates a MISSING
-        # style record -- synthesizing the candidate from the active slot --
-        # while aborting only on a CORRUPT one. Because both records carry
-        # the identical PMAS payload, writing the authoritative slot first
-        # makes the worst interruption "map active, style record one build
-        # stale (self-heals on the next activation or retry)" instead of
-        # "no active pack, map unusable until retry".
-        _write_atomic_at(pyxis_fd, target, record)
+        # Style record first, active slot second (the web flasher's order).
+        # The firmware's device-side style activation
+        # (MapStyleCatalog::activate) reads the style record as the source
+        # of truth and resequences its composition into the active slot.
+        # If the style record were ever older than the slot, that path
+        # would reseed the slot from the stale composition and drop a
+        # newly installed pack. Writing the style record first guarantees
+        # the style record is never older than the slot, so every recovery
+        # path (CLI retry, device-side style re-activation) converges
+        # forward to the newest composition. The worst interruption is
+        # "slot one build stale, style record current" -- the map still
+        # serves from the previous pack and the next style cycle or
+        # builder retry completes the new activation. Both records carry
+        # the identical PMAS payload.
         _write_atomic_at(map_sets_fd, style_name, record)
+        _write_atomic_at(pyxis_fd, target, record)
     finally:
         os.close(map_sets_fd)
     return target, packs

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1266,6 +1266,9 @@ def _preflight_activation(pyxis_fd: int, *, pack_id: str, map_set_id: str, attri
         raw = _read_selection_at(pyxis_fd, slot_name)
         if raw is not None:
             slots[index] = decode_active_selection(raw)
+    if slots[0] is not None and slots[1] is not None \
+            and slots[0]["generation"] == slots[1]["generation"] and slots[0] != slots[1]:
+        raise PackError("conflicting active map-set records")
     valid = [slot for slot in slots if slot is not None]
     map_sets_fd, _ = _mkdir_open(pyxis_fd, "map-sets")
     try:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1443,21 +1443,37 @@ def _renew_install_marker(pyxis_fd: int, owner: str) -> None:
     and a second producer could reclaim our live claim. The rewrite
     keeps our owner identity and advances the epoch; the release path
     and the commit-time check compare the owner, so renewed markers are
-    still recognized as ours. Best effort: a failed renewal is retried
-    on the next tile and the commit-time marker check is the backstop.
+    still recognized as ours.
+
+    The renewal is ownership-checked, never a blind overwrite: if the
+    marker no longer carries OUR owner -- it aged out and another
+    producer legitimately reclaimed it, was deleted, or is corrupt --
+    our claim is void. Overwriting a foreign claim would steal the
+    card mid-install, so the install aborts instead; the (possibly
+    partially published) pack stays device-harmless and the user
+    retries after the other installer finishes. A transient I/O error
+    on the marker read/write also aborts: an unverifiable claim is no
+    safer than a lost one.
     """
+    current = _read_selection_at(pyxis_fd, _INSTALL_MARKER_NAME)
+    if current is None:
+        raise PackError("the map-install marker was reclaimed during "
+                        "installation; wait for the other installer to "
+                        "finish and retry")
+    parsed = _parse_marker(current)
+    if parsed is None or parsed[0] != owner:
+        raise PackError("the map-install marker was reclaimed during "
+                        "installation; wait for the other installer to "
+                        "finish and retry")
+    token = _marker_token(owner)
+    descriptor = os.open(_INSTALL_MARKER_NAME,
+                         os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC,
+                         dir_fd=pyxis_fd)
     try:
-        token = _marker_token(owner)
-        descriptor = os.open(_INSTALL_MARKER_NAME,
-                             os.O_WRONLY | os.O_TRUNC | os.O_CLOEXEC,
-                             dir_fd=pyxis_fd)
-        try:
-            _write_all(descriptor, token.encode("ascii"), _INSTALL_MARKER_NAME)
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
-    except OSError:
-        pass
+        _write_all(descriptor, token.encode("ascii"), _INSTALL_MARKER_NAME)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def _release_install_marker(pyxis_fd: int, token: str) -> None:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -20,6 +20,7 @@ Coverage models:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import ctypes
 from dataclasses import dataclass
 import errno
@@ -1042,6 +1043,58 @@ def validate_pack(pack_directory: Path, max_bytes: int = DEFAULT_MAX_BYTES) -> d
         os.close(descriptor)
 
 
+def _existing_pack_fd(packs_fd: int, pack_id: str) -> int | None:
+    """Open a published pack directory if it exists; None otherwise."""
+    try:
+        return os.open(pack_id, _DIRECTORY_FLAGS, dir_fd=packs_fd)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise PackError(f"existing pack is not a real directory: {pack_id}: {exc}") from exc
+
+
+def _verify_existing_pack(source_fd: int, pack_fd: int, pack_id: str,
+                          expected_manifest: bytes, tiles: list[Tile],
+                          max_bytes: int) -> None:
+    """Verify a published pack byte-for-byte against the source tiles.
+
+    Mirrors the web flasher's verifyExistingPack: a pack that already
+    exists may only be resumed when its manifest and every tile match the
+    input exactly, so a resume never republishes different content under
+    an existing name.
+    """
+    try:
+        raw_manifest = _read_file_at(pack_fd, "manifest.pmp", MAX_MANIFEST_BYTES)
+    except FileNotFoundError:
+        raise PackError(f"existing pack {pack_id} is incomplete: manifest.pmp missing") from None
+    if raw_manifest != expected_manifest:
+        raise PackError(f"existing pack {pack_id} does not match this source and "
+                        "cannot be resumed")
+    tiles_fd, _ = _open_child_directory(pack_fd, "tiles", f"{pack_id}/tiles")
+    try:
+        actual = _discover_tiles_fd(tiles_fd, Path(pack_id) / "tiles", len(tiles), max_bytes)
+    finally:
+        os.close(tiles_fd)
+    if len(actual) != len(tiles):
+        raise PackError(f"existing pack {pack_id} tile count does not match this source")
+    input_by_key = {(tile.zoom, tile.x, tile.y): tile for tile in tiles}
+    for actual_tile in actual:
+        key = (actual_tile.zoom, actual_tile.x, actual_tile.y)
+        source_tile = input_by_key.get(key)
+        if source_tile is None:
+            raise PackError(f"existing pack {pack_id} contains a tile this source does not")
+        existing_bytes = _read_file_at(pack_fd, f"tiles/{actual_tile.zoom}/"
+                                                f"{actual_tile.x}/{actual_tile.y}.png", max_bytes)
+        input_fd = _open_verified_tile(source_fd, source_tile)
+        try:
+            input_bytes = _read_exact(input_fd, source_tile.size, str(source_tile.path))
+        finally:
+            os.close(input_fd)
+        if existing_bytes != input_bytes:
+            raise PackError(f"existing pack {pack_id} tile {actual_tile.zoom}/"
+                            f"{actual_tile.x}/{actual_tile.y}.png differs from this source")
+
+
 STYLE_POLICIES: dict[str, dict[str, str]] = {
     "osm-bright": {
         "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
@@ -1193,6 +1246,73 @@ def _unlink_quietly_at(parent_fd: int, name: str) -> None:
         pass
 
 
+_INSTALL_LOCK_NAME = ".pyxis-install-owner"
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0 or pid > 0x7FFFFFFF:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@contextlib.contextmanager
+def _install_lock_at(pyxis_fd: int):
+    """Hold the exclusive on-disk install lock across preflight-to-activation.
+
+    The web flasher serializes concurrent installers through the Web Locks
+    API; this CLI needs an equivalent because two concurrent --activate
+    builds could otherwise both pass the preflight and each clobber the
+    other's records. The lock is a single well-known file in pyxis-map/,
+    so every builder on the card sees it. A lock left behind by a crashed
+    builder is reclaimed when its owner pid is dead; a live owner blocks
+    (pid reuse is resolved conservatively -- block rather than corrupt).
+    The lock file is removed on every exit path.
+    """
+    for attempt in range(4):
+        try:
+            descriptor = os.open(_INSTALL_LOCK_NAME,
+                                 os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_CLOEXEC,
+                                 0o644, dir_fd=pyxis_fd)
+            try:
+                _write_all(descriptor, str(os.getpid()).encode("ascii"),
+                           _INSTALL_LOCK_NAME)
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            break
+        except FileExistsError:
+            try:
+                raw = _read_file_at(pyxis_fd, _INSTALL_LOCK_NAME, 32)
+            except (PackError, FileNotFoundError):
+                raw = b""
+            owner_pid = 0
+            try:
+                owner_pid = int(raw.decode("ascii"))
+            except ValueError:
+                owner_pid = 0
+            if _pid_alive(owner_pid):
+                raise PackError("another map installer is already running on "
+                                "this card; wait for it to finish and retry") from None
+            _unlink_quietly_at(pyxis_fd, _INSTALL_LOCK_NAME)
+            _fsync_directory_fd(pyxis_fd)
+        except OSError as exc:
+            raise PackError(f"cannot acquire the map-install lock: {exc}") from exc
+    else:
+        raise PackError("cannot acquire the map-install lock")
+    _fsync_directory_fd(pyxis_fd)
+    try:
+        yield _INSTALL_LOCK_NAME
+    finally:
+        _unlink_quietly_at(pyxis_fd, _INSTALL_LOCK_NAME)
+        _fsync_directory_fd(pyxis_fd)
+
+
 def _remove_tree_at(parent_fd: int, name: str) -> None:
     try:
         descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
@@ -1320,7 +1440,7 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
     output_root = Path(output_root)
     target = output_root / "pyxis-map" / "packs" / pack_id
     source_fd = _open_path(source_directory)
-    output_fd = pyxis_fd = packs_fd = stage_fd = -1
+    output_fd = pyxis_fd = packs_fd = stage_fd = pack_fd = -1
     temporary = ""
     committed = False
     try:
@@ -1360,53 +1480,122 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
         output_fd = _open_path(output_root, create=True)
         pyxis_fd, pyxis_identity = _mkdir_open(output_fd, "pyxis-map")
         packs_fd, packs_identity = _mkdir_open(pyxis_fd, "packs")
+        existing = _existing_pack_fd(packs_fd, pack_id)
+        resumed = False
+        if existing is not None:
+            if not activate:
+                # Without --activate a resume would leave the card exactly
+                # as it was, so an existing pack is simply refused.
+                if existing >= 0:
+                    os.close(existing)
+                    existing = -1
+                raise PackError(f"output already exists: {target}")
+            # The pack already exists on the card. This is either a retry
+            # of a run interrupted between pack publication and activation
+            # (the style/slot records may be stale or split), or an exact
+            # duplicate run. Mirroring the web flasher, resume is allowed
+            # only when the published pack is byte-identical to this
+            # source; then re-activating (or activating for the first
+            # time) converges the records to this run's generation.
+            _verify_existing_pack(source_fd, existing, pack_id, manifest, tiles, max_bytes)
+            pack_fd = existing
+            resumed = True
         if activate:
             assert style is not None
-            _preflight_activation(pyxis_fd, pack_id=pack_id, map_set_id=style,
-                                  attribution=attribution)
-        temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
-        copied = 0
-        for tile in tiles:
-            copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
-            copied += tile.size
-        manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
-                              0o644, dir_fd=stage_fd)
-        try:
-            _write_all(manifest_fd, manifest, "manifest.pmp")
-            os.fsync(manifest_fd)
-        finally:
-            os.close(manifest_fd)
-        _fsync_directory_fd(stage_fd)
-        _validate_pack_fd(stage_fd, target, max_bytes)
-        _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity, packs_identity)
-        _rename_noreplace(packs_fd, temporary, pack_id, target)
-        committed = True
-        try:
-            _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity, packs_identity)
-        except BaseException as exc:
+            # Hold the install lock from the preflight through activation:
+            # two concurrent builders could otherwise both pass the
+            # preflight and each clobber the other's records.
+            with _install_lock_at(pyxis_fd):
+                _preflight_activation(pyxis_fd, pack_id=pack_id, map_set_id=style,
+                                      attribution=attribution)
+                if not resumed:
+                    temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
+                    copied = 0
+                    for tile in tiles:
+                        copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
+                        copied += tile.size
+                    manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                                           | os.O_CLOEXEC, 0o644, dir_fd=stage_fd)
+                    try:
+                        _write_all(manifest_fd, manifest, "manifest.pmp")
+                        os.fsync(manifest_fd)
+                    finally:
+                        os.close(manifest_fd)
+                    _fsync_directory_fd(stage_fd)
+                    _validate_pack_fd(stage_fd, target, max_bytes)
+                    _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity,
+                                         packs_identity)
+                    _rename_noreplace(packs_fd, temporary, pack_id, target)
+                    committed = True
+                    try:
+                        _verify_output_chain(output_root, output_fd, pyxis_fd,
+                                             pyxis_identity, packs_identity)
+                    except BaseException as exc:
+                        try:
+                            _remove_tree_at(packs_fd, pack_id)
+                            _fsync_directory_fd(packs_fd)
+                            committed = False
+                        except BaseException as cleanup_error:
+                            raise PublishedDurabilityError(target, OSError(
+                                f"publication location changed and rollback failed: "
+                                f"{cleanup_error}")) from exc
+                        raise PackError("output directory changed during publication; "
+                                        "rolled back") from exc
+                    try:
+                        os.close(stage_fd)
+                    except OSError as exc:
+                        stage_fd = -1
+                        raise PublishedDurabilityError(target, exc) from exc
+                    stage_fd = -1
+                slot_name, _enabled = activate_map_set(pyxis_fd, pack_id=pack_id,
+                                                       map_set_id=style,
+                                                       attribution=attribution)
+        else:
+            temporary, stage_fd = _temporary_directory(packs_fd, pack_id)
+            copied = 0
+            for tile in tiles:
+                copy_tile(source_fd, tile, stage_fd, max_bytes - copied)
+                copied += tile.size
+            manifest_fd = os.open("manifest.pmp", os.O_WRONLY | os.O_CREAT | os.O_EXCL
+                                   | os.O_CLOEXEC, 0o644, dir_fd=stage_fd)
             try:
-                _remove_tree_at(packs_fd, pack_id)
-                _fsync_directory_fd(packs_fd)
-                committed = False
-            except BaseException as cleanup_error:
-                raise PublishedDurabilityError(target, OSError(
-                    f"publication location changed and rollback failed: {cleanup_error}")) from exc
-            raise PackError("output directory changed during publication; rolled back") from exc
-        if activate:
-            assert style is not None
-            slot_name, _enabled = activate_map_set(pyxis_fd, pack_id=pack_id,
-                                                   map_set_id=style,
-                                                   attribution=attribution)
-        try:
-            os.close(stage_fd)
-        except OSError as exc:
+                _write_all(manifest_fd, manifest, "manifest.pmp")
+                os.fsync(manifest_fd)
+            finally:
+                os.close(manifest_fd)
+            _fsync_directory_fd(stage_fd)
+            _validate_pack_fd(stage_fd, target, max_bytes)
+            _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity,
+                                 packs_identity)
+            _rename_noreplace(packs_fd, temporary, pack_id, target)
+            committed = True
+            try:
+                _verify_output_chain(output_root, output_fd, pyxis_fd, pyxis_identity,
+                                     packs_identity)
+            except BaseException as exc:
+                try:
+                    _remove_tree_at(packs_fd, pack_id)
+                    _fsync_directory_fd(packs_fd)
+                    committed = False
+                except BaseException as cleanup_error:
+                    raise PublishedDurabilityError(target, OSError(
+                        f"publication location changed and rollback failed: "
+                        f"{cleanup_error}")) from exc
+                raise PackError("output directory changed during publication; "
+                                "rolled back") from exc
+            try:
+                os.close(stage_fd)
+            except OSError as exc:
+                stage_fd = -1
+                raise PublishedDurabilityError(target, exc) from exc
             stage_fd = -1
-            raise PublishedDurabilityError(target, exc) from exc
-        stage_fd = -1
         try:
             _fsync_directory_fd(packs_fd)
         except OSError as exc:
             raise PublishedDurabilityError(target, exc) from exc
+        if resumed and pack_fd >= 0:
+            os.close(pack_fd)
+            pack_fd = -1
         return target
     finally:
         active_exception = sys.exc_info()[0] is not None
@@ -1418,7 +1607,7 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
                 close_error = exc
         if temporary and not committed and packs_fd >= 0:
             _remove_tree_at(packs_fd, temporary)
-        for descriptor in (packs_fd, pyxis_fd, output_fd, source_fd):
+        for descriptor in (pack_fd, packs_fd, pyxis_fd, output_fd, source_fd):
             if descriptor >= 0:
                 try:
                     os.close(descriptor)


### PR DESCRIPTION
## Summary

Adds the indexless **PMPK v3** pack format and the matching **PMAS v3**
active map-set record to `tools/maps/build_map_pack.py`, byte-compatible
with the firmware's `ActiveMapSetCodec` (decoder landed in PR #88).

- **PMPK v3** — indexless tile records. Emitted by `--style`, and used as
  the fallback when sparse span coverage exceeds the v2 512-span cap.
- **PMAS v3** — 12-byte header (`PMAS` magic, version 3, reserved,
  u16 total length, u32 generation) followed by the selection payload.
- Decoder paths extended to accept v1/v2/v3 for both pack and
  active map-set records; the generation field is carried through
  selection.

## Review remediation (Greptile rounds 1–13)

All activation P1s are fixed in the follow-up commits:

1. **Non-atomic style-record replacement** (round 1) — the style record
   and active slot are published via an exclusive temp file +
   `renameat()` swap (fsync + dir fsync + byte-exact read-back). An
   interruption at any point leaves either the previous or the new
   record intact; the sole `map-sets/<style>.pmas` can no longer be
   truncated mid-write.
2. **Ninth-pack orphan** (round 1) — the inherited PMAS composition is
   validated against the firmware's 8-pack limit (`MAX_ACTIVE_PACKS`,
   mirroring `ActiveMapSetCodec::MAX_PACKS`) in a preflight **before**
   any tile is staged or the pack is published.
3. **Slot-conflict orphan** (round 2) — the equal-generation
   redundant-slot conflict is also rejected by the preflight, before
   publication.
4. **Unsynchronized concurrent builders** (rounds 3–4) — the web flasher
   serializes installers via the Web Locks API; the CLI had no
   equivalent. Activation (preflight through both record commits) runs
   under an exclusive on-disk lock. The final primitive is an advisory
   `fcntl.flock(LOCK_EX | LOCK_NB)` on a persistent `.pyxis-install.lock`
   in `pyxis-map/` — a single atomic kernel operation (no create-then-
   write-PID race), auto-released when the holder dies (no stale-lock
   reclamation, no pid-reuse window), and never unlinked (unlinking a
   flock'd file is the inode race). The lock file is invisible to the
   firmware and flasher, which only read fixed named paths under
   `pyxis-map/`.
5. **Interruptible two-record activation** (rounds 3–6) — the style
   record and active slot commit separately. `build_map_pack` verifies an
   existing pack byte-for-byte against the source (manifest + every
   tile, mirroring `verifyExistingPack`) and, when it matches, re-
   activates to converge the records. `activate_map_set` publishes the
   **style record first**, then the active slot (the web flasher's
   order). The firmware's device-side style re-activation
   (`MapStyleCatalog::activate`) reads the style record as the source of
   truth and resequences its composition into the active slot, so the
   style record must never be older than the slot: an older style record
   would reseed the slot and drop a newly installed pack (Greploop
   round 6). With style-first ordering the worst interruption is "slot
   one build stale, style record current" -- the map keeps serving the
   previous pack, and both the CLI retry and the device's own style
   re-activation converge forward to the newest composition. (An
   intermediate "slot-first" attempt was reverted for this reason.)
6. **Generation-exhaustion orphan** (round 5) — the preflight validated
   the inherited pack composition and slot conflicts before publishing
   but omitted the generation-exhaustion rejection that
   `activate_map_set` performs only after publication. The preflight now
   computes the highest active-slot generation and rejects an exhausted
   selection (at the u32 maximum) before any tile is staged or the pack
   is published, preserving the no-orphan guarantee.
7. **Stale style record reseeds the slot** (round 6) — the slot-first
   ordering introduced in rounds 3–4 left a stale-but-valid style record
   after an interrupted write; a later device-side style re-activation
   would resequence that stale composition into the authoritative slot,
   deselecting the newly installed pack. Reverted to style-first
   ordering so the style record is always at least as fresh as the slot,
   which makes both recovery paths (CLI retry and
   `MapStyleCatalog::activate`) converge forward. The interruption
   regression test now asserts the style record is current and the slot
   converges on retry.
8. **Cross-producer install race** (round 7) — the CLI's advisory
   `fcntl.flock` and the web flasher's Web Locks name live in
   incompatible lock namespaces, so a CLI install and a browser install
   on the same card could each hold "their" lock, both pass preflight on
   identical slot state, and clobber each other's records (orphaning a
   pack or writing the same generation to two slots). Two symmetric
   layers are added to **both** producers:
   - **Shared on-disk install marker** — `.pyxis-installing` in
     `pyxis-map/` holding `PYXI 1 <owner> <epoch_ms>`. Both producers
     claim it at install start (CLI via `O_EXCL`, browser via
     `getFileHandle({exclusive:true})`), verify ownership by read-back
     (a contested claim aborts instead of deleting the foreign marker),
     refuse when a fresh foreign marker is present, and reclaim stale
     ones (15-minute TTL; a future epoch counts as fresh — refusing is
     the safe direction under clock skew). The marker is released only
     if it still carries the releasee's own token. Both producers'
     parsers accept each other's tokens (verified: same 4-field layout,
     ASCII owner ≤64, ms epoch, identical 15-minute TTL), so neither
     side ever reclaims the other's live marker.
   - **Commit-time revalidation** — both `activate_map_set` and
     `activateMapSet` snapshot the raw slot + style bytes at derivation
     and re-read them immediately before the record writes, aborting if
     the card's activation state moved since derivation or a fresh
     foreign marker is present. An aborted activation keeps its
     published pack (device-harmless: `MapTilePack::initialize` only
     reads packs enumerated in the active selection) and converges on
     the existing retry/resume path.
   Residual: a sub-millisecond cross-producer commit overlap with a
   missed marker still converges to split-but-safe state under the
   style-first ordering, and the firmware's same-generation conflict
   detection fails closed rather than corrupting.
9. **Marker TTL expires during long installs** (round 8) — the shared
   marker was written once at install start, so a publication longer
   than the 15-minute TTL (a full world pack on slow SD storage) aged
   out while its installer was still live; a second producer then
   reclaimed the marker and both producers passed commit-time
   revalidation against the same activation state. Both producers now
   **renew the marker's epoch during tile publication** (heartbeat:
   every 25 tiles plus one final renewal), keeping the claim live for
   arbitrarily long installs while a *crashed* installer (no renewals)
   is still reclaimed after the TTL. The release and commit-time
   marker checks compare the **owner**, not the full token, so a
   renewed (epoch-advanced) marker is still recognized as ours — and a
   different owner (a later installer that reclaimed our aged marker)
   is still never deleted by mistake.
10. **Heartbeat could steal a legitimately reclaimed marker** (round 9)
   — the round-8 renewal was a blind overwrite: if installer A stalled
   on a single tile operation past the TTL, installer B could
   legitimately reclaim the marker, and A's next heartbeat then
   overwrote B's live claim. A's install now **aborts** on a
   reclaimed, deleted, or corrupt marker (ownership-checked renewal,
   same direction as the acquire and release paths): the (possibly
   partially published) pack stays device-harmless, B's claim is left
   intact, and A's user retries after B finishes. Commit-time
   revalidation remains the independent backstop for the residual
   sub-TTL overlap.
11. **Marker coordination remained a shared-file check-then-act**
   (round 10) — even with ownership-checked renewal, two producers
   writing ONE file leaves a read-then-write window a stalled
   installer's in-flight renewal can cross, and the browser derived
   its activation record from decoded reads separate from the raw
   snapshot it later re-validated (a concurrent swap between the two
   reads would write a record derived from stale state). Fixed by
   structure: each producer now writes ONLY its own marker file —
   `.pyxis-installing-cli` (CLI), `.pyxis-installing-web` (flasher) —
   so no producer can ever clobber the other's claim (steal-back is
   impossible by construction; the legacy `.pyxis-installing` is
   honored for old producers but never written). Cross awareness is
   read-only: fresh foreign markers refuse at acquire, are reclaimed
   when stale, and are re-checked at every renewal and again at
   commit-time revalidation — so an installer that starts mid-install
   is detected at the next heartbeat and aborts. The flasher's
   `prepareActiveMapSet` now snapshots the raw slot/style bytes first
   and decodes FROM that same snapshot (no separate decode read), so
   the CAS re-validation covers exactly the bytes the record was
   derived from.
12. **Stale cross-reclaim could delete a renewed live claim; missing
   own marker was accepted at commit** (round 11) — reclamation was
   check-then-act: a cross-installer renews between the stale check
   and the delete, and the delete clobbers the renewed claim; the
   victim's commit-time verification then accepted a MISSING own
   marker and both activations proceeded into the same write window.
   Two fixes, both producers: (a) reclaim is now CONDITIONAL — the
   file is re-read immediately before deletion and a token that
   became fresh after the original check aborts the reclaim instead
   of deleting; (b) commit-time verification now REQUIRES the own
   marker when the install acquired one — a missing own file (the
   claim was reclaimed from under us) or a foreign owner aborts the
   activation before any record write.
13. **Expired own marker passed commit-time ownership validation**
   (round 12) — the commit check compared the own marker's owner but
   not its freshness, so a claim that aged out (one operation
   stalling past the TTL) still validated, and a cross-producer could
   legitimately reclaim it in the validation→writes window, racing
   our record writes against the new holder's. Commit-time
   verification now requires the own marker to be present, owned, AND
   FRESH — freshness is exactly what makes the claim non-reclaimable
   at that instant (a cross-reclaim only proceeds on a stale marker),
   so a lapsed claim aborts the commit instead of proceeding. A
   lapsed claim means the heartbeat stopped (a genuinely stalled or
   crashed producer); the pack stays published and a retry re-derives
   from the post-reclaim state.
14. **Claim could expire inside the two-record commit** (round 13) —
   the commit-time check ran once, before the style write, but the
   style write + read-back can sit a long time before the slot write
   on a stalled card; a claim expiring in that gap could be
   legitimately reclaimed, and the slot write (the record the device
   actually reads) would then clobber the new holder's record. Both
   producers now re-validate IMMEDIATELY before the slot write: the
   slot stays CAS'd against the derivation snapshot, and the style is
   compared against the record just written (a self-check that catches
   a cross-producer style write landing after ours). A missing /
   foreign / expired claim, or any record mismatch, aborts before the
   slot byte. An abort here leaves either our own (newer) style record
   over the old slot — the documented style-first worst case,
   completed by the retry or device style re-activation — or the
   cross-producer's consistent pair; both are device-safe.

Single producer + reader module plus its flasher counterpart; 2826
insertions across `tools/maps/build_map_pack.py`,
`docs/flasher/js/map-installer.js`, and both test files.

## Test Plan

- [x] `pytest tests/tools/test_build_map_pack.py` — 93 passed, covering
      v3 serialization round-trips, v1/v2/v3 decoder compatibility,
      span-cap fallback, selection behavior, interrupted-activation
      recovery + retry convergence (style-first), pre-publication rejection
      (pack limit, slot conflict, generation exhaustion), install-flock
      serialization via a real concurrent holder, resume source
      verification, install-marker refusal before any publication
      (flasher file + legacy file), stale-marker reclamation + release,
      conditional reclaim against a racing renewal, commit-time
      revalidation abort with retry convergence, marker
      renewal during long publication + owner-based release, renewal
      refusal to steal a reclaimed claim, crashed-marker reclamation,
      stale cross-marker reclamation, mid-install cross-marker
      detection at renewal, commit abort when the own marker is
      reclaimed or expired, final pre-slot revalidation abort on an
      expired claim (the slot byte is never written), and the
      fresh-own-marker pass case.
- [x] `node --test tests/web/test_map_installer.mjs` — 30 passed
       (the flasher half of the cross-producer P1: marker refusal from
       both cross files (CLI + legacy), stale-marker reclaim + release,
       conditional reclaim against a racing renewal, CAS abort + retry
       convergence, marker renewal contract, renewal refusal to steal a
       reclaimed claim, mid-install cross-marker detection at renewal,
       commit abort when the own marker is missing or expired (plus the
       fresh-own-marker pass case), final pre-slot revalidation abort
       on an expired claim (the slot record is never written over), and
       the existing contract suite; the in-memory FS now models
       `getFileHandle({exclusive:true})` → `FileExistsError`).
- [x] Diff privacy-scrubbed (no names, addresses, or local paths).
- [ ] Firmware-side acceptance: end-to-end install of a v3-built pack on
      device is still open (this PR is the writer half of the pair; the
      firmware decoder half is already in main via #88). The PMAS v3
      record format is covered by byte-level round-trip tests against
      the firmware codec layout.
