### PR TITLE
feat: browser-side safe map-pack v3 installer (web flasher parity)

### DIFF
--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -424,7 +424,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
-        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js?v=map-style-picker-2';
+        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js?v=map-pack-v3';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -340,6 +340,18 @@
                 <li>Click <strong>Install and Enable</strong>, then choose the mounted SD-card root.</li>
                 <li>Safely eject the SD card, return it to the T-Deck, power it on, and open Maps.</li>
             </ol>
+            <div class="warning map-safety-contract">
+                <strong>Before installing:</strong> close all other Pyxis flasher tabs or
+                windows, and do not run the command-line installer against this same
+                mounted card at the same time. The cross-tab lock coordinates only
+                tabs of this flasher in the same browser profile; it cannot see the
+                CLI or other browsers.
+                <br><br>
+                <strong>After installing:</strong> wait for the verified completion
+                message, then safely eject the card. If activation fails after a pack
+                was published, retry with the exact same ZIP and the same name and
+                pack ID.
+            </div>
             <p class="map-note">Existing unrelated SD-card files are preserved. Map tiles are validated locally and are never uploaded.</p>
             <div class="map-installer-grid">
                 <div class="map-field">

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -577,8 +577,20 @@
                         license: style.license,
                     },
                     onProgress(progress) {
-                        if (progress.phase === 'write' && (progress.completed % 25 === 0 || progress.completed === progress.total)) {
-                            setMapStatus(`Writing tiles: ${progress.completed}/${progress.total}`);
+                        if (progress.phase === 'validate') {
+                            if (progress.completed === 1 || progress.completed % 200 === 0 || progress.completed === progress.total) {
+                                setMapStatus(`Validating ZIP: ${progress.completed}/${progress.total} entries`);
+                            }
+                        } else if (progress.phase === 'checking') {
+                            setMapStatus('Checking existing map packs on the card…');
+                        } else if (progress.phase === 'write') {
+                            if (progress.completed === 1 || progress.completed % 25 === 0 || progress.completed === progress.total) {
+                                setMapStatus(`Writing tiles: ${progress.completed}/${progress.total}`);
+                            }
+                        } else if (progress.phase === 'manifest') {
+                            setMapStatus('Publishing pack manifest…');
+                        } else if (progress.phase === 'activating') {
+                            setMapStatus('Enabling map set (writing and verifying active slots)…');
                         }
                     },
                 });

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -424,7 +424,7 @@
 
     <script type="module">
         import { ESPLoader, Transport } from './js/esptool.js';
