### PR TITLE
feat: safe CLI PMPK v3 / PMAS v3 map-pack writers

### DIFF
--- a/docs/offline-map-packs.md
+++ b/docs/offline-map-packs.md
@@ -135,6 +135,12 @@ map-set ID, shared attribution, and the full ordered list of pack IDs (up to
 eight), so the writer never depends on per-pack row-span bookkeeping to know
 what belongs to a set. `--activate` requires `--style`.
 
+The CLI is deliberately stricter than the firmware here: when activating a
+v3 set it refuses, before any write, any set that references a pack whose
+manifest is not itself PMPK v3. A v3 active set that still points at legacy
+v1/v2 packs may be readable by the firmware, but the CLI will not activate
+one — it reports the mismatch and leaves all records untouched.
+
 Before activation the CLI, under a persistent CLI install lock:
 
 1. reads the two redundant `active-pack.0`/`active-pack.1` slots and the style

--- a/docs/offline-map-packs.md
+++ b/docs/offline-map-packs.md
@@ -109,6 +109,58 @@ The pack ID must match `[a-z0-9_-]{1,31}`. The destination is:
 
 The output root is normally the mounted SD-card root. The importer refuses to replace an existing pack.
 
+## Safe CLI installation with style and activation (PMPK/PMAS v3)
+
+For the four Coalition/MUI styles the CLI can emit the indexless **PMPK v3**
+manifest and, with `--activate`, write the complete **PMAS v3** active map set
+in the same safe order the firmware expects. Run from the repository root with
+the SD card mounted and not in use by Pyxis:
+
+```sh
+python3 tools/maps/build_map_pack.py ./my-xyz /media/$USER/SDCARD \
+  --pack-id regional-map \
+  --name "Regional Map" \
+  --style osm-bright \
+  --activate
+```
+
+With `--style`, `--attribution`, `--source`, and `--license` must exactly match
+the firmware style policy; the CLI refuses a style request whose metadata does
+not match. The supported styles are `osm-bright`, `dark-matter`, `positron`,
+and `toner`.
+
+**PMPK v3** stores only the manifest identity, metadata, minimum and maximum
+zoom, and total tile count. **PMAS v3** is a single complete record holding the
+map-set ID, shared attribution, and the full ordered list of pack IDs (up to
+eight), so the writer never depends on per-pack row-span bookkeeping to know
+what belongs to a set. `--activate` requires `--style`.
+
+Before activation the CLI, under a persistent CLI install lock:
+
+1. reads the two redundant `active-pack.0`/`active-pack.1` slots and the style
+   snapshot,
+2. derives the candidate PMAS v3 record (new pack at priority zero, existing
+   same-style packs preserved, generation advanced),
+3. validates every inherited pack's manifest,
+4. stages and independently validates the new pack and publishes it,
+5. revalidates every candidate pack including the new one, then
+6. writes and reads back the style snapshot first and exactly one redundant
+   active slot second, preserving the peer slot as the last known-valid
+   fallback.
+
+A preflight failure changes no style or active-slot bytes. A failed slot write
+leaves the previous valid active set available. A published-but-not-activated
+pack is never deleted: rerun the exact same command to retry activation. There
+are no marker, lease, or heartbeat files to delete or clean up.
+
+**Safe eject.** After the CLI reports success, safely unmount/eject the SD card
+before returning it to the T-Deck.
+
+**Concurrency.** The CLI install lock serializes *CLI processes only*. It does
+not coordinate with the browser installer. **Do not run the CLI and the browser
+installer against the same mounted card at the same time.** To install with the
+CLI, keep the browser installer closed (and vice versa).
+
 ## Legacy single-pack selection from the CLI
 
 With the SD card still mounted on the host and not in use by Pyxis, write the