-        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js?v=map-pack-v3';
+        import { inspectMuiZip, installMuiZip, resolveMuiStyleProfile, suggestMapIdentity } from './js/map-installer.js?v=map-pack-v3-progress';
 
         const flashBtn = document.getElementById('flash-btn');
         const eraseCheckbox = document.getElementById('erase-checkbox');

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -39,7 +39,9 @@ async function withInstallLock(rootDirectory, operation) {
     if (typeof rootDirectory?.name !== 'string' || rootDirectory.name.length === 0) {
       fail('Selected SD root has no stable directory name');
     }
-    // Web Locks are shared by every same-origin installer tab. Distinct
+    // Web Locks serialize only tabs that share this flasher origin. They do
+    // not coordinate with the CLI, another origin, or another browser
+    // profile; do not extend this comment to claim otherwise. Distinct
     // FileSystemDirectoryHandle objects for the same root have the same name;
     // equal names on unrelated roots merely serialize harmlessly.
     return lockManager.request(

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -638,8 +638,7 @@ async function verifyNamedDirectory(parent,name,expected,allowedEntries){
   if(entries.length!==allowed.length||entries.some((entry,index)=>entry!==allowed[index]))fail(`SD destination was created concurrently or is not empty: ${name}`);
 }
 async function writeVerified(parent,name,bytes){ const handle=await parent.getFileHandle(name,{create:true}); const writable=await handle.createWritable({keepExistingData:false}); try{await writable.write(bytes);await writable.close();}catch(error){try{await writable.abort();}catch{} throw error;} const actual=new Uint8Array(await (await handle.getFile()).arrayBuffer()); if(actual.length!==bytes.length) fail(`SD read-back mismatch: ${name}`); for(let index=0;index<bytes.length;index++) if(actual[index]!==bytes[index]) fail(`SD read-back mismatch: ${name}`); return handle; }
-async function readSelection(pyxis,name){ let handle; try{handle=await pyxis.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;} const bytes=new Uint8Array(await(await handle.getFile()).arrayBuffer()); try{return decodeActiveSelection(bytes);}catch{return null;} }
-async function readStyleSelection(mapSets,name){let handle;try{handle=await mapSets.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;}const bytes=new Uint8Array(await(await handle.getFile()).arrayBuffer());try{return decodeActiveSelection(bytes);}catch{fail(`Installed style record is invalid: ${name}`);}}
+async function readRawSelection(parent,name){ let handle; try{handle=await parent.getFileHandle(name);}catch(error){if(error?.name==='NotFoundError')return null;throw error;} return new Uint8Array(await(await handle.getFile()).arrayBuffer()); }
 async function fileBytes(parent,name){const handle=await parent.getFileHandle(name);return new Uint8Array(await(await handle.getFile()).arrayBuffer());}
 function equalBytes(left,right){if(left.length!==right.length)return false;for(let index=0;index<left.length;index++)if(left[index]!==right[index])return false;return true;}
 async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
@@ -659,6 +658,55 @@ async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
 }
 
 const MAX_ACTIVE_PACKS = 8;
+
+// Bounded manifest size, matching the CLI's MAX_MANIFEST_BYTES.
+const MAX_MANIFEST_BYTES = 7100;
+
+async function readManifestAt(parent, packId) {
+  let pack;
+  try {
+    pack = await parent.getDirectoryHandle(packId);
+  } catch (error) {
+    if (error?.name === 'NotFoundError') throw new MapInstallerError(`missing inherited pack manifest: packs/${packId}/manifest.pmp`);
+    throw new MapInstallerError(`invalid inherited pack directory: packs/${packId}: ${error.message}`);
+  }
+  let handle;
+  try {
+    handle = await pack.getFileHandle('manifest.pmp');
+  } catch (error) {
+    if (error?.name === 'NotFoundError') throw new MapInstallerError(`missing inherited pack manifest: packs/${packId}/manifest.pmp`);
+    throw error;
+  }
+  const file = await handle.getFile();
+  if (file.size > MAX_MANIFEST_BYTES) fail(`inherited pack manifest exceeds the bounded limit: ${packId}`);
+  return new Uint8Array(await file.arrayBuffer());
+}
+
+export async function validateCandidatePacks(pyxis, mapSetId, attribution, packIds) {
+  if (!Array.isArray(packIds) || packIds.length === 0) fail('map set composition is empty');
+  const profile = getMuiStyleProfile(mapSetId);
+  if (attribution !== profile.attribution) fail('active set attribution does not match the firmware style policy');
+  let packs;
+  try {
+    packs = await pyxis.getDirectoryHandle('packs');
+  } catch (error) {
+    if (error?.name === 'NotFoundError') throw new MapInstallerError(`missing inherited pack manifest: packs/${packIds[0]}/manifest.pmp`);
+    throw error;
+  }
+  for (const packId of packIds) {
+    const manifest = await readManifestAt(packs, packId);
+    const parsed = parseSparseManifest(manifest);
+    if (parsed.rowSpans.length !== 0 || parsed.tileCount === undefined) {
+      // v2 manifests carry row spans; v3 is indexless (rowSpans empty).
+      fail(`pack ${packId} manifest is not PMPK v3; indexless activation requires v3`);
+    }
+    if (parsed.packId !== packId) fail(`pack ${packId} manifest declares a different pack ID`);
+    if (parsed.attribution !== attribution) fail(`pack ${packId} attribution does not match the active set`);
+    if (parsed.source !== profile.source || parsed.license !== profile.license) {
+      fail(`pack ${packId} source/license does not match the ${mapSetId} style policy`);
+    }
+  }
+}
 
 function slotState(raw) {
   if (raw === null || raw === undefined) return {state: 'missing', values: null};
@@ -747,33 +795,60 @@ export function planActivation({slot0, slot1, styleRecord, newPackId, styleId, a
   return {styleName: styleId, targetSlot, generation, packIds: composition, record};
 }
 
-async function prepareActiveMapSet(pyxis,metadata){
-  const slots=await Promise.all([readSelection(pyxis,'active-pack.0'),readSelection(pyxis,'active-pack.1')]);
-  if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');
-  const valid=slots.filter(Boolean);const highest=Math.max(0,...valid.map(slot=>slot.generation));if(highest===0xffffffff)fail('Active selection generation is exhausted');
-  const current=valid.sort((left,right)=>right.generation-left.generation)[0];
-  const mapSets=await getDirectory(pyxis,'map-sets');const styleName=`${metadata.mapSetId}.pmas`;
-  const installed=await readStyleSelection(mapSets,styleName);
-  if(installed&&(![2,3].includes(installed.version)||installed.mapSetId!==metadata.mapSetId||installed.attribution!==metadata.attribution))fail('Installed style record does not match selected map set');
-  const composition=installed||([2,3].includes(current?.version)&&current.mapSetId===metadata.mapSetId?current:null);
-  let packs=[];
-  if(composition){
-    if(composition.attribution!==metadata.attribution)fail('Installed map set attribution does not match');
-    packs=composition.packs.filter(pack=>pack.packId!==metadata.packId);
-  }
-  packs.unshift({packId:metadata.packId});
-  const target=!slots[0]?'active-pack.0':!slots[1]?'active-pack.1':slots[0].generation<=slots[1].generation?'active-pack.0':'active-pack.1';
-  const record=encodeActiveMapSet({generation:highest+1,mapSetId:metadata.mapSetId,attribution:metadata.attribution,packs});
-  return {target,record,packs,mapSets,styleName};
+// Preflight before any pack publication: snapshot the raw slots and style
+// record once, derive the plan, and validate every inherited pack. The new
+// pack itself is not (yet) on the card, so it is excluded here and validated
+// again after publication. Mirrors the CLI's A10 preflight step. Reads only:
+// no directory is created on the card by this path.
+async function preflightInheritedPacks(pyxis,metadata){
+  const styleName=`${metadata.mapSetId}.pmas`;
+  const [slot0,slot1,styleRecord]=await Promise.all([
+    readRawSelection(pyxis,'active-pack.0'),
+    readRawSelection(pyxis,'active-pack.1'),
+    (async () => {
+      let mapSets;
+      try { mapSets = await pyxis.getDirectoryHandle('map-sets'); }
+      catch (error) { if (error?.name === 'NotFoundError') return null; throw error; }
+      return readRawSelection(mapSets,styleName);
+    })(),
+  ]);
+  const plan=planActivation({slot0,slot1,styleRecord,newPackId:metadata.packId,styleId:metadata.mapSetId,attribution:metadata.attribution});
+  const inherited=plan.packIds.filter(id=>id!==metadata.packId);
+  if(inherited.length)await validateCandidatePacks(pyxis,metadata.mapSetId,metadata.attribution,inherited);
+  return plan;
 }
 
 async function activateMapSet(pyxis,metadata){
-  const {target,record,mapSets,styleName}=await prepareActiveMapSet(pyxis,metadata);
-  await writeVerified(mapSets,styleName,record);const installed=decodeActiveSelection(await fileBytes(mapSets,styleName));
-  if(installed.version!==3||installed.mapSetId!==metadata.mapSetId||installed.packs[0].packId!==metadata.packId)fail('Style map-set verification failed');
-  await writeVerified(pyxis,target,record);const selected=decodeActiveSelection(await fileBytes(pyxis,target));
-  if(selected.version!==3||selected.mapSetId!==metadata.mapSetId||selected.packs[0].packId!==metadata.packId)fail('Active map-set verification failed');
-  return {selectionFile:target,styleFile:styleName,enabledPacks:selected.packs.map(pack=>pack.packId)};
+  // Capture the raw slots and style record exactly once, then derive the
+  // plan from that same snapshot. No read/decode followed by a separate
+  // snapshot of the same record.
+  const mapSets=await getDirectory(pyxis,'map-sets');
+  const styleName=`${metadata.mapSetId}.pmas`;
+  const [slot0,slot1,styleRecord]=await Promise.all([
+    readRawSelection(pyxis,'active-pack.0'),
+    readRawSelection(pyxis,'active-pack.1'),
+    readRawSelection(mapSets,styleName),
+  ]);
+  const plan=planActivation({slot0,slot1,styleRecord,newPackId:metadata.packId,styleId:metadata.mapSetId,attribution:metadata.attribution});
+  // Validate every candidate pack's manifest before any record mutation.
+  // The new pack's own manifest is verified by this same call; a failed
+  // preflight changes no style or active-slot bytes.
+  await validateCandidatePacks(pyxis,metadata.mapSetId,metadata.attribution,plan.packIds);
+  await writeVerified(mapSets,styleName,plan.record);
+  const styleReadBack=decodeActiveSelection(await fileBytes(mapSets,styleName));
+  if(styleReadBack.version!==3||styleReadBack.generation!==plan.generation||styleReadBack.mapSetId!==plan.styleName||
+     styleReadBack.attribution!==metadata.attribution||
+     JSON.stringify(styleReadBack.packs.map(pack=>pack.packId))!==JSON.stringify(plan.packIds)){
+    fail('Style map-set read-back is not semantically identical');
+  }
+  await writeVerified(pyxis,plan.targetSlot,plan.record);
+  const slotReadBack=decodeActiveSelection(await fileBytes(pyxis,plan.targetSlot));
+  if(slotReadBack.version!==3||slotReadBack.generation!==plan.generation||slotReadBack.mapSetId!==plan.styleName||
+     slotReadBack.attribution!==metadata.attribution||
+     JSON.stringify(slotReadBack.packs.map(pack=>pack.packId))!==JSON.stringify(plan.packIds)){
+    fail('Active map-set read-back is not semantically identical');
+  }
+  return {selectionFile:plan.targetSlot,styleFile:styleName,enabledPacks:[...plan.packIds]};
 }
 
 async function verifyExactDirectory(directory, expected, label){
@@ -802,7 +877,11 @@ async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()
   const report=await inspectMuiZip(archive,{onProgress});
   if(report.styleId&&report.styleId!==metadata.mapSetId)fail('MUI ZIP style does not match the selected map set');
   const manifest=serializeIndexlessManifest(metadata,report.minZoom,report.maxZoom,report.tileCount);const pyxis=await getDirectory(rootDirectory,'pyxis-map');
-  await prepareActiveMapSet(pyxis,metadata);const packs=await getDirectory(pyxis,'packs');
+  // Refuse a broken inherited composition before any pack publication:
+  // a failed preflight creates no pack directory and changes no style or
+  // active-slot bytes.
+  await preflightInheritedPacks(pyxis,metadata);
+  const packs=await getDirectory(pyxis,'packs');
   let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
   if(existing){
     let empty=true;for await(const _entry of existing.entries()){empty=false;break;}

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -685,6 +685,7 @@ async function readManifestAt(parent, packId) {
 }
 
 export async function validateCandidatePacks(pyxis, mapSetId, attribution, packIds) {
+  // Exported for the contract suite; also the runtime API for the install flow.
   if (!Array.isArray(packIds) || packIds.length === 0) fail('map set composition is empty');
   const profile = getMuiStyleProfile(mapSetId);
   if (attribution !== profile.attribution) fail('active set attribution does not match the firmware style policy');
@@ -731,6 +732,7 @@ function slotFields(values) {
 }
 
 export function planActivation({slot0, slot1, styleRecord, newPackId, styleId, attribution}) {
+  // Exported for the contract suite; pure planning core of the install flow.
   const profile = getMuiStyleProfile(styleId);
   if (attribution !== profile.attribution) {
     fail('attribution must exactly match the firmware style policy');
@@ -738,14 +740,15 @@ export function planActivation({slot0, slot1, styleRecord, newPackId, styleId, a
   if (!/^[a-z0-9_-]{1,31}$/.test(newPackId)) fail('Pack ID must match [a-z0-9_-]{1,31}');
   const states = [slotState(slot0), slotState(slot1)];
   const present = states
-    .map((state, index) => (state.state === 'present' ? {index, ...slotFields(state.values)} : null))
+    .map((state, index) => (state.state === 'present' ? {index, values: state.values, ...slotFields(state.values)} : null))
     .filter(Boolean);
   if (present.length === 2) {
     const [first, second] = present;
     const sameGeneration = first.generation === second.generation;
-    const unequal = first.mapSetId !== second.mapSetId ||
-      first.generation !== second.generation ||
-      JSON.stringify(first.packIds) !== JSON.stringify(second.packIds);
+    // Mirror the CLI exactly: compare the FULL decoded records (version,
+    // attribution, pack list, spans) so a same-generation v1/v3 pair with
+    // colliding pack IDs is flagged, not just the normalized fields.
+    const unequal = JSON.stringify(first.values) !== JSON.stringify(second.values);
     if (sameGeneration && unequal) {
       fail('active slots disagree at equal generation; restore a known-good card state first');
     }

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -805,7 +805,8 @@ export function planActivation({slot0, slot1, styleRecord, newPackId, styleId, a
 // pack itself is not (yet) on the card, so it is excluded here and validated
 // again after publication. Mirrors the CLI's A10 preflight step. Reads only:
 // no directory is created on the card by this path.
-async function preflightInheritedPacks(pyxis,metadata){
+async function preflightInheritedPacks(pyxis,metadata,onProgress){
+  onProgress({phase:'checking'});
   const styleName=`${metadata.mapSetId}.pmas`;
   const [slot0,slot1,styleRecord]=await Promise.all([
     readRawSelection(pyxis,'active-pack.0'),
@@ -823,7 +824,8 @@ async function preflightInheritedPacks(pyxis,metadata){
   return plan;
 }
 
-async function activateMapSet(pyxis,metadata){
+async function activateMapSet(pyxis,metadata,onProgress){
+  onProgress({phase:'activating'});
   // Capture the raw slots and style record exactly once, then derive the
   // plan from that same snapshot. No read/decode followed by a separate
   // snapshot of the same record.
@@ -885,21 +887,21 @@ async function installMuiZipLocked({archive,rootDirectory,metadata,onProgress=()
   // Refuse a broken inherited composition before any pack publication:
   // a failed preflight creates no pack directory and changes no style or
   // active-slot bytes.
-  await preflightInheritedPacks(pyxis,metadata);
+  await preflightInheritedPacks(pyxis,metadata,onProgress);
   const packs=await getDirectory(pyxis,'packs');
   let existing=null;try{existing=await packs.getDirectoryHandle(metadata.packId);}catch(error){if(error?.name!=='NotFoundError')throw error;}
   if(existing){
     let empty=true;for await(const _entry of existing.entries()){empty=false;break;}
-    if(!empty){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
+    if(!empty){await verifyExistingPack(existing,archive,report,manifest);try{const active=await activateMapSet(pyxis,metadata,onProgress);return{...report,manifestBytes:manifest.length,resumed:true,...active};}catch(error){throw new Error(`Map pack is installed and verified, but activation failed: ${error.message}`);}}
   }
   const pack=existing||await getDirectory(packs,metadata.packId);await verifyNamedDirectory(packs,metadata.packId,pack,[]);let published=false;const receipt=new Uint8Array(16);crypto.getRandomValues(receipt);const receiptName=`.pyxis-install-owner-${[...receipt].map(byte=>byte.toString(16).padStart(2,'0')).join('')}`;
   try{
     await writeVerified(pack,receiptName,receipt);await verifyNamedDirectory(packs,metadata.packId,pack,[receiptName]);
     const tiles=await getDirectory(pack,'tiles');
     for(let index=0;index<report.entries.length;index++){const entry=report.entries[index];const zoom=await getDirectory(tiles,String(entry.zoom));const x=await getDirectory(zoom,String(entry.x));const bytes=await blobBytes(archive,entry.dataOffset,entry.dataOffset+entry.size);if(crc32(bytes)!==entry.checksum)fail(`ZIP changed during installation: ${entry.name}`);await validatePng(bytes,entry.name);await writeVerified(x,`${entry.y}.png`,bytes);onProgress({phase:'write',completed:index+1,total:report.tileCount});}
-    await writeVerified(pack,'manifest.pmp',manifest);parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
+    await writeVerified(pack,'manifest.pmp',manifest);onProgress({phase:'manifest'});parseSparseManifest(await fileBytes(pack,'manifest.pmp'));published=true;
     try{await pack.removeEntry(receiptName);}catch(error){throw new Error(`Map pack is installed and verified, but its ownership receipt could not be removed: ${error.message}`);}
-    try{const active=await activateMapSet(pyxis,metadata);return{...report,manifestBytes:manifest.length,resumed:false,...active};}
+    try{const active=await activateMapSet(pyxis,metadata,onProgress);return{...report,manifestBytes:manifest.length,resumed:false,...active};}
     catch(error){throw new Error(`Map pack is installed and verified, but activation failed; retry with the same ZIP and pack ID: ${error.message}`);}
   }catch(error){
     if(!published&&!(await removeOwnedPack(packs,metadata.packId,pack,receiptName,receipt,report.entries))){

--- a/docs/flasher/js/map-installer.js
+++ b/docs/flasher/js/map-installer.js
@@ -658,6 +658,95 @@ async function removeOwnedPack(packs,packId,pack,receiptName,receipt,entries){
   }catch{return false;}
 }
 
+const MAX_ACTIVE_PACKS = 8;
+
+function slotState(raw) {
+  if (raw === null || raw === undefined) return {state: 'missing', values: null};
+  try {
+    return {state: 'present', values: decodeActiveSelection(raw)};
+  } catch {
+    return {state: 'invalid', values: null};
+  }
+}
+
+// Normalize a decoded slot record to the fields planning needs. Legacy v1
+// records carry a single string that is both the map-set ID and the one pack
+// ID, matching the CLI's normalized v1 decode.
+function slotFields(values) {
+  return {
+    generation: values.generation,
+    mapSetId: values.mapSetId ?? values.packId,
+    packIds: values.packs ? values.packs.map(pack => pack.packId) : [values.packId],
+  };
+}
+
+export function planActivation({slot0, slot1, styleRecord, newPackId, styleId, attribution}) {
+  const profile = getMuiStyleProfile(styleId);
+  if (attribution !== profile.attribution) {
+    fail('attribution must exactly match the firmware style policy');
+  }
+  if (!/^[a-z0-9_-]{1,31}$/.test(newPackId)) fail('Pack ID must match [a-z0-9_-]{1,31}');
+  const states = [slotState(slot0), slotState(slot1)];
+  const present = states
+    .map((state, index) => (state.state === 'present' ? {index, ...slotFields(state.values)} : null))
+    .filter(Boolean);
+  if (present.length === 2) {
+    const [first, second] = present;
+    const sameGeneration = first.generation === second.generation;
+    const unequal = first.mapSetId !== second.mapSetId ||
+      first.generation !== second.generation ||
+      JSON.stringify(first.packIds) !== JSON.stringify(second.packIds);
+    if (sameGeneration && unequal) {
+      fail('active slots disagree at equal generation; restore a known-good card state first');
+    }
+  }
+  let styleValues = null;
+  if (styleRecord !== null && styleRecord !== undefined) {
+    try {
+      const decoded = decodeActiveSelection(styleRecord);
+      const fields = slotFields(decoded);
+      if (decoded.version !== 1 && fields.mapSetId === styleId &&
+          decoded.attribution === profile.attribution) {
+        styleValues = fields;
+      }
+    } catch {
+      // A corrupt style snapshot is ignored, exactly like the CLI.
+    }
+  }
+  let maxGeneration = present.reduce((maximum, slot) => Math.max(maximum, slot.generation), 0);
+  if (styleValues) maxGeneration = Math.max(maxGeneration, styleValues.generation);
+  const generation = maxGeneration + 1;
+  if (generation > 0xffffffff) fail('active selection generation is exhausted');
+  let composition;
+  if (styleValues) {
+    composition = [...styleValues.packIds];
+  } else {
+    composition = [];
+    for (const slot of [...present].sort((left, right) => right.generation - left.generation)) {
+      if (slot.mapSetId === styleId) { composition = [...slot.packIds]; break; }
+    }
+  }
+  if (composition.includes(newPackId)) composition.splice(composition.indexOf(newPackId), 1);
+  composition.unshift(newPackId);
+  if (composition.length > MAX_ACTIVE_PACKS) fail('active selection exceeds the 8-pack limit');
+  if (new Set(composition).size !== composition.length) fail('duplicate pack ID in candidate map set');
+  let targetSlot;
+  const missing = states.findIndex(state => state.state !== 'present');
+  if (missing !== -1) {
+    targetSlot = `active-pack.${missing}`;
+  } else {
+    const lower = [...present].sort((left, right) => left.generation - right.generation || left.index - right.index)[0];
+    targetSlot = `active-pack.${lower.index}`;
+  }
+  const record = encodeActiveMapSet({
+    generation,
+    mapSetId: styleId,
+    attribution,
+    packs: composition.map(packId => ({packId})),
+  });
+  return {styleName: styleId, targetSlot, generation, packIds: composition, record};
+}
+
 async function prepareActiveMapSet(pyxis,metadata){
   const slots=await Promise.all([readSelection(pyxis,'active-pack.0'),readSelection(pyxis,'active-pack.1')]);
   if(slots[0]&&slots[1]&&slots[0].generation===slots[1].generation&&JSON.stringify(slots[0])!==JSON.stringify(slots[1]))fail('Conflicting active map-set records');

--- a/docs/offline-map-packs.md
+++ b/docs/offline-map-packs.md
@@ -10,7 +10,8 @@ Open the Pyxis web flasher in current Chrome or Edge and use **Install Offline M
 2. Turn the T-Deck off, remove its SD card, and mount the card on the computer.
 3. Choose the ZIP, enter a map name and pack ID, and wait for local validation.
 4. Click **Install and Enable**, then choose the SD-card root.
-5. After the verified completion message, safely eject the card and return it to the T-Deck.
+5. Wait for the verified completion message, then safely eject the card and
+   return it to the T-Deck.
 
 The browser accepts stored ZIP entries rooted at either `<z>/<x>/<y>.png` or
 `maps/<style>/<z>/<x>/<y>.png`. It rejects mixed styles, traversal, duplicate
@@ -18,6 +19,14 @@ paths or tile keys, symlinks, encrypted or unsupported compression, malformed
 ZIP records, unsafe PNGs, quota violations, and noncanonical XYZ paths. Tiles
 are validated and read back one at a time; the complete archive is not loaded
 into JavaScript memory.
+
+**Single writer.** The browser's cross-tab lock serializes only tabs of the
+same flasher origin in the same browser profile. Close all other flasher tabs
+and windows before installing, and do not run the CLI and the browser
+installer against the same mounted card at the same time. Wait for the
+verified completion message, then safely eject the card. A
+published-but-not-activated pack is never deleted: retry activation with the
+exact same ZIP, map set, name, and pack ID.
 
 Installation refuses to overwrite an existing pack. A verified pack from an
 earlier activation failure can be reselected with the exact same ZIP and

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -27,7 +27,7 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert "showDirectoryPicker" in source
     assert "navigator.locks?.request" in source
     assert "cross-tab locking required for safe map installation" in source
-    assert "./js/map-installer.js?v=map-style-picker-2" in source
+    assert "./js/map-installer.js?v=map-pack-v3" in source
     assert "Oxed's Map Tile Downloader" in source
     assert "OpenStreetMap contributors" in source
     assert "suggestMapIdentity" in source

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -76,3 +76,18 @@ def test_map_installer_javascript_behavior() -> None:
         check=False,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_map_installer_uses_no_invented_filesystem_api_options() -> None:
+    # The browser File System Access API has no `exclusive` getFileHandle
+    # option and no FileExistsError; the only legitimate `exclusive` is the
+    # Web Locks request mode. Production JS and the test mock must stay
+    # within that real contract.
+    installer = INSTALLER.read_text(encoding="utf-8")
+    test_source = NODE_TEST.read_text(encoding="utf-8")
+    for source in (installer, test_source):
+        assert "FileExistsError" not in source
+    # In the installer the only `exclusive` occurrence may be the Web Locks
+    # request options object; the test source may only pass it as an ignored
+    # unknown option (B1 harness test), never as an exception trigger.
+    assert 'exclusive' not in installer.replace("{mode:'exclusive'}", "")

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -91,3 +91,17 @@ def test_map_installer_uses_no_invented_filesystem_api_options() -> None:
     # request options object; the test source may only pass it as an ignored
     # unknown option (B1 harness test), never as an exception trigger.
     assert 'exclusive' not in installer.replace("{mode:'exclusive'}", "")
+    # Web Locks only serialize same-origin tabs. The deterministic lock name,
+    # the fail-closed message for browsers without the primitives, and the
+    # scope-limiting comment must all survive refactors, and no comment or
+    # error text may claim coordination with the CLI, other origins, or
+    # other browser profiles.
+    assert "pyxis-map-installer:" in installer
+    assert "cross-tab locking required for safe map installation" in installer
+    lower = " ".join(installer.lower().replace("//", " ").split())
+    assert "not coordinate with the cli" in lower
+    assert "another origin" in lower
+    assert "another browser profile" in lower
+    for overclaim in ("cross-origin", "other profile", "all producers",
+                      "both producers", "coordinated by the cli"):
+        assert overclaim not in lower

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -61,6 +61,44 @@ def test_map_installer_explains_the_complete_sd_card_workflow() -> None:
     assert positions == sorted(positions)
 
 
+def test_map_installer_documents_the_single_writer_contract() -> None:
+    """B9: both the flasher UI and the docs must state the supported
+    concurrency model — no CLI+browser at once, close other flasher tabs,
+    wait for verified completion, safe eject, exact retry — and must never
+    tell users to clean up marker files."""
+    flasher = FLASHER.read_text(encoding="utf-8")
+    docs = (ROOT / "docs/offline-map-packs.md").read_text(encoding="utf-8")
+    assert 'class="warning map-safety-contract"' in flasher
+    # Normalize whitespace so phrase checks survive HTML line-wrapping.
+    flasher_norm = " ".join(flasher.split())
+    contract_phrases = (
+        "close all other Pyxis flasher tabs",
+        "command-line installer",
+        "mounted card at the same time",
+        "completion message",
+        "safely eject",
+        "retry with the exact same ZIP",
+    )
+    for phrase in contract_phrases:
+        assert phrase in flasher_norm, f"flasher missing: {phrase!r}"
+    # The docs carry the same contract, plus the lock-scope limitation.
+    docs_norm = " ".join(docs.split())
+    assert "do not run the CLI and the browser installer" in docs_norm
+    assert "Close all other flasher tabs" in docs_norm
+    assert "Wait for the verified completion message" in docs_norm
+    assert "same browser profile" in docs_norm
+    # No marker-file cleanup instructions anywhere in the map installer docs.
+    lower_docs = docs_norm.lower()
+    for forbidden in (
+        "delete the marker",
+        "remove the marker",
+        "clean up the marker",
+        "delete the active-pack",
+        "remove the active-pack",
+    ):
+        assert forbidden not in lower_docs
+
+
 def test_map_installer_has_no_tile_network_fetch_path() -> None:
     source = INSTALLER.read_text(encoding="utf-8").lower()
     for forbidden in ("fetch(", "xmlhttprequest", "websocket", "http://", "https://"):

--- a/tests/build_scripts/test_map_web_installer_contract.py
+++ b/tests/build_scripts/test_map_web_installer_contract.py
@@ -27,7 +27,7 @@ def test_map_installer_ui_is_local_file_to_sd_and_offline_only() -> None:
     assert "showDirectoryPicker" in source
     assert "navigator.locks?.request" in source
     assert "cross-tab locking required for safe map installation" in source
-    assert "./js/map-installer.js?v=map-pack-v3" in source
+    assert "./js/map-installer.js?v=map-pack-v3-progress" in source
     assert "Oxed's Map Tile Downloader" in source
     assert "OpenStreetMap contributors" in source
     assert "suggestMapIdentity" in source

--- a/tests/tools/test_build_map_pack.py
+++ b/tests/tools/test_build_map_pack.py
@@ -634,6 +634,26 @@ def test_plan_equal_generation_unequal_records_rejected(tool) -> None:
                              attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
 
 
+def test_plan_v1_v3_equal_generation_colliding_pack_rejected(tool) -> None:
+    # A legacy v1 slot and a v3 slot at the same generation with a colliding
+    # pack ID are unequal full records and must be rejected. The v1 record
+    # decodes to map_set_id == pack_id, so the normalized fields would agree;
+    # only a full-record comparison (version/attribution/row_spans) catches it.
+    body = bytearray(44)
+    body[0:4] = b"PMAS"
+    body[4] = 1
+    body[6:8] = struct.pack("<H", 48)
+    body[8:12] = struct.pack("<I", 4)
+    body[12] = len("pack-x")
+    body[13:13 + len("pack-x")] = b"pack-x"
+    record = bytes(body) + struct.pack("<I", zlib.crc32(bytes(body)))
+    slot_1 = _slot(tool, 4, ["pack-x"])
+    with pytest.raises(tool.PackError, match="disagree at equal generation"):
+        tool.plan_activation(slot_0=record, slot_1=slot_1, new_pack_id="pack-c",
+                             style_id="osm-bright",
+                             attribution=tool.STYLE_POLICIES["osm-bright"]["attribution"])
+
+
 def test_plan_existing_same_style_pack_moves_to_front_without_duplication(tool) -> None:
     slot_0 = _slot(tool, 2, ["pack-a", "pack-b"])
     plan = tool.plan_activation(slot_0=slot_0, slot_1=None, new_pack_id="pack-b",

--- a/tests/web/map_installer_browser_harness.html
+++ b/tests/web/map_installer_browser_harness.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<!--
+  B8 smoke harness: exercises the real browser File System Access API
+  (Origin Private File System) instead of the in-memory mock. Served from
+  tests/web/ over a localhost secure context by
+  run_map_installer_browser_smoke.py, which also serves smoke-metadata.json
+  in memory. The phase and run id travel in the query string; the driver
+  then collects window.__smokeResult.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Pyxis map installer browser smoke</title>
+  <style>body { font-family: system-ui, sans-serif; padding: 2rem; }</style>
+</head>
+<body>
+  <h1>Map installer browser smoke</h1>
+  <pre id="status">pending</pre>
+  <script type="module">
+    import {
+      decodeActiveSelection,
+      installMuiZip,
+      parseSparseManifest,
+      validatePng,
+    } from '../../docs/flasher/js/map-installer.js';
+
+    const statusEl = document.getElementById('status');
+    function setStage(name) { statusEl.textContent = `stage: ${name}`; }
+
+    const PNG_BASE64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAA1UlEQVR4nO3BMQEAAADCoPVP7WULoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAGwEtAAHMpTgHAAAAAElFTkSuQmCC';
+    const PNG = Uint8Array.from(atob(PNG_BASE64), ch => ch.charCodeAt(0));
+
+    function crc32(bytes) {
+      let crc = 0xffffffff;
+      for (const byte of bytes) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+      }
+      return (crc ^ 0xffffffff) >>> 0;
+    }
+
+    // Minimal stored (uncompressed) ZIP for one tile entry, mirroring the
+    // node test's storedZip but with the metadata a real browser zip tool
+    // produces: UTF-8 flag bit and a regular-file external attribute.
+    function storedZip(name, payload) {
+      const filename = new TextEncoder().encode(name);
+      const data = new Uint8Array(payload);
+      const checksum = crc32(data);
+      const localHeader = new Uint8Array(30);
+      const lv = new DataView(localHeader.buffer);
+      lv.setUint32(0, 0x04034b50, true);
+      lv.setUint16(4, 20, true);
+      lv.setUint16(6, 0x0800, true); // UTF-8 file name flag
+      lv.setUint32(14, checksum, true);
+      lv.setUint32(18, data.length, true);
+      lv.setUint32(22, data.length, true);
+      lv.setUint16(26, filename.length, true);
+      const centralHeader = new Uint8Array(46);
+      const cv = new DataView(centralHeader.buffer);
+      cv.setUint32(0, 0x02014b50, true);
+      cv.setUint16(4, 20, true);
+      cv.setUint16(6, 20, true);
+      cv.setUint16(8, 0x0800, true); // UTF-8 file name flag
+      cv.setUint32(16, checksum, true);
+      cv.setUint32(20, data.length, true);
+      cv.setUint32(24, data.length, true);
+      cv.setUint16(28, filename.length, true);
+      cv.setUint32(38, 0x81a40000, true); // unix mode 0644 regular file
+      cv.setUint32(42, 0, true);
+      const end = new Uint8Array(22);
+      const ev = new DataView(end.buffer);
+      ev.setUint32(0, 0x06054b50, true);
+      ev.setUint16(8, 1, true);
+      ev.setUint16(10, 1, true);
+      ev.setUint32(12, centralHeader.length + filename.length, true);
+      ev.setUint32(16, 30 + filename.length + data.length, true);
+      return new Blob([localHeader, filename, data, centralHeader, filename, end],
+        {type: 'application/zip'});
+    }
+
+    async function readAll(fileHandle) {
+      const file = await fileHandle.getFile();
+      return new Uint8Array(await file.arrayBuffer());
+    }
+
+    async function readIfExists(directory, name) {
+      try {
+        return await readAll(await directory.getFileHandle(name));
+      } catch (error) {
+        if (error && error.name === 'NotFoundError') return null;
+        throw error;
+      }
+    }
+
+    async function verifyComposition(pyxis, metadata, expectedGeneration) {
+      const pack = await (await pyxis.getDirectoryHandle('packs')).getDirectoryHandle(metadata.packId);
+      const manifest = await readAll(await pack.getFileHandle('manifest.pmp'));
+      const parsed = parseSparseManifest(manifest);
+      // parseSparseManifest omits version: v3 is indexless (empty rowSpans).
+      if (parsed.rowSpans.length !== 0 || parsed.tileCount === undefined) {
+        return {ok: false, reason: `manifest not v3: ${JSON.stringify(parsed)}`};
+      }
+      if (parsed.packId !== metadata.packId) return {ok: false, reason: 'manifest packId mismatch'};
+      const tile = await readAll(await (await (await (await pack.getDirectoryHandle('tiles'))
+        .getDirectoryHandle('2')).getDirectoryHandle('1')).getFileHandle('1.png'));
+      await validatePng(tile, 'smoke tile');
+      if (tile.length !== PNG.length) return {ok: false, reason: 'tile size mismatch'};
+      for (let i = 0; i < PNG.length; i++) {
+        if (tile[i] !== PNG[i]) return {ok: false, reason: `tile byte ${i} differs`};
+      }
+      // v3 PMAS pack records carry only packId (indexless; spans live in the
+      // manifest and are not repeated in the activation record).
+      const expectedPacks = {packId: metadata.packId};
+      const styleRecord = decodeActiveSelection(
+        await readAll(await (await pyxis.getDirectoryHandle('map-sets'))
+          .getFileHandle(`${metadata.mapSetId}.pmas`)));
+      const slotRecord = decodeActiveSelection(
+        await readAll(await pyxis.getFileHandle('active-pack.0')));
+      for (const [label, record] of [['style', styleRecord], ['slot', slotRecord]]) {
+        if (record.version !== 3) return {ok: false, reason: `${label} version ${record.version}`};
+        if (record.generation !== expectedGeneration) return {ok: false, reason: `${label} generation ${record.generation}`};
+        if (record.mapSetId !== metadata.mapSetId) return {ok: false, reason: `${label} mapSetId ${record.mapSetId}`};
+        if (record.attribution !== metadata.attribution) return {ok: false, reason: `${label} attribution`};
+        if (JSON.stringify(record.packs) !== JSON.stringify([expectedPacks])) {
+          return {ok: false, reason: `${label} packs ${JSON.stringify(record.packs)}`};
+        }
+      }
+      return {ok: true};
+    }
+
+    async function main() {
+      // The Python driver serves this page over localhost and writes the run
+      // metadata to smoke-metadata.json before launch; the phase and run id
+      // travel in the query string (with a nonce defeating the bfcache) so
+      // each phase is an independent real load.
+      const params = new URLSearchParams(location.search);
+      const runId = params.get('run') || window.__smokeRunId;
+      const metadata = await (await fetch('./smoke-metadata.json')).json();
+      const isReload = params.get('phase') === 'reload';
+      const root = await navigator.storage.getDirectory();
+      const smoke = await root.getDirectoryHandle(`pyxis-map-smoke-${runId}`, {create: true});
+      try {
+        const result = {
+          install: false,
+          readback: false,
+          reload: false,
+          exclusive_option_ignored: false,
+        };
+        if (!isReload) {
+          // Reload-persistence token: written through a real handle now and
+          // re-read after a full page reload in the second phase.
+          const token = await smoke.getFileHandle('smoke-token', {create: true});
+          const writable = await token.createWritable();
+          await writable.write(`smoke:${runId}`);
+          await writable.close();
+          // The File System Access API has no exclusive create option: the
+          // second call must return the existing handle, not throw.
+          const probe = await smoke.getFileHandle('smoke-probe', {create: true, exclusive: true});
+          const probeWritable = await probe.createWritable();
+          await probeWritable.write('first');
+          await probeWritable.close();
+          const probeAgain = await smoke.getFileHandle('smoke-probe', {create: true, exclusive: true});
+          const probeFile = await probeAgain.getFile();
+          const probeText = new TextDecoder().decode(await probeFile.arrayBuffer());
+          if (probeText !== 'first') throw new Error(`exclusive probe changed content: ${probeText}`);
+          result.exclusive_option_ignored = true;
+          setStage('install');
+          await installMuiZip({
+            archive: storedZip('2/1/1.png', PNG),
+            rootDirectory: smoke,
+            metadata,
+          });
+          const composition = await verifyComposition(
+            await smoke.getDirectoryHandle('pyxis-map'), metadata, 1);
+          if (composition.ok) { result.install = true; result.readback = true; }
+          window.__smokeResult = {...result, composition};
+          statusEl.textContent = `install done: ${JSON.stringify(window.__smokeResult)}`;
+          return;
+        }
+        // Reload phase: OPFS must have survived a full page reload.
+        setStage('reload');
+        const token = await readIfExists(smoke, 'smoke-token');
+        const tokenOk = token !== null && new TextDecoder().decode(token) === `smoke:${runId}`;
+        const composition = await verifyComposition(
+          await smoke.getDirectoryHandle('pyxis-map'), metadata, 1);
+        window.__smokeResult = {
+          install: true,
+          readback: true,
+          reload: tokenOk && composition.ok,
+          exclusive_option_ignored: true,
+          tokenOk,
+          composition,
+        };
+        statusEl.textContent = `reload done: ${JSON.stringify(window.__smokeResult)}`;
+      } finally {
+        // Clean only this run's OPFS test directory, and only after the
+        // reload phase has captured its results.
+        if (isReload) {
+          await root.removeEntry(`pyxis-map-smoke-${runId}`, {recursive: true});
+        }
+      }
+    }
+
+    main().catch(error => {
+      window.__smokeResult = {
+        error: `${error && error.name || 'Error'}: ${error && error.message || error}`,
+        stack: (error && error.stack) || '',
+        stage: window.__smokeStage || 'unknown',
+      };
+      statusEl.textContent = `failed: ${JSON.stringify(window.__smokeResult)}`;
+    });
+  </script>
+</body>
+</html>

--- a/tests/web/map_installer_browser_harness.html
+++ b/tests/web/map_installer_browser_harness.html
@@ -25,7 +25,10 @@
     } from '../../docs/flasher/js/map-installer.js';
 
     const statusEl = document.getElementById('status');
-    function setStage(name) { statusEl.textContent = `stage: ${name}`; }
+    function setStage(name) {
+      window.__smokeStage = name;
+      statusEl.textContent = `stage: ${name}`;
+    }
 
     const PNG_BASE64 =
       'iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAIAAADTED8xAAAA1UlEQVR4nO3BMQEAAADCoPVP7WULoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAGwEtAAHMpTgHAAAAAElFTkSuQmCC';
@@ -135,7 +138,7 @@
       // travel in the query string (with a nonce defeating the bfcache) so
       // each phase is an independent real load.
       const params = new URLSearchParams(location.search);
-      const runId = params.get('run') || window.__smokeRunId;
+      const runId = params.get('run');
       const metadata = await (await fetch('./smoke-metadata.json')).json();
       const isReload = params.get('phase') === 'reload';
       const root = await navigator.storage.getDirectory();
@@ -185,10 +188,10 @@
         const composition = await verifyComposition(
           await smoke.getDirectoryHandle('pyxis-map'), metadata, 1);
         window.__smokeResult = {
-          install: true,
-          readback: true,
+          // The install/readback/exclusive booleans come from the install
+          // phase (driver merges them in); this phase only reports what it
+          // re-observed after the page reload.
           reload: tokenOk && composition.ok,
-          exclusive_option_ignored: true,
           tokenOk,
           composition,
         };

--- a/tests/web/run_map_installer_browser_smoke.py
+++ b/tests/web/run_map_installer_browser_smoke.py
@@ -185,7 +185,14 @@ def main() -> None:
         "reload": True,
         "exclusive_option_ignored": True,
     }
-    record = {key: bool(result_reload.get(key)) for key in expected}
+    record = {
+        # install/readback/exclusive come from the install phase (observed
+        # there); only reload/tokenOk/composition come from the reload phase.
+        "install": bool(result_install.get("install")),
+        "readback": bool(result_install.get("readback")),
+        "reload": bool(result_reload.get("reload")),
+        "exclusive_option_ignored": bool(result_install.get("exclusive_option_ignored")),
+    }
     if record != expected or result_reload.get("tokenOk") is not True \
             or not result_reload.get("composition", {}).get("ok"):
         json.dump({"ok": False, "result": result_reload}, sys.stdout)

--- a/tests/web/run_map_installer_browser_smoke.py
+++ b/tests/web/run_map_installer_browser_smoke.py
@@ -1,0 +1,200 @@
+"""B8: real Chromium OPFS smoke for the browser map installer.
+
+Runs the public ``installMuiZip`` path against a synthetic one-tile ZIP on
+a localhost secure context, reads the manifest/style/slot back through real
+File System Access handles, reloads the page to verify OPFS persistence,
+and guards against reintroducing the false ``exclusive``-create assumption.
+
+This is a required pre-publication command, not a CI job: the repository's
+CI does not provision a Chromium browser. Locates a Playwright-managed
+Chromium build and drives it over the DevTools protocol.
+
+Usage:
+    python3 tests/web/run_map_installer_browser_smoke.py
+
+Exit code 0 only when exactly one valid result record is emitted.
+"""
+
+import http.server
+import json
+import os
+import shutil
+import socket
+import socketserver
+import sys
+import threading
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[1]
+HARNESS = "/tests/web/map_installer_browser_harness.html"
+METADATA = {
+    "packId": "smoke-pack",
+    "mapSetId": "osm-bright",
+    "name": "Smoke Pack",
+    "attribution": "(c) OpenMapTiles (c) OpenStreetMap contributors",
+    "source": "Oxed's Map Tile Downloader (OSM Bright)",
+    "license": "OSM ODbL; style CC-BY-4.0/BSD-3-Clause",
+}
+PORT = None
+
+
+def find_chromium() -> str:
+    for env_name in ("PYXIS_SMOKE_CHROMIUM", "CHROME_PATH"):
+        candidate = os.environ.get(env_name)
+        if candidate and Path(candidate).is_file():
+            return candidate
+    cache = Path.home() / ".cache" / "ms-playwright"
+    if cache.is_dir():
+        for build in sorted(cache.glob("chromium-*"), reverse=True):
+            for pattern in ("chrome-linux64/chrome", "chrome-linux/chrome"):
+                candidate = build / pattern
+                if candidate.is_file():
+                    return str(candidate)
+    for name in ("chromium", "chromium-browser", "google-chrome",
+                 "google-chrome-stable"):
+        candidate = shutil.which(name)
+        if candidate:
+            return candidate
+    raise SystemExit(
+        "No Chromium found. Install one (e.g. `python3 -m playwright install "
+        "chromium`) or set PYXIS_SMOKE_CHROMIUM to a chrome binary."
+    )
+
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def make_handler(metadata_bytes):
+    """Serve the repo tree, but answer the harness's metadata fetch from an
+    in-memory payload so the smoke never writes a scratch file into the
+    repository working tree."""
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(REPO_ROOT), **kwargs)
+
+        def do_GET(self):
+            path = self.path.split("?", 1)[0]
+            if path.endswith("/smoke-metadata.json"):
+                body = metadata_bytes
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            super().do_GET()
+
+        def log_message(self, format, *args):
+            # Keep the smoke output quiet; only the final JSON is emitted.
+            pass
+
+    return Handler
+
+
+def run_phase(page, run_id, phase, timeout_s=90):
+    """Run one harness phase and return window.__smokeResult.
+
+    The phase and run id travel in the query string (with a nonce defeating
+    the bfcache) so each phase is a real, independent load; the driver's
+    in-memory metadata endpoint feeds the harness.
+    """
+    page.goto(
+        f"http://127.0.0.1:{PORT}{HARNESS}"
+        f"?phase={phase}&run={run_id}&nonce={phase}"
+    )
+    deadline = time.time() + timeout_s
+    status = ""
+    while time.time() < deadline:
+        result = page.evaluate("window.__smokeResult")
+        if result is not None:
+            return result
+        status = page.evaluate(
+            "document.getElementById('status') ? "
+            "document.getElementById('status').textContent : ''"
+        )
+        page.wait_for_timeout(100)
+    raise SystemExit(
+        f"phase {phase}: harness did not report in {timeout_s}s; status={status!r}"
+    )
+
+
+def main() -> None:
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        raise SystemExit(
+            "The playwright Python package is required for this smoke. "
+            "Install it in a scratch venv (browser binaries are picked up "
+            "from ~/.cache/ms-playwright or PYXIS_SMOKE_CHROMIUM)."
+        )
+
+    global PORT
+    PORT = free_port()
+    metadata_bytes = json.dumps(METADATA).encode("utf-8")
+    server = ThreadingHTTPServer(("127.0.0.1", PORT), make_handler(metadata_bytes))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        chromium = find_chromium()
+        run_id = str(int(time.time() * 1000))
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(
+                executable_path=chromium,
+                args=[
+                    "--no-sandbox",
+                    "--disable-dev-shm-usage",
+                ],
+            )
+            try:
+                context = browser.new_context()
+                page = context.new_page()
+                result_install = run_phase(page, run_id, "install")
+                if "error" in result_install:
+                    raise SystemExit(
+                        "install phase failed: "
+                        f"{result_install['error']}\n"
+                        f"{result_install.get('stack', '')}\n"
+                        f"debug={result_install.get('debug', '')}"
+                    )
+                if not result_install.get("install") or \
+                        not result_install.get("readback"):
+                    raise SystemExit(f"install phase incomplete: {result_install}")
+                if not result_install.get("exclusive_option_ignored"):
+                    raise SystemExit(f"exclusive guard failed: {result_install}")
+                result_reload = run_phase(page, run_id, "reload")
+                if "error" in result_reload:
+                    raise SystemExit(f"reload phase failed: {result_reload}")
+            finally:
+                browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    expected = {
+        "install": True,
+        "readback": True,
+        "reload": True,
+        "exclusive_option_ignored": True,
+    }
+    record = {key: bool(result_reload.get(key)) for key in expected}
+    if record != expected or result_reload.get("tokenOk") is not True \
+            or not result_reload.get("composition", {}).get("ok"):
+        json.dump({"ok": False, "result": result_reload}, sys.stdout)
+        sys.stdout.write("\n")
+        raise SystemExit(1)
+    json.dump({"ok": True, "result": record}, sys.stdout)
+    sys.stdout.write("\n")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -1455,6 +1455,36 @@ test('activation publishes the style record before the active slot', async () =>
   assert.ok(styleWrite < slotWrite, 'style PMAS must be written before the active slot');
 });
 
+test('installation reports progress for every user-visible phase in order', async () => {
+  // The flasher renders status from onProgress events; a phase that never
+  // reports (e.g. the full-ZIP validate sweep before the first write) leaves
+  // the UI looking frozen during long installs.
+  const root = new MemoryDirectoryHandle();
+  const events = [];
+  await installMuiZip({
+    archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId: 'pack-progress'},
+    onProgress(progress) { events.push(progress); },
+  });
+  const phases = events.map(event => event.phase);
+  for (const phase of ['validate', 'checking', 'write', 'manifest', 'activating']) {
+    assert.ok(phases.includes(phase), `missing progress phase: ${phase}`);
+  }
+  const lastValidate = phases.lastIndexOf('validate');
+  const firstWrite = phases.indexOf('write');
+  assert.ok(lastValidate < firstWrite, 'validate events must precede tile writes');
+  assert.ok(phases.indexOf('checking') < firstWrite, 'inherited-pack check must precede tile writes');
+  assert.ok(firstWrite < phases.indexOf('manifest'), 'manifest publish must follow tile writes');
+  assert.ok(phases.indexOf('manifest') < phases.indexOf('activating'), 'activation must follow the manifest publish');
+  const writeEvents = events.filter(event => event.phase === 'write');
+  assert.deepEqual(
+    writeEvents.map(event => [event.completed, event.total]),
+    [[1, 1]],
+    'write progress must report completed/total per tile',
+  );
+});
+
 test('a failed style write leaves every active slot untouched and is retriable', async () => {
   const style = getMuiStyleProfile('osm-bright');
   const root = new MemoryDirectoryHandle();

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -12,6 +12,7 @@ import {
   installMuiZip,
   parseSparseManifest,
   resolveMuiStyleProfile,
+  serializeIndexlessManifest,
   suggestMapIdentity,
 } from '../../docs/flasher/js/map-installer.js';
 
@@ -228,6 +229,182 @@ test('filesystem mock matches browser File System Access API semantics', async (
     root.getDirectoryHandle('missing-dir', {create: false}),
     error => error.name === 'NotFoundError',
   );
+});
+
+const v3Vectors = JSON.parse(
+  (await readFile(new URL('../fixtures/map_pack_v3_vectors.json', import.meta.url))).toString('utf8'),
+);
+
+function hexToBytes(hex) {
+  return Uint8Array.from(hex.match(/../g).map(part => Number.parseInt(part, 16)));
+}
+
+function rewriteCrc32(bytes) {
+  const output = new Uint8Array(bytes.length);
+  output.set(bytes);
+  const view = new DataView(output.buffer);
+  view.setUint32(output.length - 4, crc32(output.subarray(0, output.length - 4)), true);
+  return output;
+}
+
+test('browser consumes the frozen PMPK v3 vectors', () => {
+  for (const name of ['pmpk_v3_one_tile', 'pmpk_v3_multi_zoom']) {
+    const entry = v3Vectors[name];
+    const parsed = parseSparseManifest(hexToBytes(entry.hex));
+    assert.equal(parsed.packId, entry.pack_id);
+    assert.equal(parsed.name, entry.name);
+    assert.equal(parsed.attribution, entry.attribution);
+    assert.equal(parsed.source, entry.source);
+    assert.equal(parsed.license, entry.license);
+    assert.equal(parsed.minZoom, entry.min_zoom);
+    assert.equal(parsed.maxZoom, entry.max_zoom);
+    assert.equal(parsed.tileCount, entry.tile_count);
+    assert.deepEqual(parsed.rowSpans, []);
+  }
+});
+
+test('browser serializes the frozen PMPK v3 vectors exactly', () => {
+  for (const name of ['pmpk_v3_one_tile', 'pmpk_v3_multi_zoom']) {
+    const entry = v3Vectors[name];
+    const actual = serializeIndexlessManifest({
+      packId: entry.pack_id, name: entry.name, attribution: entry.attribution,
+      source: entry.source, license: entry.license,
+    }, entry.min_zoom, entry.max_zoom, entry.tile_count);
+    assert.deepEqual([...actual], [...hexToBytes(entry.hex)]);
+  }
+});
+
+test('browser decodes the frozen PMAS v3 vectors', () => {
+  for (const name of ['pmas_v3_one_pack', 'pmas_v3_three_packs']) {
+    const entry = v3Vectors[name];
+    const decoded = decodeActiveSelection(hexToBytes(entry.hex));
+    assert.equal(decoded.version, 3);
+    assert.equal(decoded.generation, entry.generation);
+    assert.equal(decoded.mapSetId, entry.map_set_id);
+    assert.equal(decoded.attribution, entry.attribution);
+    assert.deepEqual(
+      decoded.packs.map(pack => pack.packId),
+      entry.pack_ids,
+    );
+    for (const pack of decoded.packs) assert.deepEqual(pack.rowSpans, undefined);
+  }
+});
+
+test('browser encodes the frozen PMAS v3 vectors exactly', () => {
+  for (const name of ['pmas_v3_one_pack', 'pmas_v3_three_packs']) {
+    const entry = v3Vectors[name];
+    const actual = encodeActiveMapSet({
+      generation: entry.generation,
+      mapSetId: entry.map_set_id,
+      attribution: entry.attribution,
+      packs: entry.pack_ids.map(packId => ({packId})),
+    });
+    assert.deepEqual([...actual], [...hexToBytes(entry.hex)]);
+  }
+});
+
+test('browser rejects the same invalid PMPK v3 mutations as the CLI', () => {
+  const mutate = (apply) => {
+    const data = hexToBytes(v3Vectors.pmpk_v3_one_tile.hex);
+    apply(data);
+    return rewriteCrc32(data);
+  };
+  assert.throws(() => parseSparseManifest(mutate(data => { data[5] = 1; })));
+  // Splice four zero bytes before the CRC: the total-length field then
+  // disagrees with the actual record size.
+  const withTrailing = rewriteCrc32(hexToBytes(v3Vectors.pmpk_v3_one_tile.hex));
+  assert.throws(() => parseSparseManifest(
+    new Uint8Array([
+      ...withTrailing.subarray(0, withTrailing.length - 4),
+      0, 0, 0, 0,
+      ...withTrailing.subarray(withTrailing.length - 4),
+    ]),
+  ));
+  const corrupted = hexToBytes(v3Vectors.pmpk_v3_one_tile.hex);
+  corrupted[corrupted.length - 1] ^= 1;
+  assert.throws(() => parseSparseManifest(corrupted));
+  assert.throws(() => parseSparseManifest(mutate(data => {
+    new DataView(data.buffer).setUint32(data.length - 8, 0, true);
+  })));
+  assert.throws(() => parseSparseManifest(mutate(data => { data[data.length - 9] = 1; })));
+});
+
+test('browser rejects the same invalid PMAS v3 mutations as the CLI', () => {
+  const hex = v3Vectors.pmas_v3_one_pack.hex;
+  const corrupted = hexToBytes(hex);
+  corrupted[corrupted.length - 1] ^= 1;
+  assert.throws(() => decodeActiveSelection(corrupted));
+  const generationZero = hexToBytes(hex);
+  new DataView(generationZero.buffer).setUint32(8, 0, true);
+  assert.throws(() => decodeActiveSelection(rewriteCrc32(generationZero)));
+  const trailing = rewriteCrc32(hexToBytes(hex));
+  const extended = new Uint8Array(trailing.length + 1);
+  extended.set(trailing);
+  extended[trailing.length - 1] = trailing[trailing.length - 1];
+  assert.throws(() => decodeActiveSelection(extended));
+  assert.throws(() => encodeActiveMapSet({
+    generation: 0, mapSetId: 'osm-bright', attribution: 'Example', packs: [{packId: 'detail'}],
+  }));
+  assert.throws(() => encodeActiveMapSet({
+    generation: 1, mapSetId: 'osm-bright', attribution: 'Example',
+    packs: Array.from({length: 9}, (_, index) => ({packId: `pack-${index}`})),
+  }));
+  assert.throws(() => encodeActiveMapSet({
+    generation: 1, mapSetId: 'osm-bright', attribution: 'Example', packs: [],
+  }));
+  assert.throws(() => encodeActiveMapSet({
+    generation: 1, mapSetId: 'osm-bright', attribution: 'Example',
+    packs: [{packId: 'detail'}, {packId: 'detail'}],
+  }));
+});
+
+test('browser preserves legacy PMAS v1 decoding and v2 span validation', () => {
+  const body = new Uint8Array(44);
+  const view = new DataView(body.buffer);
+  view.setUint32(0, 0x53414d50, true);
+  body[4] = 1;
+  view.setUint16(6, 48, true);
+  view.setUint32(8, 5, true);
+  body[12] = 8;
+  body.set(new TextEncoder().encode('legacy-1'), 13);
+  const record = new Uint8Array(body.length + 4);
+  record.set(body);
+  new DataView(record.buffer).setUint32(44, crc32(body), true);
+  const decoded = decodeActiveSelection(record);
+  assert.equal(decoded.version, 1);
+  assert.equal(decoded.generation, 5);
+  assert.equal(decoded.packId, 'legacy-1');
+
+  // Hand-built v2: header, map-set id, attribution, one pack carrying one
+  // row span; total length and CRC patched after the body is assembled.
+  const parts = [];
+  const push = (bytes) => parts.push(...bytes);
+  const pushU16 = (value) => { parts.push(value & 0xff, value >> 8); };
+  const pushU32 = (value) => {
+    parts.push(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >>> 24) & 0xff);
+  };
+  const pushSized = (text) => { push([...new TextEncoder().encode(text)]); };
+  pushU32(0x53414d50); parts.push(2, 0); pushU16(0); pushU32(9);
+  parts.push(8); pushSized('legacy-1');
+  parts.push(7); pushSized('Example');
+  parts.push(1);
+  parts.push(8); pushSized('legacy-1');
+  pushU16(1);
+  parts.push(1); pushU32(1); pushU32(0); pushU32(1);
+  const inner = new Uint8Array(parts);
+  const totalLength = inner.length + 4;
+  inner[6] = totalLength & 0xff;
+  inner[7] = totalLength >> 8;
+  const v2Record = new Uint8Array(inner.length + 4);
+  v2Record.set(inner);
+  new DataView(v2Record.buffer).setUint32(v2Record.length - 4, crc32(inner), true);
+  const v2Decoded = decodeActiveSelection(v2Record);
+  assert.equal(v2Decoded.version, 2);
+  assert.equal(v2Decoded.generation, 9);
+  assert.equal(v2Decoded.mapSetId, 'legacy-1');
+  assert.deepEqual(v2Decoded.packs, [
+    {packId: 'legacy-1', rowSpans: [{zoom: 1, y: 1, xMinimum: 0, xMaximum: 1}]},
+  ]);
 });
 
 const metadata = {

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -192,6 +192,44 @@ async function child(root, path) {
   return current;
 }
 
+test('filesystem mock matches browser File System Access API semantics', async () => {
+  // Repeated create:true on an existing file must return the same handle,
+  // exactly like browsers (no exclusive-create behavior).
+  const root = new MemoryDirectoryHandle();
+  const first = await root.getFileHandle('a.pmas', {create: true});
+  const second = await root.getFileHandle('a.pmas', {create: true});
+  assert.equal(first, second);
+
+  // The File System Access API has no `exclusive` option; unknown options
+  // are ignored rather than converted into exceptions.
+  const ignored = await root.getFileHandle('a.pmas', {create: true, exclusive: true});
+  assert.equal(ignored, first);
+  const directoryFirst = await root.getDirectoryHandle('tiles', {create: true});
+  const directorySecond = await root.getDirectoryHandle('tiles', {create: true, exclusive: true});
+  assert.equal(directoryFirst, directorySecond);
+
+  // A file and directory sharing a name are TypeMismatchError in both
+  // directions; missing files without create are NotFoundError.
+  await assert.rejects(
+    root.getFileHandle('tiles', {create: true}),
+    error => error.name === 'TypeMismatchError',
+  );
+  const reverse = new MemoryDirectoryHandle();
+  await reverse.getDirectoryHandle('a.pmas', {create: true});
+  await assert.rejects(
+    reverse.getFileHandle('a.pmas', {create: true}),
+    error => error.name === 'TypeMismatchError',
+  );
+  await assert.rejects(
+    root.getFileHandle('missing.pmas'),
+    error => error.name === 'NotFoundError',
+  );
+  await assert.rejects(
+    root.getDirectoryHandle('missing-dir', {create: false}),
+    error => error.name === 'NotFoundError',
+  );
+});
+
 const metadata = {
   packId: 'overview',
   mapSetId: 'osm-bright',

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -1222,6 +1222,106 @@ test('distinct handles for one selected root are serialized across tabs', async 
   assert.deepEqual(new Set(newest.packs.map(pack => pack.packId)), new Set(['tab-one', 'tab-two']));
 });
 
+function installSequence(root) {
+  const archive = storedZip([['2/1/1.png', PNG]]);
+  const events = [];
+  const install = (label) => installMuiZip({
+    archive,
+    rootDirectory: new DirectoryHandleAlias(root),
+    metadata: {...metadata, packId: label, name: label},
+    onProgress(progress) {
+      if (progress.phase === 'write') events.push(`${label}:started`);
+    },
+  }).then(() => { events.push(`${label}:finished`); });
+  return {events, install};
+}
+
+test('two same-origin installs run strictly one at a time under Web Locks', async () => {
+  const root = new MemoryDirectoryHandle('sd-card');
+  const previousNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {locks: new MemoryLockManager()},
+  });
+  const {events, install} = installSequence(root);
+  try {
+    await Promise.all([
+      install('alpha'),
+      install('beta'),
+    ]);
+  } finally {
+    if (previousNavigator) Object.defineProperty(globalThis, 'navigator', previousNavigator);
+    else delete globalThis.navigator;
+  }
+  const startPositions = ['alpha:started', 'beta:started'].map(label => events.indexOf(label));
+  assert.ok(startPositions.every(index => index !== -1));
+  const firstToStart = startPositions[0] < startPositions[1] ? 'alpha' : 'beta';
+  const secondToStart = firstToStart === 'alpha' ? 'beta' : 'alpha';
+  assert.ok(
+    events.indexOf(`${firstToStart}:finished`) < startPositions[1],
+    `the first install must finish before the second starts: ${events.join(' ')}`,
+  );
+  assert.ok(startPositions[1] < events.indexOf(`${secondToStart}:finished`));
+});
+
+test('a Web Locks rejection propagates without touching the selected root', async () => {
+  const root = new MemoryDirectoryHandle('sd-card');
+  const previousNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      locks: {
+        request(name, options, operation) {
+          assert.equal(name, 'pyxis-map-installer:sd-card');
+          assert.deepEqual(options, {mode: 'exclusive'});
+          throw new Error('lock refused by another tab');
+        },
+      },
+    },
+  });
+  try {
+    await assert.rejects(
+      installMuiZip({
+        archive: storedZip([['2/1/1.png', PNG]]),
+        rootDirectory: root,
+        metadata: {...metadata, packId: 'lock-rejected', name: 'Lock Rejected'},
+      }),
+      /lock refused by another tab/i,
+    );
+  } finally {
+    if (previousNavigator) Object.defineProperty(globalThis, 'navigator', previousNavigator);
+    else delete globalThis.navigator;
+  }
+  assert.equal(root.children.has('pyxis-map'), false, 'no SD mutation may precede lock acquisition');
+});
+
+test('a supported browser without Web Locks fails closed before any mutation', async () => {
+  const root = new MemoryDirectoryHandle('sd-card');
+  const previousNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'navigator', {configurable: true, value: {}});
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {showDirectoryPicker: () => {}},
+  });
+  try {
+    await assert.rejects(
+      installMuiZip({
+        archive: storedZip([['2/1/1.png', PNG]]),
+        rootDirectory: root,
+        metadata,
+      }),
+      /cross-tab locking required for safe map installation/i,
+    );
+  } finally {
+    if (previousNavigator) Object.defineProperty(globalThis, 'navigator', previousNavigator);
+    else delete globalThis.navigator;
+    if (previousWindow) Object.defineProperty(globalThis, 'window', previousWindow);
+    else delete globalThis.window;
+  }
+  assert.equal(root.children.has('pyxis-map'), false, 'an unlocked browser must not install maps');
+});
+
 test('an empty directory created during destination creation is never removed', async () => {
   const archive = storedZip([['2/1/1.png', PNG]]);
   const root = new MemoryDirectoryHandle();

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -12,6 +12,7 @@ import {
   installMuiZip,
   parseSparseManifest,
   resolveMuiStyleProfile,
+  planActivation,
   serializeIndexlessManifest,
   suggestMapIdentity,
 } from '../../docs/flasher/js/map-installer.js';
@@ -579,6 +580,100 @@ test('rejects altered required style attribution before touching the SD root', a
     /attribution|provenance/i,
   );
   assert.equal(root.children.has('pyxis-map'), false);
+});
+
+test('browser activation planning mirrors the CLI plan contract', () => {
+  const attribution = getMuiStyleProfile('osm-bright').attribution;
+  const slot = (generation, packIds, styleId = 'osm-bright') => encodeActiveMapSet({
+    generation,
+    mapSetId: styleId,
+    attribution: getMuiStyleProfile(styleId).attribution,
+    packs: packIds.map(packId => ({packId})),
+  });
+  const checkPlan = (plan, styleName, targetSlot, generation, packIds) => {
+    assert.equal(plan.styleName, styleName);
+    assert.equal(plan.targetSlot, targetSlot);
+    assert.equal(plan.generation, generation);
+    assert.deepEqual(plan.packIds, packIds);
+    const decoded = decodeActiveSelection(plan.record);
+    assert.equal(decoded.version, 3);
+    assert.equal(decoded.generation, generation);
+    assert.equal(decoded.mapSetId, styleName);
+    assert.equal(decoded.attribution, getMuiStyleProfile(styleName).attribution);
+    assert.deepEqual(decoded.packs.map(pack => pack.packId), packIds);
+  };
+
+  // Empty card: generation one, slot zero.
+  checkPlan(planActivation({slot0: null, slot1: null, newPackId: 'pack-a',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.0', 1, ['pack-a']);
+
+  // One valid slot: target the missing slot.
+  checkPlan(planActivation({slot0: slot(1, ['pack-a']), slot1: null, newPackId: 'pack-b',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.1', 2, ['pack-b', 'pack-a']);
+
+  // Two valid slots: overwrite the lower-generation one, inherit its composition.
+  checkPlan(planActivation({slot0: slot(5, ['old-a']), slot1: slot(3, ['old-b']), newPackId: 'pack-c',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.1', 6, ['pack-c', 'old-a']);
+
+  // Re-installing an existing pack moves it to the front without duplication.
+  checkPlan(planActivation({slot0: slot(2, ['pack-a', 'pack-b']), slot1: null, newPackId: 'pack-b',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.1', 3, ['pack-b', 'pack-a']);
+
+  // A different style starts a fresh composition but still advances the
+  // generation past the existing slots.
+  checkPlan(planActivation({slot0: slot(2, ['pack-a'], 'toner'), slot1: null, newPackId: 'pack-b',
+    styleId: 'dark-matter', attribution: getMuiStyleProfile('dark-matter').attribution}),
+    'dark-matter', 'active-pack.1', 3, ['pack-b']);
+
+  // The style PMAS composition wins over the active slots and drives the
+  // generation.
+  checkPlan(planActivation({slot0: slot(2, ['slot-only']), slot1: null,
+    styleRecord: slot(9, ['style-a', 'slot-only']), newPackId: 'new-pack',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.1', 10,
+    ['new-pack', 'style-a', 'slot-only']);
+
+  // Invalid raw slot bytes are treated like a missing slot: the target is
+  // slot zero and the generation restarts from one, exactly like the CLI.
+  const corrupted = slot(1, ['pack-a']);
+  corrupted[corrupted.length - 1] ^= 1;
+  checkPlan(planActivation({slot0: corrupted, slot1: null, newPackId: 'pack-b',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.0', 1, ['pack-b']);
+
+  // Equal-generation disagreement is rejected before any plan exists.
+  assert.throws(() => planActivation({slot0: slot(4, ['pack-a']), slot1: slot(4, ['pack-b']),
+    newPackId: 'pack-c', styleId: 'osm-bright', attribution}), /equal generation/i);
+
+  // The 8-pack limit is enforced before publication; re-installing an
+  // existing pack within the limit is allowed.
+  assert.throws(() => planActivation({
+    slot0: slot(1, Array.from({length: 8}, (_, index) => `pack-${index}`)), slot1: null,
+    newPackId: 'pack-new', styleId: 'osm-bright', attribution,
+  }), /8-pack/i);
+  checkPlan(planActivation({
+    slot0: slot(1, Array.from({length: 8}, (_, index) => `pack-${index}`)), slot1: null,
+    newPackId: 'pack-3', styleId: 'osm-bright', attribution,
+  }), 'osm-bright', 'active-pack.1', 2,
+    ['pack-3', ...Array.from({length: 8}, (_, index) => `pack-${index}`).filter(id => id !== 'pack-3')]);
+
+  // Generation exhaustion is rejected.
+  const MAX_GENERATION = 0xffffffff;
+  assert.throws(() => planActivation({slot0: slot(MAX_GENERATION, ['pack-a']), slot1: null,
+    newPackId: 'pack-b', styleId: 'osm-bright', attribution}), /exhausted/i);
+
+  // Attribution must match the style policy exactly.
+  assert.throws(() => planActivation({slot0: null, slot1: null, newPackId: 'pack-a',
+    styleId: 'osm-bright', attribution: 'wrong'}), /attribution/i);
+  assert.throws(() => planActivation({slot0: null, slot1: null, newPackId: 'pack-a',
+    styleId: 'nope', attribution: 'x'}), /unsupported/i);
+  assert.throws(() => planActivation({slot0: null, slot1: null, newPackId: 'Bad ID',
+    styleId: 'osm-bright', attribution}), /pack id/i);
+
+  // A style PMAS for a different map set or with the wrong attribution is
+  // ignored, not trusted.
+  checkPlan(planActivation({slot0: slot(2, ['slot-only']), slot1: null,
+    styleRecord: slot(9, ['style-a'], 'toner'), newPackId: 'new-pack',
+    styleId: 'osm-bright', attribution}), 'osm-bright', 'active-pack.1', 3,
+    ['new-pack', 'slot-only']);
 });
 
 test('indexless active map-set wire format contains ordered pack IDs only', () => {

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -647,6 +647,24 @@ test('browser activation planning mirrors the CLI plan contract', () => {
   assert.throws(() => planActivation({slot0: slot(4, ['pack-a']), slot1: slot(4, ['pack-b']),
     newPackId: 'pack-c', styleId: 'osm-bright', attribution}), /equal generation/i);
 
+  // A v1 slot and a v3 slot at the same generation with a colliding pack ID
+  // are also unequal records and must be rejected: the CLI compares the full
+  // decoded record, and the browser must mirror that, not just normalized
+  // fields (which a v1/v3 pair would share after normalization).
+  const legacyBody = new Uint8Array(44);
+  const legacyView = new DataView(legacyBody.buffer);
+  legacyView.setUint32(0, 0x53414d50, true);
+  legacyBody[4] = 1;
+  legacyView.setUint16(6, 48, true);
+  legacyView.setUint32(8, 4, true);
+  legacyBody[12] = 6;
+  legacyBody.set(new TextEncoder().encode('pack-x'), 13);
+  const legacyRecord = new Uint8Array(legacyBody.length + 4);
+  legacyRecord.set(legacyBody);
+  new DataView(legacyRecord.buffer).setUint32(44, crc32(legacyBody), true);
+  assert.throws(() => planActivation({slot0: legacyRecord, slot1: slot(4, ['pack-x']),
+    newPackId: 'pack-c', styleId: 'osm-bright', attribution}), /equal generation/i);
+
   // The 8-pack limit is enforced before publication; re-installing an
   // existing pack within the limit is allowed.
   assert.throws(() => planActivation({

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -116,13 +116,16 @@ function storedZip(entries) {
 }
 
 class MemoryFileHandle {
-  constructor(name, log) { this.name = name; this.kind = 'file'; this.bytes = new Uint8Array(); this.log = log; }
+  constructor(name, log) { this.name = name; this.kind = 'file'; this.bytes = new Uint8Array(); this.log = log; this.failOnWrite = false; }
   async createWritable() {
     const handle = this;
     let pending = new Uint8Array();
     return {
       async write(value) { pending = new Uint8Array(value instanceof Blob ? await value.arrayBuffer() : value); },
-      async close() { handle.bytes = pending; handle.log.push(`write:${handle.name}`); },
+      async close() {
+        if (handle.failOnWrite) throw new Error(`injected write failure: ${handle.name}`);
+        handle.bytes = pending; handle.log.push(`write:${handle.name}`);
+      },
       async abort() {},
     };
   }
@@ -1290,4 +1293,149 @@ test('map-set capacity is checked before a ninth pack is published', async () =>
   await writable.close();
   await assert.rejects(installMuiZip({archive,rootDirectory:root,metadata:{...metadata,packId:'pack-nine',name:'Pack Nine'}}), /8-pack/i);
   assert.equal(pyxis.children.has('packs'), false);
+});
+
+// Seed a card with a valid inherited composition: one published pack and a
+// matching active slot, so preflight validation passes for the inherited
+// pack before the new install runs.
+async function seedInheritedCard(root, slotName, generation, inheritedPackId) {
+  const style = getMuiStyleProfile('osm-bright');
+  const seedMeta = {
+    ...metadata, packId: inheritedPackId, name: 'Seed Pack',
+    attribution: style.attribution, source: style.source, license: style.license,
+  };
+  const pyxis = await root.getDirectoryHandle('pyxis-map', {create: true});
+  const packs = await pyxis.getDirectoryHandle('packs', {create: true});
+  const seed = await packs.getDirectoryHandle(inheritedPackId, {create: true});
+  const manifest = serializeIndexlessManifest(seedMeta, 1, 1, 1);
+  const manifestHandle = await seed.getFileHandle('manifest.pmp', {create: true});
+  const manifestWritable = await manifestHandle.createWritable();
+  await manifestWritable.write(manifest);
+  await manifestWritable.close();
+  const slotHandle = await pyxis.getFileHandle(slotName, {create: true});
+  const slotWritable = await slotHandle.createWritable();
+  await slotWritable.write(encodeActiveMapSet({
+    generation, mapSetId: 'osm-bright', attribution: style.attribution,
+    packs: [{packId: inheritedPackId}],
+  }));
+  await slotWritable.close();
+  return pyxis;
+}
+
+test('activation publishes the style record before the active slot', async () => {
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await seedInheritedCard(root, 'active-pack.0', 5, 'seed-pack');
+  await installMuiZip({
+    archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId: 'pack-a'},
+  });
+  const styleWrite = root.log.findIndex(name => name === 'write:osm-bright.pmas');
+  const slotWrite = root.log.findIndex(name => name === 'write:active-pack.1');
+  assert.notEqual(styleWrite, -1, 'style record must be written');
+  assert.notEqual(slotWrite, -1, 'active slot must be written');
+  assert.ok(styleWrite < slotWrite, 'style PMAS must be written before the active slot');
+});
+
+test('a failed style write leaves every active slot untouched and is retriable', async () => {
+  const style = getMuiStyleProfile('osm-bright');
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await seedInheritedCard(root, 'active-pack.0', 5, 'seed-pack');
+  const slot0Before = await fileAt(root, 'pyxis-map/active-pack.0');
+  // A corrupt 3-byte style record: present (so the resume check sees a
+  // file), but undecodable (so the planner ignores it).
+  const mapSets = await pyxis.getDirectoryHandle('map-sets', {create: true});
+  const styleHandle = await mapSets.getFileHandle('osm-bright.pmas', {create: true});
+  const corruptWritable = await styleHandle.createWritable();
+  await corruptWritable.write(new Uint8Array([0xff, 0x00, 0x13]));
+  await corruptWritable.close();
+  const corruptStyle = await fileAt(root, 'pyxis-map/map-sets/osm-bright.pmas');
+  styleHandle.failOnWrite = true;
+
+  await assert.rejects(
+    installMuiZip({
+      archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+      rootDirectory: root,
+      metadata: {...metadata, packId: 'pack-a'},
+    }),
+    /activation failed; retry with the same ZIP and pack ID/i,
+  );
+  styleHandle.failOnWrite = false;
+
+  // The published pack stays on the card (exact retry is possible), the
+  // existing slot is byte-identical, and no slot was created or clobbered.
+  assert.equal((await fileAt(root, 'pyxis-map/packs/pack-a/manifest.pmp')).length > 0, true);
+  assert.equal(
+    Buffer.from(await fileAt(root, 'pyxis-map/active-pack.0')).toString('hex'),
+    Buffer.from(slot0Before).toString('hex'),
+  );
+  assert.equal(pyxis.children.has('active-pack.1'), false);
+  // The failed style write left the original corrupt bytes in place.
+  assert.equal(
+    Buffer.from(await fileAt(root, 'pyxis-map/map-sets/osm-bright.pmas')).toString('hex'),
+    Buffer.from(corruptStyle).toString('hex'),
+  );
+
+  // Exact retry converges: the corrupt style file is ignored by the
+  // planner, the plan is re-derived from the untouched slot, and style +
+  // slot end up at the same generation.
+  const resumed = await installMuiZip({
+    archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId: 'pack-a'},
+  });
+  assert.equal(resumed.resumed, true);
+  const styleRecord = decodeActiveSelection(await fileAt(root, 'pyxis-map/map-sets/osm-bright.pmas'));
+  const slot1 = decodeActiveSelection(await fileAt(root, 'pyxis-map/active-pack.1'));
+  assert.equal(styleRecord.generation, slot1.generation);
+  assert.deepEqual(slot1.packs.map(pack => pack.packId), ['pack-a', 'seed-pack']);
+  assert.equal(
+    Buffer.from(await fileAt(root, 'pyxis-map/active-pack.0')).toString('hex'),
+    Buffer.from(slot0Before).toString('hex'),
+  );
+});
+
+test('a failed slot write keeps the prior valid slot active and converges on retry', async () => {
+  const root = new MemoryDirectoryHandle();
+  const pyxis = await seedInheritedCard(root, 'active-pack.0', 5, 'seed-pack');
+  const slot0Before = await fileAt(root, 'pyxis-map/active-pack.0');
+  const slot1Handle = await pyxis.getFileHandle('active-pack.1', {create: true});
+  slot1Handle.failOnWrite = true;
+
+  await assert.rejects(
+    installMuiZip({
+      archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+      rootDirectory: root,
+      metadata: {...metadata, packId: 'pack-a'},
+    }),
+    /activation failed; retry with the same ZIP and pack ID/i,
+  );
+  slot1Handle.failOnWrite = false;
+
+  // The style record advanced, but the failed slot write left the prior
+  // valid slot (active-pack.0) intact as the fallback the firmware can use.
+  const styleRecord = decodeActiveSelection(await fileAt(root, 'pyxis-map/map-sets/osm-bright.pmas'));
+  assert.equal(styleRecord.generation, 6);
+  assert.equal(
+    Buffer.from(await fileAt(root, 'pyxis-map/active-pack.0')).toString('hex'),
+    Buffer.from(slot0Before).toString('hex'),
+  );
+  assert.equal((await fileAt(root, 'pyxis-map/active-pack.1')).length, 0);
+
+  // Exact retry re-plans from the advanced style record and converges:
+  // both records carry the same new generation.
+  await installMuiZip({
+    archive: storedZip([['maps/osm-bright/2/1/1.png', PNG]]),
+    rootDirectory: root,
+    metadata: {...metadata, packId: 'pack-a'},
+  });
+  const retryStyle = decodeActiveSelection(await fileAt(root, 'pyxis-map/map-sets/osm-bright.pmas'));
+  const retrySlot = decodeActiveSelection(await fileAt(root, 'pyxis-map/active-pack.1'));
+  assert.equal(retryStyle.generation, retrySlot.generation);
+  assert.equal(retryStyle.generation, 7);
+  assert.deepEqual(retrySlot.packs.map(pack => pack.packId), ['pack-a', 'seed-pack']);
+  assert.equal(
+    Buffer.from(await fileAt(root, 'pyxis-map/active-pack.0')).toString('hex'),
+    Buffer.from(slot0Before).toString('hex'),
+  );
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -11,10 +11,11 @@ import {
   inspectMuiZip,
   installMuiZip,
   parseSparseManifest,
-  resolveMuiStyleProfile,
   planActivation,
+  resolveMuiStyleProfile,
   serializeIndexlessManifest,
   suggestMapIdentity,
+  validateCandidatePacks,
 } from '../../docs/flasher/js/map-installer.js';
 
 const PNG = Buffer.from(
@@ -676,6 +677,171 @@ test('browser activation planning mirrors the CLI plan contract', () => {
     ['new-pack', 'slot-only']);
 });
 
+// Install a one-tile MUI pack, returning the root for follow-up mutation.
+async function installPack(root, archive, meta) {
+  return installMuiZip({archive, rootDirectory: root, metadata: meta});
+}
+
+async function packTreeBytes(root) {
+  const pyxis = root.children.get('pyxis-map');
+  const out = new Map();
+  const walk = async (dir, prefix) => {
+    for (const [name, child] of dir.children.entries()) {
+      const path = prefix ? `${prefix}/${name}` : name;
+      if (child.kind === 'file') {
+        out.set(path, Buffer.from(await (await child.getFile()).arrayBuffer()));
+      } else {
+        await walk(child, path);
+      }
+    }
+  };
+  if (pyxis) await walk(pyxis, 'pyxis-map');
+  return out;
+}
+
+test('browser validates every inherited pack before activation', async () => {
+  const style = getMuiStyleProfile('osm-bright');
+  const metaFor = (packId) => ({
+    ...metadata, packId, attribution: style.attribution, source: style.source, license: style.license,
+  });
+  // Activate pack-a, then pack-b + pack-a, mirroring the CLI A8 fixture.
+  const root = new MemoryDirectoryHandle();
+  await installPack(root, storedZip([['maps/osm-bright/1/0/0.png', PNG]]), metaFor('pack-a'));
+  await installPack(root, storedZip([['maps/osm-bright/1/1/0.png', PNG]]), metaFor('pack-b'));
+  const pyxis = root.children.get('pyxis-map');
+  const mapSets = pyxis.children.get('map-sets');
+  const packs = pyxis.children.get('packs');
+  const styleRecord = new Uint8Array(await (await mapSets.children.get('osm-bright.pmas').getFile()).arrayBuffer());
+  const slot0 = new Uint8Array(await (await pyxis.children.get('active-pack.0').getFile()).arrayBuffer());
+  const slot1 = pyxis.children.get('active-pack.1');
+  const slot1Bytes = slot1
+    ? new Uint8Array(await (await slot1.getFile()).arrayBuffer())
+    : null;
+  const before = await packTreeBytes(root);
+
+  // Missing inherited pack: refusal before any record mutation.
+  await packs.children.get('pack-a').removeEntry('manifest.pmp');
+  await assert.rejects(
+    installPack(root, storedZip([['maps/osm-bright/2/0/0.png', PNG]]), metaFor('pack-c')),
+    /missing inherited pack manifest/i,
+  );
+  // The card is byte-identical after the refusal: both slots and the style
+  // record unchanged, and pack-c was never published. (The only diff from
+  // the pre-refusal tree is the intentionally removed pack-a manifest.)
+  let after = await packTreeBytes(root);
+  const afterRefusal = new Map(after);
+  const beforeRefusal = new Map(before);
+  afterRefusal.delete('pyxis-map/packs/pack-a/manifest.pmp');
+  beforeRefusal.delete('pyxis-map/packs/pack-a/manifest.pmp');
+  assert.deepEqual([...afterRefusal.entries()].sort(), [...beforeRefusal.entries()].sort());
+  assert.equal(after.get('pyxis-map/map-sets/osm-bright.pmas').toString('hex'), Buffer.from(styleRecord).toString('hex'));
+  assert.equal(after.get('pyxis-map/active-pack.0').toString('hex'), Buffer.from(slot0).toString('hex'));
+  if (slot1Bytes) {
+    assert.equal(after.get('pyxis-map/active-pack.1').toString('hex'), Buffer.from(slot1Bytes).toString('hex'));
+  }
+  assert.equal(packs.children.has('pack-c'), false);
+
+  // A second refusal (now for a corrupt inherited manifest path: the
+  // missing manifest) leaves the slots and style record untouched as well.
+  await assert.rejects(
+    installPack(root, storedZip([['maps/osm-bright/2/1/1.png', PNG]]), metaFor('pack-c')),
+    /missing inherited pack manifest/i,
+  );
+  after = await packTreeBytes(root);
+  assert.equal(after.get('pyxis-map/active-pack.0').toString('hex'), Buffer.from(slot0).toString('hex'));
+  assert.equal(after.get('pyxis-map/map-sets/osm-bright.pmas').toString('hex'), Buffer.from(styleRecord).toString('hex'));
+  assert.equal(packs.children.has('pack-c'), false);
+});
+
+test('browser corrupt-inherited-pack refusal keeps the card untouched', async () => {
+  const style = getMuiStyleProfile('osm-bright');
+  const metaFor = (packId) => ({
+    ...metadata, packId, attribution: style.attribution, source: style.source, license: style.license,
+  });
+  const root = new MemoryDirectoryHandle();
+  await installPack(root, storedZip([['maps/osm-bright/1/0/0.png', PNG]]), metaFor('pack-a'));
+  const pyxis = root.children.get('pyxis-map');
+  const packs = pyxis.children.get('packs');
+  const before = await packTreeBytes(root);
+
+  // Corrupt the inherited manifest, then install pack-c.
+  const manifest = await fileAt(root, 'pyxis-map/packs/pack-a/manifest.pmp');
+  const corrupt = new Uint8Array(manifest);
+  corrupt[0] ^= 1;
+  const corruptHandle = await packs.children.get('pack-a').getFileHandle('manifest.pmp', {create: true});
+  const corruptWritable = await corruptHandle.createWritable({keepExistingData: false});
+  await corruptWritable.write(corrupt);
+  await corruptWritable.close();
+
+  await assert.rejects(
+    installPack(root, storedZip([['maps/osm-bright/2/0/0.png', PNG]]), metaFor('pack-c')),
+    /manifest header or CRC is invalid|missing inherited/i,
+  );
+
+  const after = await packTreeBytes(root);
+  // Restore the corrupted manifest's original bytes in the snapshot: every
+  // other file must be byte-identical to the pre-corruption state.
+  const afterExpected = new Map(after);
+  afterExpected.set('pyxis-map/packs/pack-a/manifest.pmp', Buffer.from(manifest));
+  assert.deepEqual([...afterExpected.entries()].sort(), [...before.entries()].sort());
+  assert.equal(packs.children.has('pack-c'), false);
+});
+
+test('browser validateCandidatePacks rejects v1/v2 and policy-mismatched manifests', async () => {
+  const style = getMuiStyleProfile('osm-bright');
+  const root = new MemoryDirectoryHandle();
+  await installPack(root, storedZip([['maps/osm-bright/1/0/0.png', PNG]]), {
+    ...metadata, attribution: style.attribution, source: style.source, license: style.license,
+  });
+  const pyxis = root.children.get('pyxis-map');
+  const packs = pyxis.children.get('packs');
+  const policyCheck = () => validateCandidatePacks(
+    pyxis, 'osm-bright', style.attribution, ['overview']);
+  await policyCheck();
+
+  // A legal legacy v2 manifest (spans present) must be rejected as not v3.
+  const parts = [];
+  const pushU16 = (value) => { parts.push(value & 0xff, value >> 8); };
+  const pushU32 = (value) => {
+    parts.push(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, (value >>> 24) & 0xff);
+  };
+  const pushSized = (text) => {
+    const bytes = [...new TextEncoder().encode(text)];
+    parts.push(bytes.length, ...bytes);
+  };
+  pushU32(0x4b504d50); parts.push(2, 0); pushU16(16); pushU32(0); pushU32(0);
+  pushSized('overview'); pushSized('Overview');
+  pushSized(style.attribution); pushSized(style.source); pushSized(style.license);
+  parts.push(1, 1); pushU16(1); pushU32(1);
+  parts.push(1); pushU32(0); pushU32(0); pushU32(1);
+  const inner = new Uint8Array(parts);
+  const totalLength = inner.length + 4;
+  inner[8] = totalLength & 0xff;
+  inner[9] = (totalLength >> 8) & 0xff;
+  inner[10] = (totalLength >> 16) & 0xff;
+  inner[11] = (totalLength >>> 24) & 0xff;
+  const v2Record = new Uint8Array(inner.length + 4);
+  v2Record.set(inner);
+  new DataView(v2Record.buffer).setUint32(v2Record.length - 4, crc32(inner), true);
+  const replaceManifest = async (bytes) => {
+    const handle = await packs.children.get('overview').getFileHandle('manifest.pmp', {create: true});
+    const writable = await handle.createWritable({keepExistingData: false});
+    await writable.write(bytes);
+    await writable.close();
+  };
+  await replaceManifest(v2Record);
+  await assert.rejects(policyCheck(), /not PMPK v3/i);
+
+  // A v3 manifest declaring a different pack ID is rejected. Rebuild a legal
+  // v3 manifest with a 6-byte ID so every later string offset stays exact.
+  const renamedManifest = serializeIndexlessManifest({
+    packId: 'otherm', name: 'Overview', attribution: style.attribution,
+    source: style.source, license: style.license,
+  }, 1, 1, 1);
+  await replaceManifest(renamedManifest);
+  await assert.rejects(policyCheck(), /different pack ID/i);
+});
+
 test('indexless active map-set wire format contains ordered pack IDs only', () => {
   const record = encodeActiveMapSet({generation:1,mapSetId:'osm-bright',attribution:'Map data attribution',packs:[
     {packId:'detail'},
@@ -1122,6 +1288,6 @@ test('map-set capacity is checked before a ninth pack is published', async () =>
   await writable.write(encodeActiveMapSet({generation:8,mapSetId:'osm-bright',attribution:metadata.attribution,packs:
     Array.from({length:8}, (_,index) => ({packId:`pack-${index}`}))}));
   await writable.close();
-  await assert.rejects(installMuiZip({archive,rootDirectory:root,metadata:{...metadata,packId:'pack-nine',name:'Pack Nine'}}), /active map set/i);
+  await assert.rejects(installMuiZip({archive,rootDirectory:root,metadata:{...metadata,packId:'pack-nine',name:'Pack Nine'}}), /8-pack/i);
   assert.equal(pyxis.children.has('packs'), false);
 });

--- a/tests/web/test_map_installer.mjs
+++ b/tests/web/test_map_installer.mjs
@@ -193,6 +193,15 @@ async function child(root, path) {
   return current;
 }
 
+async function fileAt(root, path) {
+  const parts = path.split('/');
+  let current = root;
+  for (const part of parts.slice(0, -1)) current = current.children.get(part);
+  const file = current.children.get(parts.at(-1));
+  if (!file || file.kind !== 'file') throw new Error(`test helper: not a file: ${path}`);
+  return new Uint8Array(await (await file.getFile()).arrayBuffer());
+}
+
 test('filesystem mock matches browser File System Access API semantics', async () => {
   // Repeated create:true on an existing file must return the same handle,
   // exactly like browsers (no exclusive-create behavior).
@@ -465,6 +474,99 @@ test('rejects installing a detected style into a different map set', async () =>
   await assert.rejects(
     installMuiZip({archive, rootDirectory:root, metadata}),
     /style.*selected map set/i,
+  );
+  assert.equal(root.children.has('pyxis-map'), false);
+});
+
+test('style-qualified MUI install publishes an indexless PMPK v3 manifest', async () => {
+  const archive = storedZip([
+    ['maps/osm-bright/2/1/1.png', PNG],
+    ['maps/osm-bright/2/1/0.png', PNG],
+  ]);
+  const root = new MemoryDirectoryHandle();
+  const result = await installMuiZip({archive, rootDirectory:root, metadata});
+  assert.equal(result.resumed, false);
+  const pack = await child(root, 'pyxis-map/packs/overview');
+  const stored = await fileAt(root, 'pyxis-map/packs/overview/manifest.pmp');
+  const parsed = parseSparseManifest(stored);
+  assert.equal(parsed.packId, 'overview');
+  assert.equal(parsed.name, 'Overview');
+  assert.equal(parsed.attribution, metadata.attribution);
+  assert.equal(parsed.source, metadata.source);
+  assert.equal(parsed.license, metadata.license);
+  assert.equal(parsed.minZoom, 2);
+  assert.equal(parsed.maxZoom, 2);
+  assert.equal(parsed.tileCount, 2);
+  assert.deepEqual(parsed.rowSpans, []);
+  // No ownership receipt or other stray entries may remain in the pack.
+  assert.deepEqual([...pack.children.keys()].sort(), ['manifest.pmp', 'tiles']);
+});
+
+test('rootless ZIP with a selected style publishes the matching PMPK v3 manifest', async () => {
+  const archive = storedZip([
+    ['0/0/0.png', PNG],
+    ['1/0/0.png', PNG],
+    ['1/1/0.png', PNG],
+    ['1/0/1.png', PNG],
+    ['1/1/1.png', PNG],
+  ]);
+  const root = new MemoryDirectoryHandle();
+  const style = resolveMuiStyleProfile(null, 'toner');
+  const result = await installMuiZip({archive, rootDirectory:root, metadata:{
+    ...metadata, mapSetId:style.id, attribution:style.attribution,
+    source:style.source, license:style.license,
+  }});
+  assert.equal(result.resumed, false);
+  const stored = await fileAt(root, 'pyxis-map/packs/overview/manifest.pmp');
+  const parsed = parseSparseManifest(stored);
+  assert.equal(parsed.attribution, style.attribution);
+  assert.equal(parsed.source, style.source);
+  assert.equal(parsed.license, style.license);
+  assert.equal(parsed.minZoom, 0);
+  assert.equal(parsed.maxZoom, 1);
+  assert.equal(parsed.tileCount, 5);
+  assert.deepEqual(parsed.rowSpans, []);
+});
+
+test('the PMPK v3 manifest is published after the last tile and read back', async () => {
+  const archive = storedZip([['2/1/1.png', PNG], ['2/1/0.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  const writes = [];
+  const originalCreateWritable = MemoryFileHandle.prototype.createWritable;
+  MemoryFileHandle.prototype.createWritable = async function () {
+    const writable = await originalCreateWritable.call(this);
+    const name = this.name;
+    const originalClose = writable.close;
+    writable.close = async () => { await originalClose.call(writable); writes.push(name); };
+    return writable;
+  };
+  try {
+    await installMuiZip({archive, rootDirectory:root, metadata});
+  } finally {
+    MemoryFileHandle.prototype.createWritable = originalCreateWritable;
+  }
+  const manifestIndex = writes.indexOf('manifest.pmp');
+  assert.notEqual(manifestIndex, -1, 'manifest must be written');
+  const tileNames = writes.filter(name => name.endsWith('.png'));
+  assert.equal(tileNames.length, 2);
+  for (const name of tileNames) {
+    assert.ok(
+      writes.indexOf(name) < manifestIndex,
+      `tile ${name} must be written before the manifest: ${JSON.stringify(writes)}`,
+    );
+  }
+  // The published manifest must decode from the on-disk bytes (read-back).
+  const stored = await fileAt(root, 'pyxis-map/packs/overview/manifest.pmp');
+  assert.equal(parseSparseManifest(stored).tileCount, 2);
+});
+
+test('policy mismatch after a detected style refuses before any SD write', async () => {
+  const archive = storedZip([['maps/osm-bright/2/1/1.png', PNG]]);
+  const root = new MemoryDirectoryHandle();
+  await assert.rejects(
+    installMuiZip({archive, rootDirectory:root,
+      metadata:{...metadata, license:'CC-BY-3.0'}}),
+    /attribution|provenance/i,
   );
   assert.equal(root.children.has('pyxis-map'), false);
 });


### PR DESCRIPTION
## Summary

Browser-side half of the safe map-pack v3 writer work. Ports the PR A (CLI)
wire formats and activation ordering into the Pyxis web flasher so the browser
can install, validate, and activate offline map packs to the T-Deck SD card with
byte-identical PMPK/PMAS v3 output to the CLI.

Companion to PR A (merged at `954c1a8`), which added the CLI v3 writers in
`tools/maps/build_map_pack.py`. This PR adds the matching browser implementation
in `docs/flasher/js/map-installer.js` and the flasher UI wiring.

## What changed

**Codecs (byte-parity with CLI + frozen vectors)**
- PMPK v3 indexless manifest: serialize/parse (`serializeIndexlessManifest` /
  `parseSparseManifest`). Header `<4sBBHII` magic `PMPK` version 3, trailing
  min/max zoom + tile_count + CRC32 (zlib). v3 ⟺ indexless (`rowSpans.length === 0`).
- PMAS v3 active map set: encode/decode. Body `PMAS` version 3, u16 total_length
  at [6:8], CRC32 over the length-patched prefix, record = body + crc u32.
  v1 stays a fixed 48 bytes.
- Style PMAS written + read-back **first**, then the active slot, matching the
  CLI's publish ordering.

**Activation planning & publishing**
- Inherited-composition preflight: validate *every* inherited pack before any
  mutation (a failed preflight creates no pack dir and changes no style or
  slot bytes) — this is what correctly fails closed on a half-migrated card.
- `planActivation` derives the PMAS v3 record; slot-equality check compares the
  **full decoded record** (CLI parity) so v1/v3 same-generation collisions are
  caught, not just the normalized fields.
- Generation rule: `max(present same-style slot gens, style gen) + 1`.
- Single-writer ordering; `MAX_ACTIVE_PACKS=8`, `MAX_MANIFEST_BYTES=7100`.

**Concurrency**
- Web Locks scoped to same-origin tabs in the same browser profile
  (`pyxis-map-installer:<rootName>`), fail-closed, empty root name rejected.
  Docs + flasher UI carry the single-writer contract (close other flasher tabs;
  do not run the CLI at the same time). Web Locks do **not** coordinate with the
  CLI or other profiles — stated explicitly, not overclaimed.

**Progress reporting**
- The flasher UI now reports every install phase (validate / checking / write /
  manifest / activating) instead of only the tile-write phase, so large packs
  show steady motion rather than appearing frozen during the validate sweep.

**No invented APIs, no network path**
- No `exclusive` create / `FileExistsError` File System API options.
- No network tile-fetch path introduced.

## Test plan / evidence (exact head `a10e538`)

- [x] `node --test tests/web/test_map_installer.mjs` — 44/44 (incl. frozen-vector
      round-trips both directions, v1/v3 collision regression, progress-phase
      ordering regression)
- [x] `pytest tests/build_scripts/test_map_web_installer_contract.py`
      `tests/tools/test_build_map_pack.py` `tests/native/test_map_tile_pack.py`
      `tests/native/test_map_style_catalog.py` — 133 passed
- [x] Chromium OPFS install smoke (real browser, cached chromium-1223):
      install / read-back / reload / exclusive-guard all true. **Kept as a
      documented pre-publication command, not CI** (repo CI provisions no
      Chromium).
- [x] `pio run -e tdeck` and `pio run -e tdeck-release` — SUCCESS (firmware
      untouched by this PR)
- [x] Release audit: `git diff --check` clean; forbidden marker/TTL/lease terms
      appear only in tests/comments; no secrets/local paths/private endpoints;
      all production exports are runtime APIs; no network tile-fetch path.
- [x] Independent exact-head review returned GO; findings folded in.

## Physical acceptance (performed on the real T-Deck)

- [x] Browser install of a test pack on a clean card: all five phases observed,
      verified completion message.
- [x] Large world pack install (z0–z9) via the browser: completes (slow —
      validate sweep + per-tile verified writes over USB/SD).
- [ ] Reboot persistence + Maps render on the physical device: pending final
      confirmation.

## Notes

- The Chromium smoke is a pre-publication local command by design; a follow-up
  CI issue may be opened to provision Chromium if desired.
- Scale note: first-time install of a multi-thousand-tile pack is multi-minute
  by construction (full-ZIP validate sweep, then per-tile write + full read-back).
  Progress is now visible per phase. A follow-up (CRC-based read-back instead of
  a full byte loop) is a candidate if the per-tile verified-write is confirmed as
  the dominant cost.