--- a/tests/build_scripts/test_offline_map_pack_cli_contract.py
+++ b/tests/build_scripts/test_offline_map_pack_cli_contract.py
@@ -1,0 +1,71 @@
+"""Contract for the safe CLI PMPK/PMAS v3 installation documentation.
+
+`docs/offline-map-packs.md` is the user-facing operational contract for the
+Linux CLI v3 writer. These tests pin the required wording so the concurrency
+limitation and recovery steps cannot silently disappear.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC = ROOT / "docs" / "offline-map-packs.md"
+
+
+def _flat() -> str:
+    """Collapse whitespace so prose wrapping across lines still matches."""
+    return re.sub(r"\s+", " ", DOC.read_text(encoding="utf-8"))
+
+
+def test_doc_documentation_is_present() -> None:
+    assert "## Safe CLI installation with style and activation (PMPK/PMAS v3)" in _flat()
+
+
+def test_doc_shows_exact_v3_cli_command() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "python3 tools/maps/build_map_pack.py" in text
+    assert "--style osm-bright" in text
+    assert "--activate" in text
+
+
+def test_doc_explains_pmpk_and_pmas_v3_semantics() -> None:
+    flat = _flat()
+    assert "PMPK v3" in flat
+    assert "PMAS v3" in flat
+    assert "indexless" in flat
+    # The complete-record property: the set record names every pack.
+    assert "full ordered list of pack IDs" in flat
+    assert "eight" in flat
+
+
+def test_doc_states_safe_eject_requirement() -> None:
+    flat = _flat()
+    assert "Safe eject" in flat
+    assert "safely unmount/eject" in flat
+
+
+def test_doc_limits_cli_lock_to_cli_processes_and_warns_against_browser_concurrency() -> None:
+    flat = _flat()
+    assert "CLI processes only" in flat
+    assert "Do not run the CLI and the browser installer against the same mounted card at the same time" in flat
+
+
+def test_doc_documents_published_but_not_activated_recovery() -> None:
+    flat = _flat()
+    assert "published-but-not-activated" in flat
+    assert "rerun the exact same command" in flat
+
+
+def test_doc_does_not_instruct_deletion_of_marker_or_lease_files() -> None:
+    flat = _flat()
+    lower = flat.lower()
+    # The v3 writer has no marker/lease/heartbeat files, and the doc must say so.
+    assert "no marker, lease, or heartbeat files" in lower
+    # No TTL-based marker protocol may be described anywhere in the doc.
+    assert "INSTALL_MARKER_TTL" not in flat
+    assert "stale-reclaim" not in lower
+    assert "TTL" not in flat
+    # The legacy section may mention the legacy `active-pack` marker, but the doc
+    # must not tell users to delete any *.pyxis-installing* marker.
+    assert ".pyxis-installing" not in flat

--- a/tests/fixtures/map_pack_v3_vectors.json
+++ b/tests/fixtures/map_pack_v3_vectors.json
@@ -1,0 +1,48 @@
+{
+  "pmpk_v3_one_tile": {
+    "pack_id": "one-tile",
+    "name": "One Tile",
+    "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+    "source": "local-example",
+    "license": "CC-BY-4.0",
+    "min_zoom": 2,
+    "max_zoom": 2,
+    "tile_count": 1,
+    "format_version": 3,
+    "hex": "504d504b030010007400000000000000086f6e652d74696c65084f6e652054696c652f286329204f70656e4d617054696c657320286329204f70656e5374726565744d617020636f6e7472696275746f72730d6c6f63616c2d6578616d706c650943432d42592d342e30020201000000372a0b6b"
+  },
+  "pmpk_v3_multi_zoom": {
+    "pack_id": "multi-zoom",
+    "name": "Multi Zoom",
+    "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+    "source": "local-example",
+    "license": "CC-BY-4.0",
+    "min_zoom": 0,
+    "max_zoom": 1,
+    "tile_count": 5,
+    "format_version": 3,
+    "hex": "504d504b0300100078000000000000000a6d756c74692d7a6f6f6d0a4d756c7469205a6f6f6d2f286329204f70656e4d617054696c657320286329204f70656e5374726565744d617020636f6e7472696275746f72730d6c6f63616c2d6578616d706c650943432d42592d342e3000010500000009478901"
+  },
+  "pmas_v3_one_pack": {
+    "format_version": 3,
+    "generation": 1,
+    "map_set_id": "osm-bright",
+    "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+    "pack_ids": [
+      "detail"
+    ],
+    "hex": "504d415303005300010000000a6f736d2d6272696768742f286329204f70656e4d617054696c657320286329204f70656e5374726565744d617020636f6e7472696275746f7273010664657461696ca333e002"
+  },
+  "pmas_v3_three_packs": {
+    "format_version": 3,
+    "generation": 7,
+    "map_set_id": "osm-bright",
+    "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+    "pack_ids": [
+      "overview",
+      "detail",
+      "basemap"
+    ],
+    "hex": "504d415303006400070000000a6f736d2d6272696768742f286329204f70656e4d617054696c657320286329204f70656e5374726565744d617020636f6e7472696275746f727303086f766572766965770664657461696c07626173656d61708fc8a823"
+  }
+}

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -457,13 +457,26 @@ def test_style_build_publishes_no_active_record(tmp_path: Path) -> None:
 
 
 def _lock_holder_script(pyxis_map: Path, hold_seconds: float) -> str:
+    lock_path = os.fspath(pyxis_map / load_tool().INSTALL_LOCK_NAME)
     return (
         "import fcntl, os, time\n"
-        f"fd = os.open(r'{pyxis_map}/{load_tool().INSTALL_LOCK_NAME}', os.O_RDWR | os.O_CREAT, 0o644)\n"
+        # repr() so paths containing quotes or backslashes stay valid Python.
+        f"fd = os.open({lock_path!r}, os.O_RDWR | os.O_CREAT, 0o644)\n"
         "fcntl.flock(fd, fcntl.LOCK_EX)\n"
         "print('held', flush=True)\n"
         f"time.sleep({hold_seconds})\n"
     )
+
+
+def test_lock_holder_script_escapes_paths_with_quotes() -> None:
+    # A pyxis-map path containing a single quote must still produce *valid*
+    # child Python; the old r'...' interpolation turned such a path into a
+    # SyntaxError so the holder never opened the lock and the contention test
+    # passed for the wrong reason.
+    pyxis_map = Path("/tmp/a'b/pyxis-map")
+    script = _lock_holder_script(pyxis_map, 0.0)
+    compile(script, "<holder>", "exec")  # raises SyntaxError if unescaped
+    assert "os.open(" in script and ".install.lock" in script
 
 
 def test_second_cli_process_is_refused_while_first_holds_lock(tmp_path: Path) -> None:
@@ -1034,6 +1047,29 @@ def test_cli_exact_resume_after_activation_failure(tool, tmp_path: Path, monkeyp
     slot = tool.decode_active_selection(
         (tmp_path / "sd/pyxis-map/map-sets/osm-bright.pmas").read_bytes())
     assert slot["pack_ids"] == ["pack-a"]
+
+
+def test_cli_durability_failure_reports_committed_record(tool, tmp_path: Path,
+                                                         monkeypatch, capsys) -> None:
+    # Greptile P2: a post-rename parent-fsync failure (PublishedDurabilityError)
+    # must not be reported as "activation failed" — the record is committed
+    # and visible, only its durability is uncertain.
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    real_publish = tool.publish_activation
+
+    def durability_publish(*args, **kwargs):
+        target = args[2] if len(args) > 2 else kwargs["output_root"]
+        raise tool.PublishedDurabilityError(target, OSError("injected fsync failure"))
+
+    monkeypatch.setattr(tool, "publish_activation", durability_publish)
+    code = _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a") + ["--activate"])
+    assert code == 4
+    err = capsys.readouterr().err
+    # The generic "activation failed" handler must NOT fire for a committed
+    # durability failure; the committed-record message must.
+    assert "pack publication succeeded but activation failed" not in err
+    assert "committed and is visible" in err
+    assert "durability is uncertain" in err
 
 
 def test_cli_existing_pack_metadata_mismatch_refuses(tool, tmp_path: Path) -> None:

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import fcntl
 from pathlib import Path
 import struct
 import subprocess
@@ -373,6 +374,178 @@ def test_serialize_pmpk_v3_contains_no_span_payload() -> None:
     expected_length = 16 + sum(1 + len(entry[field].encode("ascii"))
                                for field in ("pack_id", "name", "attribution", "source", "license")) + 6 + 4
     assert len(data) == expected_length
+
+
+def style_metadata(tool, style: str = "osm-bright", **changes: str) -> dict[str, str]:
+    policy = dict(tool.STYLE_POLICIES[style])
+    values = {
+        "pack_id": "styled-pack",
+        "name": "Styled Pack",
+        "attribution": policy["attribution"],
+        "source": policy["source"],
+        "license": policy["license"],
+    }
+    values.update(changes)
+    return values
+
+
+def test_style_build_emits_pmpk_v3(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    for x, y in ((0, 0), (0, 1), (3, 0)):
+        put_tile(source, 2, x, y)
+    # sparse source must still emit v3 when a style is requested
+    built = tool.build_map_pack(source, tmp_path / "sd", style="osm-bright",
+                                **style_metadata(tool))
+    parsed = tool.validate_pack(built)
+    assert parsed["format_version"] == 3
+    assert parsed["indexless"] is True
+    assert parsed["min_zoom"] == 2
+    assert parsed["max_zoom"] == 2
+    assert parsed["tile_count"] == 3
+
+
+def test_style_build_rejects_policy_metadata_mismatch(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    for field in ("attribution", "source", "license"):
+        with pytest.raises(tool.PackError, match=field):
+            tool.build_map_pack(source, tmp_path / f"sd-{field}", style="osm-bright",
+                                **style_metadata(tool, **{field: "Wrong value"}))
+    with pytest.raises(tool.PackError, match="unsupported map style"):
+        tool.build_map_pack(source, tmp_path / "sd-bad", style="vintage",
+                            **style_metadata(tool))
+
+
+def test_no_style_build_keeps_v1_v2_behavior(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    make_rectangle(source)
+    rectangular = tool.build_map_pack(source, tmp_path / "sd-a", **metadata())
+    assert tool.validate_pack(rectangular)["format_version"] == 1
+    sparse_source = tmp_path / "sparse-xyz"
+    for x, y in ((1, 1), (1, 2), (2, 1)):
+        put_tile(sparse_source, 2, x, y)
+    sparse = tool.build_map_pack(sparse_source, tmp_path / "sd-b", sparse=True, **metadata())
+    assert tool.validate_pack(sparse)["format_version"] == 2
+
+
+def test_style_build_publishes_no_active_record(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    tool.build_map_pack(source, tmp_path / "sd", style="dark-matter",
+                        **style_metadata(tool, "dark-matter"))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    assert not (pyxis_map / "active-pack.0").exists()
+    assert not (pyxis_map / "active-pack.1").exists()
+    assert not (pyxis_map / "map-sets").exists()
+
+
+def _lock_holder_script(pyxis_map: Path, hold_seconds: float) -> str:
+    return (
+        "import fcntl, os, time\n"
+        f"fd = os.open(r'{pyxis_map}/{load_tool().INSTALL_LOCK_NAME}', os.O_RDWR | os.O_CREAT, 0o644)\n"
+        "fcntl.flock(fd, fcntl.LOCK_EX)\n"
+        "print('held', flush=True)\n"
+        f"time.sleep({hold_seconds})\n"
+    )
+
+
+def test_second_cli_process_is_refused_while_first_holds_lock(tmp_path: Path) -> None:
+    tool = load_tool()
+    source = tmp_path / "xyz"
+    put_tile(source, 0, 0, 0)
+    tool.build_map_pack(source, tmp_path / "sd", **metadata())
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    holder = subprocess.Popen(
+        [sys.executable, "-c", _lock_holder_script(pyxis_map, 5.0)],
+        stdout=subprocess.PIPE, text=True,
+    )
+    stdout = holder.stdout
+    assert stdout is not None
+    try:
+        assert stdout.readline().strip() == "held"
+        pyxis_fd = tool._open_path(pyxis_map)
+        try:
+            with pytest.raises(tool.PackError, match="another CLI map install is running"):
+                tool.acquire_install_lock(pyxis_fd)
+        finally:
+            os.close(pyxis_fd)
+        holder.terminate()
+        holder.wait(timeout=10)
+        pyxis_fd = tool._open_path(pyxis_map)
+        try:
+            lock_fd = tool.acquire_install_lock(pyxis_fd)
+            tool.release_install_lock(lock_fd)
+        finally:
+            os.close(pyxis_fd)
+    finally:
+        if holder.poll() is None:
+            holder.terminate()
+            holder.wait(timeout=10)
+
+
+def test_cli_lock_is_released_after_success(tmp_path: Path) -> None:
+    tool = load_tool()
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    pyxis_map.mkdir(parents=True)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        lock_fd = tool.acquire_install_lock(pyxis_fd)
+        tool.release_install_lock(lock_fd)
+        # A fresh descriptor can take the lock immediately.
+        lock_fd = tool.acquire_install_lock(pyxis_fd)
+        tool.release_install_lock(lock_fd)
+    finally:
+        os.close(pyxis_fd)
+
+
+def test_cli_lock_is_released_after_failure(tmp_path: Path) -> None:
+    tool = load_tool()
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    pyxis_map.mkdir(parents=True)
+    holder_fd = os.open(pyxis_map / tool.INSTALL_LOCK_NAME, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(holder_fd, fcntl.LOCK_EX)
+        pyxis_fd = tool._open_path(pyxis_map)
+        try:
+            with pytest.raises(tool.PackError, match="another CLI map install is running"):
+                tool.acquire_install_lock(pyxis_fd)
+        finally:
+            os.close(pyxis_fd)
+    finally:
+        os.close(holder_fd)
+    # The failed acquire must not have left any lock held by this process.
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        lock_fd = tool.acquire_install_lock(pyxis_fd)
+        tool.release_install_lock(lock_fd)
+    finally:
+        os.close(pyxis_fd)
+
+
+def test_cli_lock_file_is_persistent_and_never_unlinked(tmp_path: Path) -> None:
+    tool = load_tool()
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    pyxis_map.mkdir(parents=True)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        lock_fd = tool.acquire_install_lock(pyxis_fd)
+        tool.release_install_lock(lock_fd)
+        lock_fd = tool.acquire_install_lock(pyxis_fd)
+        tool.release_install_lock(lock_fd)
+    finally:
+        os.close(pyxis_fd)
+    lock_path = pyxis_map / tool.INSTALL_LOCK_NAME
+    assert lock_path.is_file()
+    # The acquire/release code must not delete the persistent lock file.
+    acquire_source = TOOL.read_text(encoding="utf-8").split(
+        "def acquire_install_lock", 1)[1].split("\n\n\ndef ", 1)[0]
+    release_source = TOOL.read_text(encoding="utf-8").split(
+        "def release_install_lock", 1)[1].split("\n\n\ndef ", 1)[0]
+    assert "unlink(" not in acquire_source + release_source
 
 
 def test_valid_pack_is_deterministic_and_independently_validated(tmp_path: Path) -> None:

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -953,6 +953,152 @@ def test_read_back_mismatch_is_a_failure(tool, tmp_path: Path, monkeypatch) -> N
         os.close(pyxis_fd)
 
 
+def test_activate_requires_style(tool, tmp_path: Path) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    code = tool.main([str(tmp_path / "xyz"), str(tmp_path / "sd"),
+                      "--pack-id", "p", "--name", "n", "--attribution", "a",
+                      "--source", "s", "--license", "l", "--activate"])
+    assert code == 2
+
+
+def _cli_metadata(tool, pack_id: str, style: str = "osm-bright") -> list[str]:
+    policy = tool.STYLE_POLICIES[style]
+    return ["--pack-id", pack_id, "--name", f"{pack_id} pack",
+            "--attribution", policy["attribution"], "--source", policy["source"],
+            "--license", policy["license"], "--style", style]
+
+
+def _cli_run(tool, tmp_path, source_name, args):
+    return tool.main([str(tmp_path / source_name), str(tmp_path / "sd"), *args])
+
+
+def test_cli_fresh_install_and_activate(tool, tmp_path: Path) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    code = _cli_run(tool, tmp_path, "xyz",
+                    _cli_metadata(tool, "pack-a") + ["--activate"])
+    assert code == 0
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    style_path = pyxis_map / "map-sets/osm-bright.pmas"
+    assert style_path.is_file()
+    slot = tool.decode_active_selection(style_path.read_bytes())
+    assert slot["map_set_id"] == "osm-bright"
+    assert slot["pack_ids"] == ["pack-a"]
+    assert (pyxis_map / "active-pack.0").read_bytes() == style_path.read_bytes()
+
+
+def test_cli_install_without_activate_writes_no_records(tool, tmp_path: Path) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    code = _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a"))
+    assert code == 0
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    assert (pyxis_map / "packs/pack-a/manifest.pmp").is_file()
+    assert not (pyxis_map / "active-pack.0").exists()
+    assert not (pyxis_map / "active-pack.1").exists()
+    assert not (pyxis_map / "map-sets/osm-bright.pmas").exists()
+
+
+def test_cli_exact_resume_after_activation_failure(tool, tmp_path: Path, monkeypatch) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    real_publish = tool.publish_activation
+    calls = {"n": 0}
+
+    def flaky_publish(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("injected activation failure")
+        return real_publish(*args, **kwargs)
+
+    monkeypatch.setattr(tool, "publish_activation", flaky_publish)
+    code = _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a") + ["--activate"])
+    assert code == 4
+    assert calls["n"] == 1
+    # The published immutable pack survives the failed activation and the exact
+    # retry reuses it (no republish) and converges.
+    assert (tmp_path / "sd/pyxis-map/packs/pack-a/manifest.pmp").is_file()
+    code = _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a") + ["--activate"])
+    assert code == 0
+    assert calls["n"] == 2
+    slot = tool.decode_active_selection(
+        (tmp_path / "sd/pyxis-map/map-sets/osm-bright.pmas").read_bytes())
+    assert slot["pack_ids"] == ["pack-a"]
+
+
+def test_cli_existing_pack_metadata_mismatch_refuses(tool, tmp_path: Path) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    assert _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a")) == 0
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    before = (pyxis_map / "packs/pack-a/manifest.pmp").read_bytes()
+    # Resume with a different --name must refuse; the existing pack is untouched.
+    code = tool.main([str(tmp_path / "xyz"), str(tmp_path / "sd"),
+                      "--pack-id", "pack-a", "--name", "different name",
+                      "--attribution", tool.STYLE_POLICIES["osm-bright"]["attribution"],
+                      "--source", tool.STYLE_POLICIES["osm-bright"]["source"],
+                      "--license", tool.STYLE_POLICIES["osm-bright"]["license"],
+                      "--style", "osm-bright", "--activate"])
+    assert code == 2
+    assert (pyxis_map / "packs/pack-a/manifest.pmp").read_bytes() == before
+    assert not (pyxis_map / "map-sets/osm-bright.pmas").exists()
+
+
+def test_cli_missing_inherited_pack_refuses_before_record_mutation(tool, tmp_path: Path) -> None:
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    (pyxis_map / "packs/pack-a/manifest.pmp").unlink()
+    put_tile(tmp_path / "src-c", 1, 0, 0)
+    args = [str(tmp_path / "src-c"), str(tmp_path / "sd"),
+            "--pack-id", "pack-c", "--name", "pack-c pack",
+            "--attribution", tool.STYLE_POLICIES["osm-bright"]["attribution"],
+            "--source", tool.STYLE_POLICIES["osm-bright"]["source"],
+            "--license", tool.STYLE_POLICIES["osm-bright"]["license"],
+            "--style", "osm-bright", "--activate"]
+    code = tool.main(args)
+    assert code == 2
+    # Both active slots and the (absent) style record are unchanged after refusal.
+    assert (pyxis_map / "active-pack.0").read_bytes() == gen_1
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+    assert not (pyxis_map / "map-sets/osm-bright.pmas").exists()
+    # The new pack was not published because preflight failed first.
+    assert not (pyxis_map / "packs/pack-c").exists()
+
+
+def test_cli_eight_pack_limit_refuses_before_publication(tool, tmp_path: Path) -> None:
+    for index in range(8):
+        src = tmp_path / f"src-{index}"
+        put_tile(src, 1, 0, 0)
+        assert _cli_run(tool, tmp_path, f"src-{index}",
+                        _cli_metadata(tool, f"pack-{index}")) == 0
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    for index in range(1, 8):
+        record = tool.encode_active_map_set(
+            generation=index, map_set_id="osm-bright", attribution=attribution,
+            pack_ids=[f"pack-{j}" for j in range(index, -1, -1)])
+        (pyxis_map / "active-pack.0").write_bytes(record)
+    put_tile(tmp_path / "src-new", 1, 0, 0)
+    code = tool.main([str(tmp_path / "src-new"), str(tmp_path / "sd"),
+                      "--pack-id", "pack-new", "--name", "pack-new pack",
+                      "--attribution", attribution,
+                      "--source", tool.STYLE_POLICIES["osm-bright"]["source"],
+                      "--license", tool.STYLE_POLICIES["osm-bright"]["license"],
+                      "--style", "osm-bright", "--activate"])
+    assert code == 2
+    assert not (pyxis_map / "packs/pack-new").exists()
+    assert not (pyxis_map / "map-sets/osm-bright.pmas").exists()
+
+
+def test_cli_activate_lock_contention(tool, tmp_path: Path) -> None:
+    put_tile(tmp_path / "xyz", 1, 0, 0)
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    pyxis_map.mkdir(parents=True)
+    lock_fd = os.open(pyxis_map / tool.INSTALL_LOCK_NAME, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        code = _cli_run(tool, tmp_path, "xyz", _cli_metadata(tool, "pack-a") + ["--activate"])
+        assert code == 2
+        assert not (pyxis_map / "map-sets/osm-bright.pmas").exists()
+    finally:
+        os.close(lock_fd)
+
+
 def test_valid_pack_is_deterministic_and_independently_validated(tmp_path: Path) -> None:
     tool = load_tool()
     source = tmp_path / "xyz"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -159,6 +159,19 @@ def test_pmas_v1_v2_decode_unchanged() -> None:
     assert values["pack_ids"] == ["legacy-1"]
 
 
+def test_pmas_v1_non_ascii_pack_id_raises_pack_error_not_traceback() -> None:
+    tool = load_tool()
+    # A valid-CRC legacy v1 record whose pack ID carries a non-ASCII byte
+    # (0x80) must surface a clean PackError (exit-2 path), not an
+    # uncaught UnicodeDecodeError traceback.
+    body = bytearray(b"PMAS\x01\x00" + struct.pack("<H", 48) + struct.pack("<I", 5) + b"\x08")
+    body.extend(b"\x80egacy-1")  # 0x80 first byte: non-ASCII, invalid grammar
+    body.extend(b"\x00" * (44 - len(body)))
+    bad = bytes(body) + struct.pack("<I", zlib.crc32(body))
+    with pytest.raises(tool.PackError):
+        tool.decode_active_selection(bad)
+
+
 def test_encode_pmas_v3_matches_frozen_vector() -> None:
     tool = load_tool()
     for name in ("pmas_v3_one_pack", "pmas_v3_three_packs"):

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -672,6 +672,287 @@ def test_plan_requires_exact_style_attribution(tool) -> None:
                              style_id="osm-bright", attribution="Someone else's maps")
 
 
+def _read_slot(pyxis_map: Path, name: str) -> bytes | None:
+    path = pyxis_map / name
+    if not path.is_file():
+        return None
+    return path.read_bytes()
+
+
+def _style_record_path(pyxis_map: Path, style_id: str) -> Path:
+    return pyxis_map / "map-sets" / f"{style_id}.pmas"
+
+
+def test_install_refuses_to_overwrite_last_valid_fallback_when_inherited_pack_is_missing(tool,
+                                                                                       tmp_path: Path) -> None:
+    source_a = tmp_path / "a"; source_b = tmp_path / "b"; source_c = tmp_path / "c"
+    for source in (source_a, source_b, source_c):
+        put_tile(source, 1, 0, 0)
+    for pack_id, source in (("pack-a", source_a), ("pack-b", source_b), ("pack-c", source_c)):
+        tool.build_map_pack(source, tmp_path / "sd", style="osm-bright",
+                            **style_metadata(tool, pack_id=pack_id))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    gen_1 = tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                       attribution=attribution, pack_ids=["pack-a"])
+    gen_2 = tool.encode_active_map_set(generation=2, map_set_id="osm-bright",
+                                       attribution=attribution, pack_ids=["pack-b", "pack-a"])
+    (pyxis_map / "active-pack.0").write_bytes(gen_1)
+    (pyxis_map / "active-pack.1").write_bytes(gen_2)
+    (pyxis_map / "packs/pack-a/manifest.pmp").unlink()
+
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(tool.PackError, match="missing inherited pack manifest"):
+            tool.publish_activation(
+                pyxis_fd, tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                               style_id="osm-bright", attribution=attribution),
+                tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+    # Both active-slot byte strings are unchanged and the style PMAS was not created.
+    assert (pyxis_map / "active-pack.0").read_bytes() == gen_1
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+    assert not _style_record_path(pyxis_map, "osm-bright").exists()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda manifest: manifest[:-1], "manifest"),
+        (lambda manifest: manifest[:-4] + b"\x00\x00\x00\x00", "CRC"),
+        (lambda manifest: b"X" + manifest[1:], "invalid manifest"),
+    ],
+)
+def test_inherited_pack_corruption_is_a_hard_preflight_failure(tool, tmp_path: Path,
+                                                               mutation, message) -> None:
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    tool.build_map_pack(source, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-a"))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    gen_1 = tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                       attribution=attribution, pack_ids=["pack-a"])
+    (pyxis_map / "active-pack.0").write_bytes(gen_1)
+    manifest_path = pyxis_map / "packs/pack-a/manifest.pmp"
+    manifest_path.write_bytes(mutation(manifest_path.read_bytes()))
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(tool.PackError, match=message):
+            tool.validate_active_pack_manifests_at(pyxis_fd, map_set_id="osm-bright",
+                                                   attribution=attribution, pack_ids=("pack-a",))
+    finally:
+        os.close(pyxis_fd)
+    assert (pyxis_map / "active-pack.0").read_bytes() == gen_1
+
+
+def test_inherited_pack_policy_mismatch_is_rejected(tool, tmp_path: Path) -> None:
+    source = tmp_path / "xyz"
+    put_tile(source, 1, 0, 0)
+    tool.build_map_pack(source, tmp_path / "sd", style="dark-matter",
+                        **style_metadata(tool, "dark-matter", pack_id="pack-a"))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        # pack-a is a dark-matter pack; osm-bright validation must refuse it.
+        with pytest.raises(tool.PackError, match="source/license|attribution"):
+            tool.validate_active_pack_manifests_at(pyxis_fd, map_set_id="osm-bright",
+                                                   attribution=attribution, pack_ids=("pack-a",))
+    finally:
+        os.close(pyxis_fd)
+
+
+def test_all_inherited_packs_valid_passes_preflight(tool, tmp_path: Path) -> None:
+    for pack_id in ("pack-a", "pack-b"):
+        source = tmp_path / f"src-{pack_id}"
+        put_tile(source, 1, 0, 0)
+        tool.build_map_pack(source, tmp_path / "sd", style="positron",
+                            **style_metadata(tool, "positron", pack_id=pack_id))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["positron"]["attribution"]
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        tool.validate_active_pack_manifests_at(pyxis_fd, map_set_id="positron",
+                                               attribution=attribution,
+                                               pack_ids=("pack-a", "pack-b"))
+    finally:
+        os.close(pyxis_fd)
+
+
+def _build_two_pack_card(tool, tmp_path: Path) -> tuple[Path, bytes, bytes]:
+    for pack_id in ("pack-a", "pack-b"):
+        source = tmp_path / f"src-{pack_id}"
+        put_tile(source, 1, 0, 0)
+        tool.build_map_pack(source, tmp_path / "sd", style="osm-bright",
+                            **style_metadata(tool, pack_id=pack_id))
+    pyxis_map = tmp_path / "sd/pyxis-map"
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    gen_1 = tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                       attribution=attribution, pack_ids=["pack-a"])
+    gen_2 = tool.encode_active_map_set(generation=2, map_set_id="osm-bright",
+                                       attribution=attribution, pack_ids=["pack-b", "pack-a"])
+    (pyxis_map / "active-pack.0").write_bytes(gen_1)
+    (pyxis_map / "active-pack.1").write_bytes(gen_2)
+    return pyxis_map, gen_1, gen_2
+
+
+def test_successful_activation_writes_exact_style_and_slot_bytes(tool, tmp_path: Path) -> None:
+    source_c = tmp_path / "src-c"
+    put_tile(source_c, 1, 0, 0)
+    tool.build_map_pack(source_c, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-c"))
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        plan = tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                    style_id="osm-bright",
+                                    attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+        tool.publish_activation(pyxis_fd, plan, tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+    assert plan.generation == 3
+    assert plan.target_slot == "active-pack.0"
+    assert plan.pack_ids == ("pack-c", "pack-b", "pack-a")
+    assert _style_record_path(pyxis_map, "osm-bright").read_bytes() == plan.record
+    assert (pyxis_map / "active-pack.0").read_bytes() == plan.record
+    # The peer slot (the higher-generation last-valid fallback) is untouched.
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+
+
+def test_style_write_failure_changes_no_records(tool, tmp_path: Path, monkeypatch) -> None:
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    source_c = tmp_path / "src-c"
+    put_tile(source_c, 1, 0, 0)
+    tool.build_map_pack(source_c, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-c"))
+    monkeypatch.setattr(tool, "_rename_at",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("injected style rename failure")))
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(OSError, match="injected style rename failure"):
+            tool.publish_activation(
+                pyxis_fd,
+                tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                     style_id="osm-bright",
+                                     attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"]),
+                tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+    assert (pyxis_map / "active-pack.0").read_bytes() == gen_1
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+    assert not _style_record_path(pyxis_map, "osm-bright").exists()
+    assert not list((pyxis_map / "map-sets").glob("*.tmp-*")) if (pyxis_map / "map-sets").exists() else True
+
+
+def test_slot_write_failure_preserves_prior_active_selection(tool, tmp_path: Path, monkeypatch) -> None:
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    source_c = tmp_path / "src-c"
+    put_tile(source_c, 1, 0, 0)
+    tool.build_map_pack(source_c, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-c"))
+    rename_calls = {"count": 0}
+    real_rename = tool._rename_at
+
+    def failing_slot_rename(parent_fd, source, destination, target):
+        rename_calls["count"] += 1
+        if rename_calls["count"] == 2:
+            raise OSError("injected slot rename failure")
+        real_rename(parent_fd, source, destination, target)
+
+    monkeypatch.setattr(tool, "_rename_at", failing_slot_rename)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(OSError, match="injected slot rename failure"):
+            tool.publish_activation(
+                pyxis_fd,
+                tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                     style_id="osm-bright",
+                                     attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"]),
+                tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+    # Style snapshot is committed; the old slot 1 record (gen 2) is still the active selection.
+    assert _style_record_path(pyxis_map, "osm-bright").is_file()
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+    assert (pyxis_map / "active-pack.0").read_bytes() == gen_1
+    assert not list((pyxis_map).glob("active-pack.1.tmp-*"))
+
+
+def test_retry_after_style_only_interruption_converges(tool, tmp_path: Path, monkeypatch) -> None:
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    source_c = tmp_path / "src-c"
+    put_tile(source_c, 1, 0, 0)
+    tool.build_map_pack(source_c, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-c"))
+    attribution = tool.STYLE_POLICIES["osm-bright"]["attribution"]
+    plan = tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                style_id="osm-bright", attribution=attribution)
+    rename_calls = {"count": 0}
+    real_rename = tool._rename_at
+
+    def failing_slot_rename(parent_fd, source, destination, target):
+        rename_calls["count"] += 1
+        if rename_calls["count"] == 2:
+            raise OSError("injected slot rename failure")
+        real_rename(parent_fd, source, destination, target)
+
+    monkeypatch.setattr(tool, "_rename_at", failing_slot_rename)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(OSError, match="injected slot rename failure"):
+            tool.publish_activation(pyxis_fd, plan, tmp_path / "sd")
+        # Retry from the new raw snapshot: the style PMAS now carries gen 3,
+        # so the candidate generation is 4 and pack-c stays at priority zero
+        # without duplicating pack IDs.
+        retry_plan = tool.plan_activation(
+            slot_0=_read_slot(pyxis_map, "active-pack.0"),
+            slot_1=_read_slot(pyxis_map, "active-pack.1"),
+            style_record=_read_slot(pyxis_map, "map-sets/osm-bright.pmas"),
+            new_pack_id="pack-c", style_id="osm-bright", attribution=attribution)
+        tool.publish_activation(pyxis_fd, retry_plan, tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+    final_slot = tool.decode_active_selection((pyxis_map / "active-pack.0").read_bytes())
+    assert final_slot["generation"] == 4
+    assert final_slot["pack_ids"] == ["pack-c", "pack-b", "pack-a"]
+    assert len(set(final_slot["pack_ids"])) == len(final_slot["pack_ids"])
+    # The peer slot (last valid fallback) is untouched.
+    assert (pyxis_map / "active-pack.1").read_bytes() == gen_2
+    final_style = tool.decode_active_selection(
+        _style_record_path(pyxis_map, "osm-bright").read_bytes())
+    assert final_style["pack_ids"] == final_slot["pack_ids"]
+    assert final_style["generation"] == 4
+
+
+def test_read_back_mismatch_is_a_failure(tool, tmp_path: Path, monkeypatch) -> None:
+    pyxis_map, gen_1, gen_2 = _build_two_pack_card(tool, tmp_path)
+    source_c = tmp_path / "src-c"
+    put_tile(source_c, 1, 0, 0)
+    tool.build_map_pack(source_c, tmp_path / "sd", style="osm-bright",
+                        **style_metadata(tool, pack_id="pack-c"))
+    real_read = tool._read_file_at
+
+    def corrupted_slot_read(parent_fd, name, maximum):
+        if "active-pack" in name:
+            return b"\x00" * 48
+        return real_read(parent_fd, name, maximum)
+
+    monkeypatch.setattr(tool, "_read_file_at", corrupted_slot_read)
+    pyxis_fd = tool._open_path(pyxis_map)
+    try:
+        with pytest.raises(tool.PackError, match="read-back mismatch"):
+            tool.publish_activation(
+                pyxis_fd,
+                tool.plan_activation(slot_0=gen_1, slot_1=gen_2, new_pack_id="pack-c",
+                                     style_id="osm-bright",
+                                     attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"]),
+                tmp_path / "sd")
+    finally:
+        os.close(pyxis_fd)
+
+
 def test_valid_pack_is_deterministic_and_independently_validated(tmp_path: Path) -> None:
     tool = load_tool()
     source = tmp_path / "xyz"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -548,6 +548,130 @@ def test_cli_lock_file_is_persistent_and_never_unlinked(tmp_path: Path) -> None:
     assert "unlink(" not in acquire_source + release_source
 
 
+@pytest.fixture(scope="module")
+def tool():
+    return load_tool()
+
+
+def assert_plan(tool, plan, style_id, slot, generation, pack_ids) -> None:
+    policy = tool.STYLE_POLICIES[style_id]
+    assert plan.style_name == style_id
+    assert plan.target_slot == slot
+    assert plan.generation == generation
+    assert plan.pack_ids == tuple(pack_ids)
+    decoded = tool.decode_active_selection(plan.record)
+    assert decoded["format_version"] == 3
+    assert decoded["generation"] == generation
+    assert decoded["map_set_id"] == style_id
+    assert decoded["attribution"] == policy["attribution"]
+    assert decoded["pack_ids"] == pack_ids
+
+
+def _slot(tool, generation, pack_ids, style_id="osm-bright") -> bytes:
+    return tool.encode_active_map_set(generation=generation, map_set_id=style_id,
+                                      attribution=tool.STYLE_POLICIES[style_id]["attribution"],
+                                      pack_ids=list(pack_ids))
+
+
+def test_plan_empty_card_is_generation_one_slot_zero(tool) -> None:
+    plan = tool.plan_activation(slot_0=None, slot_1=None, new_pack_id="pack-a",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    assert_plan(tool, plan, "osm-bright", "active-pack.0", 1, ["pack-a"])
+
+
+def test_plan_one_valid_slot_targets_missing_slot(tool) -> None:
+    slot_0 = _slot(tool, 1, ["pack-a"])
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-b",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    assert_plan(tool, plan, "osm-bright", "active-pack.1", 2, ["pack-b", "pack-a"])
+
+
+def test_plan_two_valid_slots_overwrites_lower_generation(tool) -> None:
+    slot_0 = _slot(tool, 5, ["old-a"])
+    slot_1 = _slot(tool, 3, ["old-b"])
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=slot_1, new_pack_id="pack-c",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    # Lower-generation slot (slot 1, gen 3) is overwritten; slot 0 (gen 5) stays as fallback.
+    # Composition inherits the highest-generation same-style active set (slot 0, gen 5).
+    assert_plan(tool, plan, "osm-bright", "active-pack.1", 6, ["pack-c", "old-a"])
+
+
+def test_plan_equal_generation_unequal_records_rejected(tool) -> None:
+    slot_0 = _slot(tool, 4, ["pack-a"])
+    slot_1 = _slot(tool, 4, ["pack-b"])
+    with pytest.raises(tool.PackError, match="disagree at equal generation"):
+        tool.plan_activation(slot_0=slot_0, slot_1=slot_1, new_pack_id="pack-c",
+                             style_id="osm-bright",
+                             attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+
+
+def test_plan_existing_same_style_pack_moves_to_front_without_duplication(tool) -> None:
+    slot_0 = _slot(tool, 2, ["pack-a", "pack-b"])
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-b",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    assert_plan(tool, plan, "osm-bright", "active-pack.1", 3, ["pack-b", "pack-a"])
+
+
+def test_plan_different_style_starts_new_composition(tool) -> None:
+    slot_0 = _slot(tool, 2, ["pack-a"], style_id="toner")
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-b",
+                                style_id="dark-matter",
+                                attribution=tool.STYLE_POLICIES["dark-matter"]["attribution"])
+    # No dark-matter style PMAS or active set exists yet: fresh one-pack composition.
+    assert_plan(tool, plan, "dark-matter", "active-pack.1", 3, ["pack-b"])
+
+
+def test_plan_style_pmas_composition_wins_over_active_slots(tool) -> None:
+    slot_0 = _slot(tool, 2, ["slot-only"])
+    style_record = _slot(tool, 9, ["style-a", "slot-only"])
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="new-pack",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"],
+                                style_record=style_record)
+    assert_plan(tool, plan, "osm-bright", "active-pack.1", 10, ["new-pack", "style-a", "slot-only"])
+
+
+def test_plan_pack_limit_rejects_before_any_publication(tool) -> None:
+    slot_0 = _slot(tool, 1, [f"pack-{index}" for index in range(8)])
+    with pytest.raises(tool.PackError, match="8-pack"):
+        tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-new",
+                             style_id="osm-bright",
+                             attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    # Re-installing an existing pack within the limit is fine.
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-3",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    assert_plan(tool, plan, "osm-bright", "active-pack.1", 2,
+                ["pack-3"] + [f"pack-{index}" for index in range(8) if index != 3])
+
+
+def test_plan_generation_exhaustion_rejects(tool) -> None:
+    slot_0 = _slot(tool, tool.MAX_GENERATION, ["pack-a"])
+    with pytest.raises(tool.PackError, match="generation is exhausted"):
+        tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-b",
+                             style_id="osm-bright",
+                             attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+
+
+def test_plan_invalid_slot_is_treated_as_missing(tool) -> None:
+    slot_0 = b"\x00" * 64
+    slot_1 = _slot(tool, 1, ["pack-a"])
+    plan = tool.plan_activation(slot_0=slot_0, slot_1=slot_1, new_pack_id="pack-b",
+                                style_id="osm-bright",
+                                attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+    assert_plan(tool, plan, "osm-bright", "active-pack.0", 2, ["pack-b", "pack-a"])
+
+
+def test_plan_requires_exact_style_attribution(tool) -> None:
+    with pytest.raises(tool.PackError, match="attribution"):
+        tool.plan_activation(slot_0=None, slot_1=None, new_pack_id="pack-a",
+                             style_id="osm-bright", attribution="Someone else's maps")
+
+
 def test_valid_pack_is_deterministic_and_independently_validated(tmp_path: Path) -> None:
     tool = load_tool()
     source = tmp_path / "xyz"

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import json
 import os
 from pathlib import Path
 import struct
@@ -54,9 +55,10 @@ def raw_rgb() -> bytes:
     return b"".join(b"\x00" + b"\x00\x00\x00" * 256 for _ in range(256))
 
 
-def rewrite_crc(data: bytearray) -> bytes:
-    data[-4:] = struct.pack("<I", zlib.crc32(data[:-4]))
-    return bytes(data)
+def rewrite_crc(data: bytearray | bytes) -> bytes:
+    mutable = bytearray(data)
+    mutable[-4:] = struct.pack("<I", zlib.crc32(mutable[:-4]))
+    return bytes(mutable)
 
 
 def put_tile(source: Path, z: int | str, x: int | str, y: int | str, data: bytes | None = None) -> Path:
@@ -92,6 +94,285 @@ def digest_tree(path: Path) -> str:
         if item.is_file():
             digest.update(item.read_bytes())
     return digest.hexdigest()
+
+
+V3_VECTORS = json.loads((ROOT / "tests/fixtures/map_pack_v3_vectors.json").read_text(encoding="utf-8"))
+
+
+def assert_versioned_header(data: bytes, magic: bytes, total_length_field: bool) -> None:
+    assert data[:4] == magic
+    assert data[4] == 3
+    assert data[5] == 0
+    if total_length_field:
+        # PMPK: u16 header size (16), u32 total length, reserved u32
+        assert struct.unpack("<H", data[6:8])[0] == 16
+        assert struct.unpack("<I", data[8:12])[0] == len(data)
+        assert struct.unpack("<I", data[12:16])[0] == 0
+    else:
+        # PMAS: u16 total length, u32 generation
+        assert struct.unpack("<H", data[6:8])[0] == len(data)
+        assert struct.unpack("<I", data[8:12])[0] >= 1
+    assert struct.unpack("<I", data[-4:])[0] == zlib.crc32(data[:-4])
+
+
+def test_frozen_v3_vectors_have_expected_header_length_and_crc() -> None:
+    for name, entry in V3_VECTORS.items():
+        data = bytes.fromhex(entry["hex"])
+        assert name.startswith(("pmpk_v3_", "pmas_v3_")), name
+        assert len(data) >= 20 and len(data) <= 7105
+        assert_versioned_header(data, b"PMPK" if name.startswith("pmpk") else b"PMAS",
+                                total_length_field=name.startswith("pmpk"))
+
+
+def test_decode_frozen_pmpk_v3_vectors() -> None:
+    tool = load_tool()
+    for name in ("pmpk_v3_one_tile", "pmpk_v3_multi_zoom"):
+        entry = V3_VECTORS[name]
+        values = tool.parse_manifest(bytes.fromhex(entry["hex"]))
+        assert values["format_version"] == 3
+        assert values["pack_id"] == entry["pack_id"]
+        assert values["name"] == entry["name"]
+        assert values["attribution"] == entry["attribution"]
+        assert values["source"] == entry["source"]
+        assert values["license"] == entry["license"]
+        assert values["min_zoom"] == entry["min_zoom"]
+        assert values["max_zoom"] == entry["max_zoom"]
+        assert values["tile_count"] == entry["tile_count"]
+        assert values["indexless"] is True
+        assert values["extents"] == []
+        assert values["row_spans"] == []
+
+
+def test_pmas_v1_v2_decode_unchanged() -> None:
+    tool = load_tool()
+    # Legacy v1: 48-byte fixed record, magic, version 1, zero reserved, u16 size,
+    # u32 generation, single pack ID at offset 13, zero padding to offset 44, CRC32.
+    body = bytearray(b"PMAS\x01\x00" + struct.pack("<H", 48) + struct.pack("<I", 5) + b"\x08")
+    body.extend(b"legacy-1")
+    body.extend(b"\x00" * (44 - len(body)))
+    legacy = bytes(body) + struct.pack("<I", zlib.crc32(body))
+    values = tool.decode_active_selection(legacy)
+    assert values["format_version"] == 1
+    assert values["generation"] == 5
+    assert values["map_set_id"] == "legacy-1"
+    assert values["pack_ids"] == ["legacy-1"]
+
+
+def test_encode_pmas_v3_matches_frozen_vector() -> None:
+    tool = load_tool()
+    for name in ("pmas_v3_one_pack", "pmas_v3_three_packs"):
+        entry = V3_VECTORS[name]
+        actual = tool.encode_active_map_set(
+            generation=entry["generation"], map_set_id=entry["map_set_id"],
+            attribution=entry["attribution"], pack_ids=list(entry["pack_ids"]),
+        )
+        assert actual == bytes.fromhex(entry["hex"])
+
+
+def test_pmas_v3_rejects_duplicate_pack_ids() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="duplicate"):
+        tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                   attribution="Example", pack_ids=["same", "same"])
+    # Hand-built decode-side record with the same pack id twice (valid CRC).
+    body = bytearray(struct.pack("<4sBBHI", b"PMAS", 3, 0, 0, 1))
+    body.extend(b"\x0aosm-bright")
+    body.extend(b"\x07Example")
+    body.append(2)
+    body.extend(b"\x06detail")
+    body.extend(b"\x06detail")
+    total = len(body) + 4
+    record = bytes(body[:6]) + struct.pack("<H", total) + bytes(body[8:])
+    record += struct.pack("<I", zlib.crc32(record))
+    with pytest.raises(tool.PackError, match="duplicate"):
+        tool.decode_active_selection(record)
+
+
+def test_pmas_v3_rejects_generation_zero() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="generation"):
+        tool.encode_active_map_set(generation=0, map_set_id="osm-bright",
+                                   attribution="Example", pack_ids=["detail"])
+    with pytest.raises(tool.PackError, match="generation"):
+        tool.encode_active_map_set(generation=1 << 32, map_set_id="osm-bright",
+                                   attribution="Example", pack_ids=["detail"])
+    entry = bytearray(bytes.fromhex(V3_VECTORS["pmas_v3_one_pack"]["hex"]))
+    struct.pack_into("<I", entry, 8, 0)
+    with pytest.raises(tool.PackError, match="generation"):
+        tool.decode_active_selection(rewrite_crc(bytes(entry)))
+
+
+def test_pmas_v3_rejects_more_than_eight_packs() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="1..8"):
+        tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                   attribution="Example",
+                                   pack_ids=[f"pack-{index}" for index in range(9)])
+    with pytest.raises(tool.PackError, match="1..8"):
+        tool.encode_active_map_set(generation=1, map_set_id="osm-bright",
+                                   attribution="Example", pack_ids=[])
+    # hand-built decode-side record claiming nine packs is structurally impossible
+    # to pass CRC, so verify encode-side enforcement plus a trailing-byte reject
+    entry = bytearray(bytes.fromhex(V3_VECTORS["pmas_v3_one_pack"]["hex"]))
+    entry.append(0)
+    with pytest.raises(tool.PackError):
+        tool.decode_active_selection(rewrite_crc(bytes(entry)))
+
+
+def test_decode_pmas_v3_rejects_bad_crc_and_trailing_bytes() -> None:
+    tool = load_tool()
+    entry = bytes.fromhex(V3_VECTORS["pmas_v3_one_pack"]["hex"])
+    corrupted = entry[:-1] + bytes([entry[-1] ^ 1])
+    with pytest.raises(tool.PackError, match="CRC"):
+        tool.decode_active_selection(corrupted)
+    entry = bytearray(bytes.fromhex(V3_VECTORS["pmas_v3_one_pack"]["hex"]))
+    entry[13] = 0x01  # first map-set-id character becomes a control byte
+    with pytest.raises(tool.PackError):
+        tool.decode_active_selection(rewrite_crc(bytes(entry)))
+
+
+def test_decode_frozen_pmas_v3_vectors() -> None:
+    tool = load_tool()
+    for name in ("pmas_v3_one_pack", "pmas_v3_three_packs"):
+        entry = V3_VECTORS[name]
+        values = tool.decode_active_selection(bytes.fromhex(entry["hex"]))
+        assert values["format_version"] == 3
+        assert values["generation"] == entry["generation"]
+        assert values["map_set_id"] == entry["map_set_id"]
+        assert values["attribution"] == entry["attribution"]
+        assert values["pack_ids"] == entry["pack_ids"]
+
+
+def test_parse_pmpk_v3_frozen_vector() -> None:
+    tool = load_tool()
+    values = tool.parse_manifest(bytes.fromhex(V3_VECTORS["pmpk_v3_one_tile"]["hex"]))
+    assert values["format_version"] == 3
+    assert values["pack_id"] == "one-tile"
+    assert values["tile_count"] == 1
+    assert values["indexless"] is True
+    assert values["extents"] == [] and values["row_spans"] == []
+
+
+def _mutated_pmpk_v3(mutate) -> bytes:
+    data = bytearray(bytes.fromhex(V3_VECTORS["pmpk_v3_one_tile"]["hex"]))
+    mutate(data)
+    return rewrite_crc(data)
+
+
+def test_pmpk_v3_rejects_nonzero_reserved_byte() -> None:
+    tool = load_tool()
+    data = bytearray(bytes.fromhex(V3_VECTORS["pmpk_v3_one_tile"]["hex"]))
+    data[5] = 1
+    with pytest.raises(tool.PackError):
+        tool.parse_manifest(rewrite_crc(data))
+
+
+def test_pmpk_v3_rejects_trailing_bytes() -> None:
+    tool = load_tool()
+    data = bytearray(bytes.fromhex(V3_VECTORS["pmpk_v3_one_tile"]["hex"]))
+    data[-5:-1] = data[-5:-1] + b"junk"[:1]
+    data = data[:-4] + b"\x00\x00\x00\x00" + data[-4:]
+    # total length field now disagrees with actual size: header check rejects
+    with pytest.raises(tool.PackError):
+        tool.parse_manifest(rewrite_crc(data))
+
+
+def test_pmpk_v3_rejects_bad_crc() -> None:
+    tool = load_tool()
+    data = bytes.fromhex(V3_VECTORS["pmpk_v3_one_tile"]["hex"])
+    corrupted = data[:-1] + bytes([data[-1] ^ 1])
+    with pytest.raises(tool.PackError):
+        tool.parse_manifest(corrupted)
+
+
+def test_pmpk_v3_rejects_zero_tile_count_and_inverted_zooms() -> None:
+    tool = load_tool()
+    def zero_tiles(data: bytearray) -> None:
+        struct.pack_into("<I", data, len(data) - 8, 0)
+
+    def inverted_zooms(data: bytearray) -> None:
+        # max zoom becomes 1 while min stays 2: min > max
+        data[-9] = 1
+
+    for mutate in (zero_tiles, inverted_zooms):
+        with pytest.raises(tool.PackError):
+            tool.parse_manifest(_mutated_pmpk_v3(mutate))
+
+
+def test_pmpk_v1_v2_vectors_unchanged() -> None:
+    tool = load_tool()
+    v1 = tool.serialize_manifest(**metadata(), extents=[tool.ZoomExtent(0, ((0, 0),), 0, 0)], tile_count=1)
+    v1_values = tool.parse_manifest(v1)
+    assert v1_values["format_version"] == 1
+    assert v1_values["indexless"] is False
+    v2 = tool.serialize_sparse_manifest(
+        **metadata(), row_spans=[tool.RowSpan(1, 0, 0, 1)], tile_count=2)
+    v2_values = tool.parse_manifest(v2)
+    assert v2_values["format_version"] == 2
+    assert v2_values["indexless"] is False
+
+
+def test_serialize_pmpk_v3_matches_frozen_vector() -> None:
+    tool = load_tool()
+    entry = V3_VECTORS["pmpk_v3_one_tile"]
+    actual = tool.serialize_indexless_manifest(
+        pack_id=entry["pack_id"], name=entry["name"], attribution=entry["attribution"],
+        source=entry["source"], license=entry["license"],
+        minimum_zoom=entry["min_zoom"], maximum_zoom=entry["max_zoom"],
+        tile_count=entry["tile_count"],
+    )
+    assert actual == bytes.fromhex(entry["hex"])
+    parsed = tool.parse_manifest(actual)
+    assert parsed["indexless"] is True
+
+
+def test_serialize_pmpk_v3_is_deterministic() -> None:
+    tool = load_tool()
+    entry = V3_VECTORS["pmpk_v3_multi_zoom"]
+    first = tool.serialize_indexless_manifest(
+        pack_id=entry["pack_id"], name=entry["name"], attribution=entry["attribution"],
+        source=entry["source"], license=entry["license"],
+        minimum_zoom=entry["min_zoom"], maximum_zoom=entry["max_zoom"],
+        tile_count=entry["tile_count"],
+    )
+    second = tool.serialize_indexless_manifest(
+        pack_id=entry["pack_id"], name=entry["name"], attribution=entry["attribution"],
+        source=entry["source"], license=entry["license"],
+        minimum_zoom=entry["min_zoom"], maximum_zoom=entry["max_zoom"],
+        tile_count=entry["tile_count"],
+    )
+    assert first == second == bytes.fromhex(entry["hex"])
+
+
+def test_serialize_pmpk_v3_rejects_zero_tiles() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="tile count"):
+        tool.serialize_indexless_manifest(**metadata(), minimum_zoom=1, maximum_zoom=1, tile_count=0)
+    with pytest.raises(tool.PackError, match="tile count"):
+        tool.serialize_indexless_manifest(**metadata(), minimum_zoom=1, maximum_zoom=1, tile_count=1 << 32)
+
+
+def test_serialize_pmpk_v3_rejects_invalid_zoom_range() -> None:
+    tool = load_tool()
+    with pytest.raises(tool.PackError, match="zoom range"):
+        tool.serialize_indexless_manifest(**metadata(), minimum_zoom=3, maximum_zoom=2, tile_count=1)
+    with pytest.raises(tool.PackError, match="zoom range"):
+        tool.serialize_indexless_manifest(**metadata(), minimum_zoom=0, maximum_zoom=tool.MAX_ZOOM + 1, tile_count=1)
+
+
+def test_serialize_pmpk_v3_contains_no_span_payload() -> None:
+    tool = load_tool()
+    entry = V3_VECTORS["pmpk_v3_one_tile"]
+    data = tool.serialize_indexless_manifest(
+        pack_id=entry["pack_id"], name=entry["name"], attribution=entry["attribution"],
+        source=entry["source"], license=entry["license"],
+        minimum_zoom=entry["min_zoom"], maximum_zoom=entry["max_zoom"],
+        tile_count=entry["tile_count"],
+    )
+    # v3 payload is exactly five length-prefixed strings plus min, max, tile_count
+    expected_length = 16 + sum(1 + len(entry[field].encode("ascii"))
+                               for field in ("pack_id", "name", "attribution", "source", "license")) + 6 + 4
+    assert len(data) == expected_length
 
 
 def test_valid_pack_is_deterministic_and_independently_validated(tmp_path: Path) -> None:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1498,6 +1498,12 @@ def _run_activate(arguments) -> int:
         _ensure_pack_published(arguments, output_root, style)
         try:
             publish_activation(pyxis_fd, plan, output_root)
+        except PublishedDurabilityError as exc:
+            print(f"error: the activation record was committed and is visible, "
+                  f"but its durability is uncertain: {exc}", file=sys.stderr)
+            print("verify the card (rerun the exact same command) instead of "
+                  "assuming activation failed", file=sys.stderr)
+            return 4
         except (PackError, OSError) as exc:
             print(f"error: pack publication succeeded but activation failed: {exc}",
                   file=sys.stderr)

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -815,7 +815,10 @@ def decode_active_selection(data: bytes) -> dict[str, object]:
         if generation == 0:
             raise PackError("invalid legacy active selection generation")
         pack_id_size = data[12]
-        pack_id, = (data[13:13 + pack_id_size].decode("ascii"),)
+        try:
+            pack_id, = (data[13:13 + pack_id_size].decode("ascii"),)
+        except UnicodeDecodeError:
+            raise PackError("invalid legacy active selection pack ID") from None
         if pack_id_size == 0 or pack_id_size >= 32 or not PACK_ID_RE.fullmatch(pack_id):
             raise PackError("invalid legacy active selection pack ID")
         if any(byte != 0 for byte in data[13 + pack_id_size:44]):
@@ -1310,8 +1313,9 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
     _validate_metadata(pack_id, name, attribution, source, license)
     if style is not None:
         policy = STYLE_POLICIES[style]
-        for field, expected in policy.items():
-            if locals()[field] != expected:
+        for field, value in (("attribution", attribution), ("source", source),
+                             ("license", license)):
+            if value != policy[field]:
                 raise PackError(
                     f"--style {style} requires {field} exactly matching the firmware style policy")
     antimeridian_zooms = set() if antimeridian_zooms is None else set(antimeridian_zooms)

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1531,7 +1531,9 @@ def _parser() -> argparse.ArgumentParser:
                         help="firmware map style; metadata must exactly match the style policy and PMPK v3 is emitted")
     parser.add_argument("--activate", action="store_true",
                         help="after publishing the pack, atomically activate it into the style PMAS "
-                             "and one redundant active slot (requires --style)")
+                             "and one redundant active slot (requires --style). Serializes CLI "
+                             "processes via a persistent lock; do not run the browser installer "
+                             "against the same mounted card at the same time")
     return parser
 
 

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -23,8 +23,10 @@ from typing import Any, cast, Iterable
 import zlib
 
 MAGIC = b"PMPK"
+ACTIVE_MAGIC = b"PMAS"
 FORMAT_VERSION = 1
 SPARSE_FORMAT_VERSION = 2
+INDEXLESS_FORMAT_VERSION = 3
 HEADER_SIZE = 16
 EXTENT_SIZE = 26
 ROW_SPAN_SIZE = 13
@@ -37,6 +39,9 @@ PACK_ID_RE = re.compile(r"[a-z0-9_-]{1,31}\Z")
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 _STRING_LIMITS = {"pack_id": 31, "name": 63, "attribution": 127, "source": 127, "license": 63}
 MAX_MANIFEST_BYTES = 7100
+MAX_ACTIVE_SELECTION_BYTES = 7105
+MAX_ACTIVE_PACKS = 8
+MAX_GENERATION = 0xFFFFFFFF
 _DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
 _FILE_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC
 
@@ -603,11 +608,34 @@ def serialize_manifest(*, pack_id: str, name: str, attribution: str, source: str
     return bytes(result)
 
 
+def serialize_indexless_manifest(*, pack_id: str, name: str, attribution: str, source: str,
+                                 license: str, minimum_zoom: int, maximum_zoom: int,
+                                 tile_count: int) -> bytes:
+    _validate_metadata(pack_id, name, attribution, source, license)
+    if not 0 <= minimum_zoom <= maximum_zoom <= MAX_ZOOM:
+        raise PackError("invalid indexless zoom range")
+    if tile_count <= 0 or tile_count > 0xFFFFFFFF:
+        raise PackError("invalid indexless tile count")
+    payload = bytearray()
+    for field, value in (("pack_id", pack_id), ("name", name), ("attribution", attribution),
+                         ("source", source), ("license", license)):
+        encoded = _checked_text(field, value)
+        payload.append(len(encoded))
+        payload.extend(encoded)
+    payload.extend((minimum_zoom, maximum_zoom))
+    payload.extend(struct.pack("<I", tile_count))
+    length = HEADER_SIZE + len(payload) + 4
+    result = bytearray(struct.pack("<4sBBHII", MAGIC, INDEXLESS_FORMAT_VERSION, 0, HEADER_SIZE, length, 0))
+    result.extend(payload)
+    result.extend(struct.pack("<I", zlib.crc32(result)))
+    return bytes(result)
+
+
 def parse_manifest(data: bytes) -> dict[str, object]:
     if len(data) < 20 or len(data) > MAX_MANIFEST_BYTES:
         raise PackError("manifest is truncated or oversized")
     magic, version, reserved, header_size, length, reserved_word = struct.unpack("<4sBBHII", data[:16])
-    if magic != MAGIC or version not in (FORMAT_VERSION, SPARSE_FORMAT_VERSION) or \
+    if magic != MAGIC or version not in (FORMAT_VERSION, SPARSE_FORMAT_VERSION, INDEXLESS_FORMAT_VERSION) or \
             (reserved, header_size, length, reserved_word) != (0, 16, len(data), 0):
         raise PackError("invalid manifest header")
     if zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
@@ -652,7 +680,22 @@ def parse_manifest(data: bytes) -> dict[str, object]:
             raise PackError("invalid manifest length or zoom range")
         _validate_manifest_values(extents, tile_count)
         values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
-                      tile_count=tile_count, extents=extents, row_spans=[])
+                      tile_count=tile_count, extents=extents, row_spans=[], indexless=False)
+    elif version == INDEXLESS_FORMAT_VERSION:
+        if position + 6 > len(data) - 4:
+            raise PackError("manifest indexless fields are truncated")
+        minimum, maximum = data[position:position + 2]
+        position += 2
+        tile_count = struct.unpack("<I", data[position:position + 4])[0]
+        position += 4
+        if position != len(data) - 4:
+            raise PackError("manifest indexless record has trailing bytes")
+        if minimum > maximum or maximum > MAX_ZOOM:
+            raise PackError("invalid manifest zoom range")
+        if tile_count == 0:
+            raise PackError("invalid manifest tile count")
+        values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
+                      tile_count=tile_count, extents=[], row_spans=[], indexless=True)
     else:
         if position + 8 > len(data) - 4:
             raise PackError("manifest sparse fields are truncated")
@@ -671,8 +714,132 @@ def parse_manifest(data: bytes) -> dict[str, object]:
             raise PackError("invalid manifest length or zoom range")
         _validate_row_spans(row_spans, tile_count)
         values.update(format_version=version, min_zoom=minimum, max_zoom=maximum,
-                      tile_count=tile_count, extents=[], row_spans=row_spans)
+                      tile_count=tile_count, extents=[], row_spans=row_spans, indexless=False)
     return values
+
+
+def _validate_indexless_selection(generation: int, map_set_id: str, attribution: str,
+                                  pack_ids: list[str]) -> None:
+    if not 1 <= generation <= MAX_GENERATION:
+        raise PackError("active selection generation must be 1..0xFFFFFFFF")
+    if not PACK_ID_RE.fullmatch(map_set_id):
+        raise PackError("map set ID must match [a-z0-9_-]{1,31}")
+    _checked_text("attribution", attribution)
+    if not 1 <= len(pack_ids) <= MAX_ACTIVE_PACKS:
+        raise PackError("active selection must reference 1..8 packs")
+    seen: set[str] = set()
+    for pack_id in pack_ids:
+        if not PACK_ID_RE.fullmatch(pack_id):
+            raise PackError("pack ID must match [a-z0-9_-]{1,31}")
+        if pack_id in seen:
+            raise PackError("duplicate pack ID in active selection")
+        seen.add(pack_id)
+
+
+def encode_active_map_set(*, generation: int, map_set_id: str, attribution: str,
+                          pack_ids: list[str]) -> bytes:
+    _validate_indexless_selection(generation, map_set_id, attribution, pack_ids)
+    body = bytearray(struct.pack("<4sBBHI", ACTIVE_MAGIC, INDEXLESS_FORMAT_VERSION, 0, 0, generation))
+    for field, value in (("pack_id", map_set_id), ("attribution", attribution)):
+        encoded = _checked_text(field, value)
+        body.append(len(encoded))
+        body.extend(encoded)
+    body.append(len(pack_ids))
+    for pack_id in pack_ids:
+        encoded = pack_id.encode("ascii")
+        body.append(len(encoded))
+        body.extend(encoded)
+    total_length = len(body) + 4
+    header = bytes(body[:6]) + struct.pack("<H", total_length) + bytes(body[8:])
+    return header + struct.pack("<I", zlib.crc32(header))
+
+
+def _decode_pmas_string(data: bytes, position: int, end: int, *, capacity: int, identifier: bool) -> tuple[str, int]:
+    if position >= end:
+        raise PackError("active selection string is truncated")
+    size = data[position]
+    position += 1
+    if size == 0 or size >= capacity or size > end - position:
+        raise PackError("invalid active selection string")
+    try:
+        value = data[position:position + size].decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise PackError("invalid active selection string") from exc
+    if not all(0x20 <= byte <= 0x7E for byte in data[position:position + size]):
+        raise PackError("invalid active selection string")
+    if identifier and not PACK_ID_RE.fullmatch(value):
+        raise PackError("invalid active selection identifier")
+    return value, position + size
+
+
+def decode_active_selection(data: bytes) -> dict[str, object]:
+    if len(data) < 16 or len(data) > MAX_ACTIVE_SELECTION_BYTES:
+        raise PackError("active selection is truncated or oversized")
+    if data[:4] != ACTIVE_MAGIC or data[5] != 0:
+        raise PackError("invalid active selection header")
+    version = data[4]
+    if version not in (1, SPARSE_FORMAT_VERSION, INDEXLESS_FORMAT_VERSION):
+        raise PackError("unsupported active selection version")
+    if zlib.crc32(data[:-4]) != struct.unpack("<I", data[-4:])[0]:
+        raise PackError("invalid active selection CRC")
+    if version == 1:
+        if len(data) != 48:
+            raise PackError("legacy active selection must be 48 bytes")
+        if struct.unpack("<H", data[6:8])[0] != 48:
+            raise PackError("invalid legacy active selection header")
+        generation = struct.unpack("<I", data[8:12])[0]
+        if generation == 0:
+            raise PackError("invalid legacy active selection generation")
+        pack_id_size = data[12]
+        pack_id, = (data[13:13 + pack_id_size].decode("ascii"),)
+        if pack_id_size == 0 or pack_id_size >= 32 or not PACK_ID_RE.fullmatch(pack_id):
+            raise PackError("invalid legacy active selection pack ID")
+        if any(byte != 0 for byte in data[13 + pack_id_size:44]):
+            raise PackError("legacy active selection must be zero padded")
+        return {"format_version": 1, "generation": generation, "map_set_id": pack_id,
+                "attribution": "", "pack_ids": [pack_id], "row_spans": {}}
+    generation = struct.unpack("<I", data[8:12])[0]
+    if generation == 0:
+        raise PackError("invalid active selection generation")
+    if struct.unpack("<H", data[6:8])[0] != len(data):
+        raise PackError("invalid active selection length")
+    end = len(data) - 4
+    position = 12
+    map_set_id, position = _decode_pmas_string(data, position, end, capacity=32, identifier=True)
+    attribution, position = _decode_pmas_string(data, position, end, capacity=128, identifier=False)
+    if position >= end:
+        raise PackError("active selection pack count is truncated")
+    pack_count = data[position]
+    position += 1
+    if not 1 <= pack_count <= MAX_ACTIVE_PACKS:
+        raise PackError("invalid active selection pack count")
+    pack_ids: list[str] = []
+    row_spans: dict[str, list[tuple[int, int, int, int]]] = {}
+    for _ in range(pack_count):
+        pack_id, position = _decode_pmas_string(data, position, end, capacity=32, identifier=True)
+        if pack_id in pack_ids:
+            raise PackError("duplicate pack ID in active selection")
+        pack_ids.append(pack_id)
+        if version == SPARSE_FORMAT_VERSION:
+            if position + 2 > end:
+                raise PackError("active selection span count is truncated")
+            span_count = struct.unpack("<H", data[position:position + 2])[0]
+            position += 2
+            if span_count == 0 or span_count > MAX_ROW_SPANS:
+                raise PackError("invalid active selection span count")
+            if span_count * ROW_SPAN_SIZE > end - position:
+                raise PackError("active selection spans are truncated")
+            spans: list[tuple[int, int, int, int]] = []
+            for _span in range(span_count):
+                zoom, y, x_minimum, x_maximum = struct.unpack(
+                    "<BIII", data[position:position + ROW_SPAN_SIZE])
+                position += ROW_SPAN_SIZE
+                spans.append((zoom, y, x_minimum, x_maximum))
+            row_spans[pack_id] = spans
+    if position != end:
+        raise PackError("active selection has trailing bytes")
+    return {"format_version": version, "generation": generation, "map_set_id": map_set_id,
+            "attribution": attribution, "pack_ids": pack_ids, "row_spans": row_spans}
 
 
 def _open_verified_tile(source_fd: int, tile: Tile) -> int:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -890,6 +890,95 @@ def release_install_lock(lock_fd: int) -> None:
     os.close(lock_fd)
 
 
+@dataclass(frozen=True)
+class ActivationPlan:
+    style_name: str
+    target_slot: str
+    generation: int
+    pack_ids: tuple[str, ...]
+    record: bytes
+
+
+def _slot_state(raw: bytes | None) -> tuple[str, dict[str, object] | None]:
+    """Classify one raw active-slot record without any filesystem access."""
+    if raw is None:
+        return "missing", None
+    try:
+        values = decode_active_selection(raw)
+    except PackError:
+        return "invalid", None
+    return "present", values
+
+
+def plan_activation(*, slot_0: bytes | None, slot_1: bytes | None,
+                    style_record: bytes | None = None,
+                    new_pack_id: str, style_id: str, attribution: str) -> ActivationPlan:
+    """Derive a candidate PMAS v3 record from a raw snapshot. No filesystem I/O."""
+    if style_id not in STYLE_POLICIES:
+        raise PackError(f"unsupported map style: {style_id}")
+    policy = STYLE_POLICIES[style_id]
+    if attribution != policy["attribution"]:
+        raise PackError("--style requires attribution exactly matching the firmware style policy")
+    if not PACK_ID_RE.fullmatch(new_pack_id):
+        raise PackError("pack ID must match [a-z0-9_-]{1,31}")
+    states = ((0, _slot_state(slot_0)), (1, _slot_state(slot_1)))
+    present: list[tuple[int, dict[str, object]]] = []
+    for index, (state, values) in states:
+        if state == "present" and values is not None:
+            present.append((index, values))
+    if len(present) == 2:
+        first = present[0][1]
+        second = present[1][1]
+        if first["generation"] == second["generation"] and first != second:
+            raise PackError("active slots disagree at equal generation; restore a known-good card state first")
+    style_values: dict[str, object] | None = None
+    if style_record is not None:
+        try:
+            decoded = decode_active_selection(style_record)
+        except PackError:
+            decoded = None
+        if decoded is not None and decoded["map_set_id"] == style_id \
+                and decoded["attribution"] == policy["attribution"]:
+            style_values = decoded
+    max_generation = max(
+        (cast(int, values["generation"]) for _, values in present),
+        default=0,
+    )
+    if style_values is not None:
+        max_generation = max(max_generation, cast(int, style_values["generation"]))
+    generation = max_generation + 1
+    if generation > MAX_GENERATION:
+        raise PackError("active selection generation is exhausted")
+
+    if style_values is not None:
+        composition = list(cast(list[str], style_values["pack_ids"]))
+    else:
+        composition: list[str] = []
+        for _index, values in sorted(present, key=lambda item: cast(int, item[1]["generation"]), reverse=True):
+            if values["map_set_id"] == style_id:
+                composition = list(cast(list[str], values["pack_ids"]))
+                break
+
+    if new_pack_id in composition:
+        composition.remove(new_pack_id)
+    composition.insert(0, new_pack_id)
+    if len(composition) > MAX_ACTIVE_PACKS:
+        raise PackError("active selection exceeds the 8-pack limit")
+    if len(set(composition)) != len(composition):
+        raise PackError("duplicate pack ID in candidate map set")
+
+    missing_or_invalid = [index for index, (state, _values) in states if state != "present"]
+    if missing_or_invalid:
+        target_slot = f"active-pack.{missing_or_invalid[0]}"
+    else:
+        lower = min(present, key=lambda item: (cast(int, item[1]["generation"]), item[0]))
+        target_slot = f"active-pack.{lower[0]}"
+    record = encode_active_map_set(generation=generation, map_set_id=style_id,
+                                   attribution=attribution, pack_ids=composition)
+    return ActivationPlan(style_name=style_id, target_slot=target_slot, generation=generation,
+                          pack_ids=tuple(composition), record=record)
+
+
 def _open_verified_tile(source_fd: int, tile: Tile) -> int:
     zoom_fd, zoom_identity = _open_child_directory(source_fd, str(tile.zoom), str(tile.path.parent.parent))
     try:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -1407,6 +1407,112 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
             raise PublishedDurabilityError(target, close_error)
 
 
+def _read_optional_file_at(parent_fd: int, name: str, maximum: int) -> bytes | None:
+    """Read a small record, treating missing or malformed files as absent."""
+    try:
+        return _read_file_at(parent_fd, name, maximum)
+    except (FileNotFoundError, PackError):
+        return None
+
+
+def _read_optional_style_record(pyxis_fd: int, style: str) -> bytes | None:
+    try:
+        map_sets_fd, _ = _open_child_directory(pyxis_fd, "map-sets", "pyxis-map/map-sets")
+    except PackError:
+        return None
+    try:
+        return _read_optional_file_at(map_sets_fd, f"{style}.pmas", MAX_ACTIVE_SELECTION_BYTES)
+    finally:
+        os.close(map_sets_fd)
+
+
+def _preflight_existing_packs(pyxis_fd: int, plan: "ActivationPlan", new_pack_id: str) -> None:
+    """Validate inherited packs before the new pack is published (A10 step 4).
+
+    The 8-pack limit is already enforced by plan_activation; this refuses a
+    missing/corrupt/policy-incompatible inherited pack before any publication.
+    """
+    inherited = tuple(p for p in plan.pack_ids if p != new_pack_id)
+    if not inherited:
+        return
+    validate_active_pack_manifests_at(
+        pyxis_fd, map_set_id=plan.style_name,
+        attribution=STYLE_POLICIES[plan.style_name]["attribution"], pack_ids=inherited)
+
+
+def _ensure_pack_published(arguments, output_root: Path, style: str) -> Path:
+    """Stage and publish the new pack, or resume an exact-match existing pack."""
+    pack_dir = output_root / "pyxis-map" / "packs" / arguments.pack_id
+    if pack_dir.exists():
+        parsed = validate_pack(pack_dir, arguments.max_bytes)
+        for field, expected in (("pack_id", arguments.pack_id),
+                                ("name", arguments.name),
+                                ("attribution", arguments.attribution),
+                                ("source", arguments.source),
+                                ("license", arguments.license)):
+            if parsed[field] != expected:
+                raise PackError(
+                    f"existing pack {arguments.pack_id} {field} does not match the request; "
+                    "refusing to overwrite")
+        return pack_dir
+    return build_map_pack(
+        arguments.xyz_directory, output_root,
+        pack_id=arguments.pack_id, name=arguments.name,
+        attribution=arguments.attribution, source=arguments.source,
+        license=arguments.license, max_tiles=arguments.max_tiles,
+        max_bytes=arguments.max_bytes,
+        antimeridian_zooms=set(arguments.antimeridian_zoom),
+        sparse=arguments.sparse, style=style)
+
+
+def _run_activate(arguments) -> int:
+    """A10 order: lock, plan, preflight, publish, revalidate, write, read-back."""
+    style = arguments.style
+    if style is None:
+        raise PackError("--activate requires --style")
+    output_root = Path(arguments.output_root)
+    root_fd = _open_path(output_root, create=True)
+    try:
+        pyxis_fd, _ = _mkdir_open(root_fd, "pyxis-map")
+    finally:
+        os.close(root_fd)
+    lock_fd = -1
+    try:
+        try:
+            lock_fd = acquire_install_lock(pyxis_fd)
+        except PackError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        slot_0 = _read_optional_file_at(pyxis_fd, "active-pack.0", MAX_ACTIVE_SELECTION_BYTES)
+        slot_1 = _read_optional_file_at(pyxis_fd, "active-pack.1", MAX_ACTIVE_SELECTION_BYTES)
+        style_record = _read_optional_style_record(pyxis_fd, style)
+        plan = plan_activation(
+            slot_0=slot_0, slot_1=slot_1, style_record=style_record,
+            new_pack_id=arguments.pack_id, style_id=style,
+            attribution=arguments.attribution)
+        _preflight_existing_packs(pyxis_fd, plan, arguments.pack_id)
+        _ensure_pack_published(arguments, output_root, style)
+        try:
+            publish_activation(pyxis_fd, plan, output_root)
+        except (PackError, OSError) as exc:
+            print(f"error: pack publication succeeded but activation failed: {exc}",
+                  file=sys.stderr)
+            print("the published pack was left in place; rerun the exact same command to retry",
+                  file=sys.stderr)
+            return 4
+        return 0
+    except PublishedDurabilityError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+    except (PackError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    finally:
+        if lock_fd >= 0:
+            release_install_lock(lock_fd)
+        os.close(pyxis_fd)
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("xyz_directory", type=Path)
@@ -1423,11 +1529,19 @@ def _parser() -> argparse.ArgumentParser:
                         help="explicitly admit sparse state/polygon coverage and emit PMPK v2")
     parser.add_argument("--style", choices=sorted(STYLE_POLICIES),
                         help="firmware map style; metadata must exactly match the style policy and PMPK v3 is emitted")
+    parser.add_argument("--activate", action="store_true",
+                        help="after publishing the pack, atomically activate it into the style PMAS "
+                             "and one redundant active slot (requires --style)")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
+    if arguments.activate and arguments.style is None:
+        print("error: --activate requires --style", file=sys.stderr)
+        return 2
+    if arguments.activate:
+        return _run_activate(arguments)
     try:
         target = build_map_pack(arguments.xyz_directory, arguments.output_root,
                                 pack_id=arguments.pack_id, name=arguments.name,

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -910,6 +910,153 @@ def _slot_state(raw: bytes | None) -> tuple[str, dict[str, object] | None]:
     return "present", values
 
 
+def _rename_at(parent_fd: int, source: str, destination: str, target: Path) -> None:
+    if _renameat2 is None:
+        raise PackError("atomic rename unsupported on this host")
+    result = _renameat2(parent_fd, os.fsencode(source), parent_fd, os.fsencode(destination), 0)
+    if result == 0:
+        return
+    error = ctypes.get_errno()
+    if error in (errno.ENOSYS, errno.EINVAL, errno.ENOTSUP, errno.EOPNOTSUPP):
+        raise PackError("atomic rename unsupported on this filesystem")
+    raise OSError(error, os.strerror(error), target)
+
+
+def _atomic_replace_file_at(parent_fd: int, name: str, data: bytes, target: Path) -> None:
+    """Publish data to name via private temp + fsync + atomic overwrite rename + parent fsync."""
+    temp_name = ""
+    temp_fd = -1
+    for attempt in range(256):
+        temp_name = f".{name}.tmp-{os.getpid():x}-{attempt:02x}"
+        try:
+            temp_fd = os.open(temp_name, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC,
+                              0o644, dir_fd=parent_fd)
+            break
+        except FileExistsError:
+            continue
+        except OSError as exc:
+            raise PackError(f"cannot stage {name}: {exc}") from exc
+    else:
+        raise PackError("cannot allocate temporary output file")
+    try:
+        try:
+            _write_all(temp_fd, data, name)
+            os.fsync(temp_fd)
+        finally:
+            os.close(temp_fd)
+        temp_fd = -1
+        _rename_at(parent_fd, temp_name, name, target)
+        temp_name = ""
+    finally:
+        if temp_fd >= 0:
+            try:
+                os.close(temp_fd)
+            except OSError:
+                pass
+        if temp_name:
+            try:
+                os.unlink(temp_name, dir_fd=parent_fd)
+            except OSError:
+                pass
+    try:
+        _fsync_directory_fd(parent_fd)
+    except OSError as exc:
+        raise PublishedDurabilityError(target, exc) from exc
+
+
+def _read_back_file_at(parent_fd: int, name: str, expected: bytes, target: Path,
+                       label: str) -> bytes:
+    data = _read_file_at(parent_fd, name, max(len(expected), MAX_ACTIVE_SELECTION_BYTES))
+    if data != expected:
+        raise PackError(f"{label} read-back mismatch for {target}")
+    return data
+
+
+def validate_active_pack_manifests_at(pyxis_fd: int, *, map_set_id: str, attribution: str,
+                                      pack_ids: tuple[str, ...]) -> None:
+    """Hard preflight: every referenced pack manifest must decode and match policy.
+
+    Mirrors firmware MapTilePack::validateMapSet() for indexless PMAS v3 sets:
+    missing, corrupt, or policy-incompatible inherited packs are preflight
+    failures and never silently dropped.
+    """
+    if not pack_ids:
+        raise PackError("map set composition is empty")
+    policy = STYLE_POLICIES.get(map_set_id)
+    if policy is None:
+        raise PackError(f"unsupported map style: {map_set_id}")
+    if attribution != policy["attribution"]:
+        raise PackError("active set attribution does not match the firmware style policy")
+    try:
+        packs_fd, _ = _open_child_directory(pyxis_fd, "packs", "pyxis-map/packs")
+    except FileNotFoundError as exc:
+        raise PackError(f"missing inherited pack manifest: packs/{pack_ids[0]}/manifest.pmp") from exc
+    try:
+        for pack_id in pack_ids:
+            try:
+                pack_fd = os.open(pack_id, _DIRECTORY_FLAGS, dir_fd=packs_fd)
+            except FileNotFoundError as exc:
+                raise PackError(
+                    f"missing inherited pack manifest: packs/{pack_id}/manifest.pmp") from exc
+            except OSError as exc:
+                raise PackError(f"invalid inherited pack directory: packs/{pack_id}: {exc}") from exc
+            try:
+                manifest_bytes = _read_file_at(pack_fd, "manifest.pmp", MAX_MANIFEST_BYTES)
+            except FileNotFoundError as exc:
+                raise PackError(
+                    f"missing inherited pack manifest: packs/{pack_id}/manifest.pmp") from exc
+            finally:
+                os.close(pack_fd)
+            parsed = parse_manifest(manifest_bytes)
+            if parsed["format_version"] != INDEXLESS_FORMAT_VERSION:
+                raise PackError(
+                    f"pack {pack_id} manifest is not PMPK v3; indexless activation requires v3")
+            if parsed["pack_id"] != pack_id:
+                raise PackError(f"pack {pack_id} manifest declares a different pack ID")
+            if parsed["attribution"] != attribution:
+                raise PackError(f"pack {pack_id} attribution does not match the active set")
+            if parsed["source"] != policy["source"] or parsed["license"] != policy["license"]:
+                raise PackError(
+                    f"pack {pack_id} source/license does not match the {map_set_id} style policy")
+    finally:
+        os.close(packs_fd)
+
+
+def publish_activation(pyxis_fd: int, plan: "ActivationPlan", output_root: Path) -> None:
+    """Validate every candidate pack, then publish style PMAS and target slot with read-back.
+
+    Order: full preflight, style record first, slot record second. The peer
+    active slot is never touched. A failed preflight changes no bytes.
+    """
+    validate_active_pack_manifests_at(
+        pyxis_fd, map_set_id=plan.style_name,
+        attribution=STYLE_POLICIES[plan.style_name]["attribution"], pack_ids=plan.pack_ids)
+    map_sets_fd, _ = _mkdir_open(pyxis_fd, "map-sets")
+    try:
+        style_target = output_root / "pyxis-map" / "map-sets" / f"{plan.style_name}.pmas"
+        _atomic_replace_file_at(map_sets_fd, f"{plan.style_name}.pmas", plan.record, style_target)
+        style_read_back = _read_back_file_at(
+            map_sets_fd, f"{plan.style_name}.pmas", plan.record, style_target, "style record")
+        decoded = decode_active_selection(style_read_back)
+        if (decoded["format_version"] != INDEXLESS_FORMAT_VERSION
+                or decoded["generation"] != plan.generation
+                or decoded["map_set_id"] != plan.style_name
+                or decoded["pack_ids"] != list(plan.pack_ids)):
+            raise PackError(f"style record read-back is not semantically identical: {style_target}")
+        slot_target = output_root / "pyxis-map" / plan.target_slot
+        _atomic_replace_file_at(pyxis_fd, plan.target_slot, plan.record, slot_target)
+        slot_read_back = _read_back_file_at(
+            pyxis_fd, plan.target_slot, plan.record, slot_target, "active slot record")
+        decoded = decode_active_selection(slot_read_back)
+        if (decoded["format_version"] != INDEXLESS_FORMAT_VERSION
+                or decoded["generation"] != plan.generation
+                or decoded["map_set_id"] != plan.style_name
+                or decoded["pack_ids"] != list(plan.pack_ids)):
+            raise PackError(f"active slot read-back is not semantically identical: {slot_target}")
+    finally:
+        os.close(map_sets_fd)
+
+
 def plan_activation(*, slot_0: bytes | None, slot_1: bytes | None,
                     style_record: bytes | None = None,
                     new_pack_id: str, style_id: str, attribution: str) -> ActivationPlan:

--- a/tools/maps/build_map_pack.py
+++ b/tools/maps/build_map_pack.py
@@ -13,6 +13,7 @@ import argparse
 import ctypes
 from dataclasses import dataclass
 import errno
+import fcntl
 import os
 from pathlib import Path
 import re
@@ -42,6 +43,29 @@ MAX_MANIFEST_BYTES = 7100
 MAX_ACTIVE_SELECTION_BYTES = 7105
 MAX_ACTIVE_PACKS = 8
 MAX_GENERATION = 0xFFFFFFFF
+INSTALL_LOCK_NAME = ".install.lock"
+STYLE_POLICIES: dict[str, dict[str, str]] = {
+    "osm-bright": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+        "source": "Oxed's Map Tile Downloader (OSM Bright)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause",
+    },
+    "dark-matter": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "source": "Oxed's Map Tile Downloader (Dark Matter)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+    },
+    "positron": {
+        "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors; style (c) CARTO",
+        "source": "Oxed's Map Tile Downloader (Positron)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (CARTO CC-BY-3.0)",
+    },
+    "toner": {
+        "attribution": "(c) MapTiler (c) OpenStreetMap contributors",
+        "source": "Oxed's Map Tile Downloader (Toner)",
+        "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause (Stamen ISC)",
+    },
+}
 _DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC
 _FILE_FLAGS = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK | os.O_CLOEXEC
 
@@ -842,6 +866,30 @@ def decode_active_selection(data: bytes) -> dict[str, object]:
             "attribution": attribution, "pack_ids": pack_ids, "row_spans": row_spans}
 
 
+def acquire_install_lock(pyxis_fd: int) -> int:
+    """Acquire the persistent CLI-to-CLI install lock.
+
+    The lock file lives inside the mounted pyxis-map directory and is never
+    unlinked: it exists only to carry an fcntl.flock that serializes CLI
+    processes. Returns the lock descriptor; closing it releases the lock.
+    """
+    flags = os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW | os.O_CLOEXEC
+    try:
+        lock_fd = os.open(INSTALL_LOCK_NAME, flags, 0o644, dir_fd=pyxis_fd)
+    except OSError as exc:
+        raise PackError(f"cannot open CLI install lock: {exc}") from exc
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        os.close(lock_fd)
+        raise PackError("another CLI map install is running; retry after it finishes") from exc
+    return lock_fd
+
+
+def release_install_lock(lock_fd: int) -> None:
+    os.close(lock_fd)
+
+
 def _open_verified_tile(source_fd: int, tile: Tile) -> int:
     zoom_fd, zoom_identity = _open_child_directory(source_fd, str(tile.zoom), str(tile.path.parent.parent))
     try:
@@ -929,11 +977,15 @@ def _validate_pack_fd(pack_fd: int, label: Path, max_bytes: int) -> dict[str, ob
         os.close(tiles_fd)
     if len(tiles) != tile_count:
         raise PackError("emitted tile tree does not match manifest")
-    if parsed["format_version"] == FORMAT_VERSION:
+    format_version = parsed["format_version"]
+    if format_version == FORMAT_VERSION:
         expected_extents = cast(list[ZoomExtent], parsed["extents"])
         extents = calculate_extents(tiles, {item.zoom for item in expected_extents if len(item.intervals) == 2})
         if extents != expected_extents:
             raise PackError("emitted tile tree does not match manifest")
+    elif format_version == INDEXLESS_FORMAT_VERSION:
+        if tiles[0].zoom != parsed["min_zoom"] or tiles[-1].zoom != parsed["max_zoom"]:
+            raise PackError("emitted tile tree does not match indexless manifest")
     else:
         expected_spans = cast(list[RowSpan], parsed["row_spans"])
         if calculate_row_spans(tiles) != expected_spans:
@@ -1013,10 +1065,19 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
                    attribution: str, source: str, license: str,
                    max_tiles: int = DEFAULT_MAX_TILES, max_bytes: int = DEFAULT_MAX_BYTES,
                    antimeridian_zooms: set[int] | None = None,
-                   sparse: bool = False) -> Path:
+                   sparse: bool = False,
+                   style: str | None = None) -> Path:
     if not sys.platform.startswith("linux"):
         raise PackError("secure importer supports Linux hosts only")
+    if style is not None and style not in STYLE_POLICIES:
+        raise PackError(f"unsupported map style: {style}")
     _validate_metadata(pack_id, name, attribution, source, license)
+    if style is not None:
+        policy = STYLE_POLICIES[style]
+        for field, expected in policy.items():
+            if locals()[field] != expected:
+                raise PackError(
+                    f"--style {style} requires {field} exactly matching the firmware style policy")
     antimeridian_zooms = set() if antimeridian_zooms is None else set(antimeridian_zooms)
     if any(zoom < 0 or zoom > MAX_ZOOM for zoom in antimeridian_zooms):
         raise PackError("antimeridian zoom is out of range")
@@ -1029,18 +1090,24 @@ def build_map_pack(source_directory: Path, output_root: Path, *, pack_id: str, n
     committed = False
     try:
         tiles = _discover_tiles_fd(source_fd, source_directory, max_tiles, max_bytes)
-        try:
-            extents = calculate_extents(tiles, antimeridian_zooms)
-        except PackError as exc:
-            if not sparse or antimeridian_zooms or not str(exc).startswith("incomplete rectangle"):
-                raise
-            row_spans = calculate_row_spans(tiles)
-            manifest = serialize_sparse_manifest(pack_id=pack_id, name=name, attribution=attribution,
-                                                 source=source, license=license,
-                                                 row_spans=row_spans, tile_count=len(tiles))
+        if style is not None:
+            manifest = serialize_indexless_manifest(
+                pack_id=pack_id, name=name, attribution=attribution, source=source,
+                license=license, minimum_zoom=tiles[0].zoom, maximum_zoom=tiles[-1].zoom,
+                tile_count=len(tiles))
         else:
-            manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
-                                          license=license, extents=extents, tile_count=len(tiles))
+            try:
+                extents = calculate_extents(tiles, antimeridian_zooms)
+            except PackError as exc:
+                if not sparse or antimeridian_zooms or not str(exc).startswith("incomplete rectangle"):
+                    raise
+                row_spans = calculate_row_spans(tiles)
+                manifest = serialize_sparse_manifest(pack_id=pack_id, name=name, attribution=attribution,
+                                                     source=source, license=license,
+                                                     row_spans=row_spans, tile_count=len(tiles))
+            else:
+                manifest = serialize_manifest(pack_id=pack_id, name=name, attribution=attribution, source=source,
+                                              license=license, extents=extents, tile_count=len(tiles))
         output_fd = _open_path(output_root, create=True)
         pyxis_fd, pyxis_identity = _mkdir_open(output_fd, "pyxis-map")
         packs_fd, packs_identity = _mkdir_open(pyxis_fd, "packs")
@@ -1118,6 +1185,8 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--antimeridian-zoom", action="append", type=int, default=[])
     parser.add_argument("--sparse", action="store_true",
                         help="explicitly admit sparse state/polygon coverage and emit PMPK v2")
+    parser.add_argument("--style", choices=sorted(STYLE_POLICIES),
+                        help="firmware map style; metadata must exactly match the style policy and PMPK v3 is emitted")
     return parser
 
 
@@ -1130,7 +1199,7 @@ def main(argv: list[str] | None = None) -> int:
                                 license=arguments.license, max_tiles=arguments.max_tiles,
                                 max_bytes=arguments.max_bytes,
                                 antimeridian_zooms=set(arguments.antimeridian_zoom),
-                                sparse=arguments.sparse)
+                                sparse=arguments.sparse, style=arguments.style)
     except PublishedDurabilityError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 3


### PR DESCRIPTION
## Summary

Adds **PMPK v3 (indexless manifest) generation** and **PMAS v3 (complete active-map-set) activation** to the Linux CLI (`tools/maps/build_map_pack.py`), with the same strictness the firmware expects — and **no marker/TTL/lease/heartbeat protocol**.

Base `origin/main` (`27a207a`) already parses PMPK v3 in firmware; this PR makes the CLI a safe, cross-conformant writer.

### What it does
- **`--style`** (`osm-bright|dark-matter|positron|toner`): forces metadata to exactly match the firmware `STYLE_POLICIES` table and emits an indexless **PMPK v3** manifest. No activation.
- **`--activate`** (requires `--style`): atomically publishes the pack and writes the style PMAS + one active slot, in this exact order:
  1. validate input
  2. acquire persistent CLI install lock (`fcntl.flock`, `LOCK_EX|LOCK_NB`, never unlinked)
  3. inspect slots/style + derive plan (`plan_activation`, pure/IO-free)
  4. **preflight: validate every pack named by the candidate** (pack_id, attribution, source/license vs policy) — a refusal changes no bytes
  5. stage + publish the new pack (atomic per-file replace + read-back)
  6. revalidate ALL candidate packs
  7. write + read-back the **style PMAS first**
  8. write + read-back **one active slot second**
  9. release the lock

### Safety invariants (each enforced and test-proven)
1. Full preflight of every candidate pack before any mutation.
2. Failed preflight changes no style/slot bytes.
3. Failed style write changes no active slot.
4. Failed slot write leaves at least one prior valid active slot (last-valid fallback).
5. Target slot = missing/invalid/lower-generation; never overwrites the sole known-valid fallback unless the candidate fully validated.
6. Every published file read back byte-for-byte **and** re-decoded semantically before success.
7. CLI and firmware accept the same PMPK/PMAS vectors (frozen in `tests/fixtures/map_pack_v3_vectors.json`).

### Exit codes
- `0` success
- `2` error (no `--style` with `--activate`, lock contention, plan/preflight/metadata-mismatch)
- `3` durability (`PublishedDurabilityError` on the pack-build path)
- `4` pack publication succeeded but activation failed (retry allowed, pack preserved)

### Scope
Exactly 5 files, host-side only — **no firmware/`lib/` changes, no browser code, no pack deletion/repair**:
```
tools/maps/build_map_pack.py
tests/tools/test_build_map_pack.py
tests/fixtures/map_pack_v3_vectors.json
docs/offline-map-packs.md
tests/build_scripts/test_offline_map_pack_cli_contract.py
```

## Verification
- **PR A tests:** `127 passed` (126 tool + docs contract, incl. frozen-vector round-trip and the last-valid-fallback reproducer).
- **Full `tests/` suite:** `381 passed` (non-green items are pre-existing env/CI gaps in files this PR never touches: `pycodec2` in `tests/interop`, scipy/soundfile/sounddevice in the auto-collected `tools/voice_test`, NomadNet real-peer env vars, CI PlatformIO).
- **Firmware builds:** `pio run -e tdeck` SUCCESS (Flash 92.3%) and `-e tdeck-release` SUCCESS (Flash 92.1%). No firmware changes in the diff.
- **Independent exact-head review:** APPROVED — spec fully met, all 7 safety invariants enforced and test-proven; 3 minor notes addressed (unguarded legacy-PMAS decode now raises a clean `PackError` + regression test; doc line on CLI-vs-firmware v3 strictness; cosmetic `locals()` cleanup).
- **Scope audit:** `git diff --check` clean; no forbidden marker/TTL/lease/heartbeat constructs; no local paths/IPs/hostnames/ports/credentials.

## Not yet done (by design)
- **Physical / real-peer acceptance** is out of scope for this host-side PR and has not been claimed.
- **PR B (browser parity)** is blocked on this PR merging, per the plan.
