### PR TITLE
feat: auto path-request for unknown LXMF sources

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -170,8 +170,8 @@ uint64_t monotonicMillis() {
 }
 
 // ---------------------------------------------------------------------------
-// App-only diagnostic: on-demand identity acquisition for unknown LXMF
-// sources (mirrors Sideband's "Query Network For Keys" button).
+// On-demand identity acquisition for unknown LXMF sources (mirrors
+// Sideband's "Query Network For Keys" button).
 //
 // When an LXMF message arrives from a source whose RNS identity has not been
 // learned, the router accepts the message but UIManager::on_message_received
@@ -184,10 +184,13 @@ uint64_t monotonicMillis() {
 // key (the hub, a phone, or another node) can answer with the cached
 // announce. The next message from that peer then validates and plots.
 //
-// The rate-limit policy lives in UnknownSourceKeyRequest.h (host-tested);
-// only the Transport::request_path side effect stays here. Diagnostic for
-// the missing-map-pin investigation; remove with the other ingest
-// diagnostics once the root cause closes.
+// Rate limiting (UnknownSourceKeyRequest.h, host-tested): one automatic
+// path request per 30 minutes per unknown identity, with at most
+// kMaxTrackedSources open request windows in total. While the table is
+// saturated with unexpired windows, new identities are deferred (at most
+// one window) instead of evicting someone else's open window, so neither
+// an honest user's repeat traffic nor a flood of bogus identities can
+// force the network to answer unbounded path requests.
 namespace {
 UnknownSourceKeyRequestPolicy s_key_request_policy;
 
@@ -1704,9 +1707,6 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
         if (location_decision.log_malformed) {
             WARNING("Malformed inbound location field ignored");
         }
-        // App-only diagnostic: tracks the store outcome for the ingest line.
-        // Temporary until the missing-map-pin investigation is closed.
-        int ingest_diag_result = -1;
         if (location_decision.apply_location) {
             const uint64_t location_wall_now =
                 static_cast<uint64_t>(RNS::Utilities::OS::ltime());
@@ -1723,7 +1723,6 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
                         location_decision.location,
                         location_decision.meta,
                         location_decision.received_at_millis);
-                ingest_diag_result = static_cast<int>(location_result);
                 if (location_result != Telemetry::PeerLocationResult::STALE &&
                     location_result != Telemetry::PeerLocationResult::NOT_FOUND &&
                     location_result != Telemetry::PeerLocationResult::INVALID_ARGUMENT) {
@@ -1733,27 +1732,6 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
             } else {
                 WARNING("Location state not restored; inbound update ignored");
             }
-        }
-        // App-only diagnostic: one bounded line per inbound location frame.
-        // Reports peer, policy branch, decoded fix, source-clock skew, and
-        // store result (0=INSERTED 1=UPDATED 4=STALE 5=EXPIRED 6=INVALID).
-        // Temporary until the missing-map-pin investigation is closed;
-        // remove with the fix.
-        {
-            const int64_t source_ts = static_cast<int64_t>(
-                location_decision.location.timestamp_seconds) * 1000LL;
-            const int64_t skew_millis = static_cast<int64_t>(
-                location_decision.received_at_millis) - source_ts;
-            INFOF(
-                "  Location ingest: peer %02x%02x kind=%d result=%d lat=%.4f "
-                "lon=%.4f src_age=%lldms",
-                (int)location_decision.authenticated_sender.bytes[14],
-                (int)location_decision.authenticated_sender.bytes[15],
-                (int)location_decision.kind,
-                ingest_diag_result,
-                (double)location_decision.location.latitude_e6 / 1000000.0,
-                (double)location_decision.location.longitude_e6 / 1000000.0,
-                (long long)skew_millis);
         }
         if (!location_decision.persist) {
             INFO("  Location telemetry processed without chat persistence");

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -168,6 +168,62 @@ uint64_t monotonicMillis() {
     return static_cast<uint64_t>(esp_timer_get_time() / 1000LL);
 }
 
+// ---------------------------------------------------------------------------
+// App-only diagnostic: on-demand identity acquisition for unknown LXMF
+// sources (mirrors Sideband's "Query Network For Keys" button).
+//
+// When an LXMF message arrives from a source whose RNS identity has not been
+// learned, the router accepts the message but UIManager::on_message_received
+// skips location ingest for unauthenticated senders. Nothing in the firmware
+// ever triggered the identity learning that microLXMF's comment at
+// LXMRouter.cpp:1267 expects ("signature will be validated later if the
+// source identity is learned via announce"). This fires a bounded
+// RNS path request — the exact mechanism of Sideband's
+// RNS.Transport.request_path — so any peer that already knows the source's
+// key (the hub, a phone, or another node) can answer with the cached
+// announce. The next message from that peer then validates and plots.
+//
+// Rate-limited per source hash (5 min) and globally (64 entries) to keep
+// opportunistic-flood cost to zero in the steady state. Diagnostic for the
+// missing-map-pin investigation; remove with the other ingest diagnostics
+// once the root cause is closed.
+namespace {
+struct KeyRequestState {
+    std::vector<std::pair<std::string, uint64_t>> last_requested;
+};
+KeyRequestState s_key_request_state;
+
+void request_key_for_unknown_source(const ::LXMF::LXMessage& message) {
+    if (message.unverified_reason() !=
+        ::LXMF::Type::Message::SOURCE_UNKNOWN) {
+        return;  // Bad signature is not recoverable by asking the network.
+    }
+    const RNS::Bytes& source_hash = message.source_hash();
+    if (source_hash.size() != Telemetry::PEER_ID_SIZE) {
+        return;
+    }
+    const std::string source_hex = source_hash.toHex();
+    const uint64_t now = monotonicMillis();
+    const static constexpr uint64_t kKeyRequestIntervalMillis = 5 * 60 * 1000;
+    for (auto& e : s_key_request_state.last_requested) {
+        if (e.first == source_hex) {
+            if (now < e.second + kKeyRequestIntervalMillis) {
+                return;  // Recently requested — wait for the answer to land.
+            }
+            e.second = now;  // Expired — re-request below.
+            break;
+        }
+    }
+    if (s_key_request_state.last_requested.size() >= 64U) {
+        s_key_request_state.last_requested.erase(s_key_request_state.last_requested.begin());
+    }
+    s_key_request_state.last_requested.emplace_back(source_hex, now);
+    INFO(("Requesting network keys for unknown LXMF source " +
+          source_hex.substr(0, 8) + "...").c_str());
+    Transport::request_path(source_hash);
+}
+}  // namespace
+
 bool peerIdFromHash(const Bytes& hash, Telemetry::PeerId& output) {
     if (hash.size() != Telemetry::PEER_ID_SIZE) return false;
     std::memcpy(output.bytes, hash.data(), Telemetry::PEER_ID_SIZE);
@@ -1584,6 +1640,14 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
 #ifdef PYXIS_TEST_HOOKS
     pyxis_test_hook_record_rx(message);
 #endif
+
+    // Diagnostic: unauthenticated messages are accepted by the router but
+    // skipped below for location ingest. Ask the network for the source's
+    // key (Sideband "request keys" equivalent) so the NEXT message from
+    // this peer can validate and be plotted.
+    if (!message.signature_validated()) {
+        request_key_for_unknown_source(message);
+    }
 
     // Classify authenticated location fields before any conversation write.
     // Raw field keys and values are MessagePack spans retained by LXMessage.

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -26,6 +26,7 @@
 #include <microReticulum/Utilities/OS.h>
 #include <esp_heap_caps.h>
 #include <esp_timer.h>
+#include "UnknownSourceKeyRequest.h"
 #include <cstring>
 #include <new>
 #include <utility>
@@ -183,15 +184,12 @@ uint64_t monotonicMillis() {
 // key (the hub, a phone, or another node) can answer with the cached
 // announce. The next message from that peer then validates and plots.
 //
-// Rate-limited per source hash (5 min) and globally (64 entries) to keep
-// opportunistic-flood cost to zero in the steady state. Diagnostic for the
-// missing-map-pin investigation; remove with the other ingest diagnostics
-// once the root cause is closed.
+// The rate-limit policy lives in UnknownSourceKeyRequest.h (host-tested);
+// only the Transport::request_path side effect stays here. Diagnostic for
+// the missing-map-pin investigation; remove with the other ingest
+// diagnostics once the root cause closes.
 namespace {
-struct KeyRequestState {
-    std::vector<std::pair<std::string, uint64_t>> last_requested;
-};
-KeyRequestState s_key_request_state;
+UnknownSourceKeyRequestPolicy s_key_request_policy;
 
 void request_key_for_unknown_source(const ::LXMF::LXMessage& message) {
     if (message.unverified_reason() !=
@@ -204,20 +202,10 @@ void request_key_for_unknown_source(const ::LXMF::LXMessage& message) {
     }
     const std::string source_hex = source_hash.toHex();
     const uint64_t now = monotonicMillis();
-    const static constexpr uint64_t kKeyRequestIntervalMillis = 5 * 60 * 1000;
-    for (auto& e : s_key_request_state.last_requested) {
-        if (e.first == source_hex) {
-            if (now < e.second + kKeyRequestIntervalMillis) {
-                return;  // Recently requested — wait for the answer to land.
-            }
-            e.second = now;  // Expired — re-request below.
-            break;
-        }
+    if (!s_key_request_policy.should_request(source_hex, now)) {
+        return;  // Recently requested — wait for the answer to land.
     }
-    if (s_key_request_state.last_requested.size() >= 64U) {
-        s_key_request_state.last_requested.erase(s_key_request_state.last_requested.begin());
-    }
-    s_key_request_state.last_requested.emplace_back(source_hex, now);
+    s_key_request_policy.record_request(source_hex, now);
     INFO(("Requesting network keys for unknown LXMF source " +
           source_hex.substr(0, 8) + "...").c_str());
     Transport::request_path(source_hash);
@@ -877,6 +865,31 @@ void UIManager::update() {
         const std::size_t peer_count = _peer_locations.snapshot(
             wall_now_millis, MAP_PEER_MAX_AGE_MS, peers,
             Telemetry::MAX_PEER_LOCATIONS);
+        // App-only diagnostic: edge-triggered so it stays quiet while the
+        // map sits idle. Temporary until the missing-map-pin investigation
+        // is closed; remove with the fix.
+        {
+            const std::size_t total = _peer_locations.size();
+            const int blocked =
+                location_state != Telemetry::LocationControllerState::READY
+                    ? 1 : 0;
+            static std::size_t last_total = static_cast<std::size_t>(-1);
+            static std::size_t last_visible = static_cast<std::size_t>(-1);
+            static int last_blocked = -1;
+            static bool have_last = false;
+            if (!have_last || last_total != total ||
+                last_visible != peer_count || last_blocked != blocked) {
+                have_last = true;
+                last_total = total;
+                last_visible = peer_count;
+                last_blocked = blocked;
+                INFOF(
+                    "  Map snapshot: store=%s total=%llu visible=%llu",
+                    blocked ? "BLOCKED" : "READY",
+                    (unsigned long long)total,
+                    (unsigned long long)peer_count);
+            }
+        }
         Pyxis::MapView::Request map_request{};
         map_request.center = {0.0, 0.0};
         map_request.zoom = 2U;
@@ -1691,6 +1704,9 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
         if (location_decision.log_malformed) {
             WARNING("Malformed inbound location field ignored");
         }
+        // App-only diagnostic: tracks the store outcome for the ingest line.
+        // Temporary until the missing-map-pin investigation is closed.
+        int ingest_diag_result = -1;
         if (location_decision.apply_location) {
             const uint64_t location_wall_now =
                 static_cast<uint64_t>(RNS::Utilities::OS::ltime());
@@ -1707,6 +1723,7 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
                         location_decision.location,
                         location_decision.meta,
                         location_decision.received_at_millis);
+                ingest_diag_result = static_cast<int>(location_result);
                 if (location_result != Telemetry::PeerLocationResult::STALE &&
                     location_result != Telemetry::PeerLocationResult::NOT_FOUND &&
                     location_result != Telemetry::PeerLocationResult::INVALID_ARGUMENT) {
@@ -1716,6 +1733,27 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
             } else {
                 WARNING("Location state not restored; inbound update ignored");
             }
+        }
+        // App-only diagnostic: one bounded line per inbound location frame.
+        // Reports peer, policy branch, decoded fix, source-clock skew, and
+        // store result (0=INSERTED 1=UPDATED 4=STALE 5=EXPIRED 6=INVALID).
+        // Temporary until the missing-map-pin investigation is closed;
+        // remove with the fix.
+        {
+            const int64_t source_ts = static_cast<int64_t>(
+                location_decision.location.timestamp_seconds) * 1000LL;
+            const int64_t skew_millis = static_cast<int64_t>(
+                location_decision.received_at_millis) - source_ts;
+            INFOF(
+                "  Location ingest: peer %02x%02x kind=%d result=%d lat=%.4f "
+                "lon=%.4f src_age=%lldms",
+                (int)location_decision.authenticated_sender.bytes[14],
+                (int)location_decision.authenticated_sender.bytes[15],
+                (int)location_decision.kind,
+                ingest_diag_result,
+                (double)location_decision.location.latitude_e6 / 1000000.0,
+                (double)location_decision.location.longitude_e6 / 1000000.0,
+                (long long)skew_millis);
         }
         if (!location_decision.persist) {
             INFO("  Location telemetry processed without chat persistence");

--- a/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
+++ b/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// On-demand identity acquisition policy for unknown LXMF sources.
+//
+// When an LXMF message is delivered to us from a source whose RNS identity
+// has not been learned, the router accepts the message (microLXMF treats
+// SOURCE_UNKNOWN as "will validate later if the identity is learned via
+// announce") but location ingest is skipped for unauthenticated senders.
+// Nothing ever triggered that learning, so an unknown peer stayed unknown
+// until — and unless — a natural announce happened to arrive.
+//
+// This policy mirrors Sideband's "Query Network For Keys" button
+// (RNS.Transport.request_path): the caller fires a broadcast RNS path
+// request for the source hash, and any peer that already holds the
+// source's cached announce (a phone on the same link, a hub, another node)
+// answers with it. The next message from that peer then validates.
+//
+// The decision is pure and host-testable; the Transport::request_path call
+// stays in the UI layer (see UIManager::on_message_received).
+//
+// Only SOURCE_UNKNOWN should ever be passed here: an invalid signature
+// from a KNOWN identity is not recoverable by asking the network for the
+// same key it already has.
+// ---------------------------------------------------------------------------
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace UI {
+namespace LXMF {
+
+struct UnknownSourceKeyRequestPolicy {
+    static constexpr unsigned long long kCooldownMillis = 5U * 60U * 1000U;
+    static constexpr unsigned kMaxTrackedSources = 64U;
+
+    std::vector<std::pair<std::string, unsigned long long>> last_requested;
+
+    bool should_request(const std::string& source_hex,
+                        unsigned long long now_millis) const {
+        for (const auto& entry : last_requested) {
+            if (entry.first == source_hex) {
+                return now_millis >=
+                       entry.second + kCooldownMillis;
+            }
+        }
+        return true;
+    }
+
+    void record_request(const std::string& source_hex,
+                        unsigned long long now_millis) {
+        for (auto& entry : last_requested) {
+            if (entry.first == source_hex) {
+                entry.second = now_millis;
+                return;
+            }
+        }
+        if (last_requested.size() >= kMaxTrackedSources) {
+            last_requested.erase(last_requested.begin());
+        }
+        last_requested.emplace_back(source_hex, now_millis);
+    }
+};
+
+}  // namespace LXMF
+}  // namespace UI

--- a/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
+++ b/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
@@ -59,7 +59,8 @@ struct UnknownSourceKeyRequestPolicy {
 
     struct Entry {
         std::string source_hex;
-        unsigned long long last_requested_millis = 0;
+        unsigned long long last_requested_millis;
+        Entry() : last_requested_millis(0) {}
     };
 
     // One entry per fired request whose window is still open.
@@ -110,7 +111,10 @@ struct UnknownSourceKeyRequestPolicy {
             // unauthorized request).
             return;
         }
-        last_requested.push_back(Entry{source_hex, now_millis});
+        Entry entry;
+        entry.source_hex = source_hex;
+        entry.last_requested_millis = now_millis;
+        last_requested.push_back(entry);
     }
 };
 

--- a/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
+++ b/lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h
@@ -22,6 +22,23 @@
 // Only SOURCE_UNKNOWN should ever be passed here: an invalid signature
 // from a KNOWN identity is not recoverable by asking the network for the
 // same key it already has.
+//
+// Rate limit, two independent bounds:
+//   1. Per-identity: at most one automatic path request per unknown
+//      identity per 30 minutes. Once the first request fires, the source's
+//      window is tracked and never dropped before it expires, so no
+//      identity can force a second request within its window — an
+//      eviction of one source cannot reset another's cooldown.
+//   2. Aggregate: at most kMaxTrackedSources automatic requests per
+//      rolling 30-minute window in total (a request budget that expires
+//      with the requests it counts). While the budget is exhausted,
+//      never-before-seen identities are declined even though their own
+//      per-identity window is empty; once their budget slots free up they
+//      may fire. This caps the worst-case network cost of a flood of
+//      rotating bogus identities at kMaxTrackedSources path requests per
+//      window, instead of leaving the answer bandwidth unbounded.
+//      Cost: a 65th honest new peer in a congested window is deferred by
+//      at most one 30-minute window.
 // ---------------------------------------------------------------------------
 
 #include <cstddef>
@@ -34,34 +51,66 @@ namespace UI {
 namespace LXMF {
 
 struct UnknownSourceKeyRequestPolicy {
-    static constexpr unsigned long long kCooldownMillis = 5U * 60U * 1000U;
+    static constexpr unsigned long long kCooldownMillis = 30U * 60U * 1000U;
+    // Aggregate bound: maximum number of automatic path requests in any
+    // rolling 30-minute window. Also bounds the per-source tracking table
+    // (one open window per fired request).
     static constexpr unsigned kMaxTrackedSources = 64U;
 
-    std::vector<std::pair<std::string, unsigned long long>> last_requested;
+    struct Entry {
+        std::string source_hex;
+        unsigned long long last_requested_millis = 0;
+    };
 
-    bool should_request(const std::string& source_hex,
-                        unsigned long long now_millis) const {
-        for (const auto& entry : last_requested) {
-            if (entry.first == source_hex) {
-                return now_millis >=
-                       entry.second + kCooldownMillis;
+    // One entry per fired request whose window is still open.
+    std::vector<Entry> last_requested;
+
+    // Drop entries whose window has fully elapsed. O(n) with n <=
+    // kMaxTrackedSources; called lazily on every decision.
+    void prune_expired(unsigned long long now_millis) {
+        for (unsigned i = 0; i < last_requested.size();) {
+            if (now_millis >=
+                last_requested[i].last_requested_millis + kCooldownMillis) {
+                last_requested.erase(last_requested.begin() + i);
+            } else {
+                ++i;
             }
         }
-        return true;
+    }
+
+    bool should_request(const std::string& source_hex,
+                        unsigned long long now_millis) {
+        for (const auto& entry : last_requested) {
+            if (entry.source_hex == source_hex) {
+                return now_millis >=
+                       entry.last_requested_millis + kCooldownMillis;
+            }
+        }
+        // Not seen since its own window expired: the request is allowed
+        // only if the aggregate budget has room, so a flood of distinct
+        // identities cannot force more than kMaxTrackedSources requests
+        // per window.
+        prune_expired(now_millis);
+        return last_requested.size() < kMaxTrackedSources;
     }
 
     void record_request(const std::string& source_hex,
                         unsigned long long now_millis) {
         for (auto& entry : last_requested) {
-            if (entry.first == source_hex) {
-                entry.second = now_millis;
+            if (entry.source_hex == source_hex) {
+                entry.last_requested_millis = now_millis;
                 return;
             }
         }
+        prune_expired(now_millis);
         if (last_requested.size() >= kMaxTrackedSources) {
-            last_requested.erase(last_requested.begin());
+            // Defensive: should_request() gates this; if the budget is
+            // full the request was not authorized and must not be
+            // recorded (recording would extend the budget for an
+            // unauthorized request).
+            return;
         }
-        last_requested.emplace_back(source_hex, now_millis);
+        last_requested.push_back(Entry{source_hex, now_millis});
     }
 };
 

--- a/tests/native/test_unknown_source_key_request.cpp
+++ b/tests/native/test_unknown_source_key_request.cpp
@@ -1,0 +1,140 @@
+// Host test for the unknown-source key-request policy
+// (lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h).
+//
+// The policy decides when the firmware fires an RNS path request for an
+// LXMF message from an identity it has not learned (Sideband's "Query
+// Network For Keys" equivalent). The decision must be pure and bounded:
+// one request per source per cooldown, independent per source, and a
+// capped tracking table so an opportunistic flood of unknown senders can
+// neither hammer the transport nor starve the table forever.
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+#include "UI/LXMF/UnknownSourceKeyRequest.h"
+
+namespace {
+
+int passed = 0;
+int failures = 0;
+
+#define CHECK(expr)                                                                 \
+    do {                                                                            \
+        if (expr) {                                                                 \
+            ++passed;                                                               \
+        } else {                                                                    \
+            ++failures;                                                             \
+            std::cerr << "FAIL line " << __LINE__ << ": " << #expr << '\n';         \
+        }                                                                           \
+    } while (false)
+
+using UI::LXMF::UnknownSourceKeyRequestPolicy;
+
+std::string sourceHex(unsigned seed) {
+    // Distinct 8-hex string per seed up to 0xffffff (the tests use <= 65),
+    // so the capacity-cap test has no hash collisions.
+    const char* digits = "0123456789abcdef";
+    std::string hex;
+    for (unsigned shift : {28U, 24U, 20U, 16U, 12U, 8U, 4U, 0U}) {
+        hex += digits[(seed >> shift) & 0xFU];
+    }
+    return hex;
+}
+
+void testNewSourceIsRequested() {
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string src = sourceHex(1);
+    CHECK(policy.should_request(src, 0));
+    CHECK(policy.should_request(src, 12345));
+}
+
+void testCooldownSuppressesRepeat() {
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string src = sourceHex(2);
+    policy.record_request(src, 1000);
+    // Within the 5-minute cooldown: suppressed.
+    CHECK(!policy.should_request(src, 1001));
+    CHECK(!policy.should_request(src, 1000 + UnknownSourceKeyRequestPolicy::kCooldownMillis - 1));
+    // At and after the cooldown: requested again.
+    CHECK(policy.should_request(src, 1000 + UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    CHECK(policy.should_request(src, 1000 + UnknownSourceKeyRequestPolicy::kCooldownMillis + 500));
+}
+
+void testReRecordResetsCooldown() {
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string src = sourceHex(3);
+    policy.record_request(src, 0);
+    CHECK(policy.should_request(src, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    // A fresh request near the original expiry restarts the window.
+    policy.record_request(src, UnknownSourceKeyRequestPolicy::kCooldownMillis - 1000);
+    CHECK(!policy.should_request(src, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    CHECK(!policy.should_request(src, 2 * UnknownSourceKeyRequestPolicy::kCooldownMillis - 1001));
+    CHECK(policy.should_request(src, 2 * UnknownSourceKeyRequestPolicy::kCooldownMillis - 1000));
+}
+
+void testSourcesTrackedIndependently() {
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string a = sourceHex(4);
+    const std::string b = sourceHex(5);
+    policy.record_request(a, 100);
+    CHECK(!policy.should_request(a, 200));
+    CHECK(policy.should_request(b, 200));  // b unaffected by a's request
+    policy.record_request(b, 200);
+    CHECK(!policy.should_request(a, 300));
+    CHECK(!policy.should_request(b, 300));
+}
+
+void testCapacityCapEvictsOldest() {
+    UnknownSourceKeyRequestPolicy policy;
+    const unsigned cap = UnknownSourceKeyRequestPolicy::kMaxTrackedSources;
+    for (unsigned i = 0; i < cap; ++i) {
+        policy.record_request(sourceHex(i + 1), 1000 + static_cast<unsigned long long>(i));
+    }
+    CHECK(policy.last_requested.size() == cap);
+    // New source pushes the oldest (seed 1) out of the table.
+    const std::string evicted = sourceHex(1);
+    const std::string newest = sourceHex(cap + 1);
+    policy.record_request(newest, 5000);
+    CHECK(policy.last_requested.size() == cap);
+    // The evicted source is no longer rate-limited (its entry is gone).
+    CHECK(policy.should_request(evicted, 1010));
+    // The most recent source IS rate-limited.
+    CHECK(!policy.should_request(newest, 5001));
+}
+
+void testSteadyStateCostIsZero() {
+    // A known source is never recorded by the caller (UIManager only calls
+    // this for SOURCE_UNKNOWN), so once a peer is learned there is no
+    // per-message work here. Model the steady state: one learned source's
+    // hash must never appear in the table.
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string learned = sourceHex(7);
+    CHECK(policy.should_request(learned, 0));
+    // Caller records only when it actually fires; after the first request
+    // plus cooldown the table holds at most one entry per unknown peer.
+    policy.record_request(learned, 0);
+    CHECK(policy.last_requested.size() == 1);
+    CHECK(!policy.should_request(learned, 10));
+    CHECK(policy.should_request(learned, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+}
+
+void testConstants() {
+    CHECK(UnknownSourceKeyRequestPolicy::kCooldownMillis == 5U * 60U * 1000U);
+    CHECK(UnknownSourceKeyRequestPolicy::kMaxTrackedSources == 64U);
+}
+
+}  // namespace
+
+int main() {
+    testConstants();
+    testNewSourceIsRequested();
+    testCooldownSuppressesRepeat();
+    testReRecordResetsCooldown();
+    testSourcesTrackedIndependently();
+    testCapacityCapEvictsOldest();
+    testSteadyStateCostIsZero();
+    std::cout << "unknown source key request policy: " << passed << " passed, "
+              << failures << " failed" << std::endl;
+    return failures == 0 ? 0 : 1;
+}

--- a/tests/native/test_unknown_source_key_request.cpp
+++ b/tests/native/test_unknown_source_key_request.cpp
@@ -4,9 +4,11 @@
 // The policy decides when the firmware fires an RNS path request for an
 // LXMF message from an identity it has not learned (Sideband's "Query
 // Network For Keys" equivalent). The decision must be pure and bounded:
-// one request per source per cooldown, independent per source, and a
-// capped tracking table so an opportunistic flood of unknown senders can
-// neither hammer the transport nor starve the table forever.
+// one request per source per 30-minute window, independent per source,
+// and an aggregate bound — a flood of distinct bogus identities must
+// never force more than kMaxTrackedSources requests per window, and a
+// source whose window is open must stay suppressed for the whole window
+// no matter what.
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -32,8 +34,8 @@ int failures = 0;
 using UI::LXMF::UnknownSourceKeyRequestPolicy;
 
 std::string sourceHex(unsigned seed) {
-    // Distinct 8-hex string per seed up to 0xffffff (the tests use <= 65),
-    // so the capacity-cap test has no hash collisions.
+    // Distinct 8-hex string per seed up to 0xffffff (the tests use <=
+    // 1512), so the flood tests have no hash collisions.
     const char* digits = "0123456789abcdef";
     std::string hex;
     for (unsigned shift : {28U, 24U, 20U, 16U, 12U, 8U, 4U, 0U}) {
@@ -53,7 +55,7 @@ void testCooldownSuppressesRepeat() {
     UnknownSourceKeyRequestPolicy policy;
     const std::string src = sourceHex(2);
     policy.record_request(src, 1000);
-    // Within the 5-minute cooldown: suppressed.
+    // Within the 30-minute cooldown: suppressed.
     CHECK(!policy.should_request(src, 1001));
     CHECK(!policy.should_request(src, 1000 + UnknownSourceKeyRequestPolicy::kCooldownMillis - 1));
     // At and after the cooldown: requested again.
@@ -85,22 +87,32 @@ void testSourcesTrackedIndependently() {
     CHECK(!policy.should_request(b, 300));
 }
 
-void testCapacityCapEvictsOldest() {
+void testSaturatedTableDeclinesNewSources() {
+    // While every tracking slot holds an open window, a never-before-seen
+    // source is DECLINED (deferred), not tracked by dropping someone
+    // else's window. Existing sources stay suppressed throughout.
     UnknownSourceKeyRequestPolicy policy;
     const unsigned cap = UnknownSourceKeyRequestPolicy::kMaxTrackedSources;
-    for (unsigned i = 0; i < cap; ++i) {
-        policy.record_request(sourceHex(i + 1), 1000 + static_cast<unsigned long long>(i));
+    for (unsigned i = 1; i <= cap; ++i) {
+        policy.record_request(sourceHex(i),
+            1000 + static_cast<unsigned long long>(i) * 1000);
     }
     CHECK(policy.last_requested.size() == cap);
-    // New source pushes the oldest (seed 1) out of the table.
-    const std::string evicted = sourceHex(1);
-    const std::string newest = sourceHex(cap + 1);
-    policy.record_request(newest, 5000);
+    const std::string stranger = sourceHex(1000);
+    CHECK(!policy.should_request(stranger, 2000));
+    // Nobody's open window was dropped to make room: existing sources are
+    // still suppressed.
+    CHECK(!policy.should_request(sourceHex(1), 2000));
+    CHECK(!policy.should_request(sourceHex(cap), 2000));
     CHECK(policy.last_requested.size() == cap);
-    // The evicted source is no longer rate-limited (its entry is gone).
-    CHECK(policy.should_request(evicted, 1010));
-    // The most recent source IS rate-limited.
-    CHECK(!policy.should_request(newest, 5001));
+    // The deferred source stays declined while the budget is full, and
+    // becomes eligible as soon as the first recorded window expires
+    // (src 1, recorded at 2000, expires at 2000 + cooldown).
+    CHECK(!policy.should_request(stranger, 1801000 - 1));  // all still open
+    const unsigned long long after_windows = 2000 + UnknownSourceKeyRequestPolicy::kCooldownMillis;
+    CHECK(policy.should_request(stranger, after_windows));
+    policy.record_request(stranger, after_windows);
+    CHECK(policy.last_requested.size() == cap);
 }
 
 void testSteadyStateCostIsZero() {
@@ -119,8 +131,89 @@ void testSteadyStateCostIsZero() {
     CHECK(policy.should_request(learned, UnknownSourceKeyRequestPolicy::kCooldownMillis));
 }
 
+void testFloodBoundWorstCaseAirtime() {
+    // Worst-case airtime an attacker can force: flood more distinct bogus
+    // identities than the table can track, all inside one 30-minute
+    // window. The total number of requests fired must be bounded by the
+    // table cap, and every fired source must stay suppressed for the rest
+    // of the window.
+    UnknownSourceKeyRequestPolicy policy;
+    const unsigned cap = UnknownSourceKeyRequestPolicy::kMaxTrackedSources;
+    const unsigned long long t0 = 100000;
+    const unsigned flood = 512;
+    unsigned requests_fired = 0;
+    for (unsigned i = 1; i <= flood; ++i) {
+        const std::string src = sourceHex(1000 + i);
+        const unsigned long long now = t0 + static_cast<unsigned long long>(i) * 1000;
+        if (policy.should_request(src, now)) {
+            ++requests_fired;
+            policy.record_request(src, now);
+        }
+    }
+    CHECK(requests_fired == cap);
+    CHECK(policy.last_requested.size() == cap);
+    // No identity whose window is open can fire a second time.
+    unsigned violations = 0;
+    for (unsigned i = 1; i <= flood; ++i) {
+        const std::string src = sourceHex(1000 + i);
+        const unsigned long long now = t0 + 29U * 60U * 1000U;
+        if (policy.should_request(src, now)) {
+            ++violations;
+        }
+    }
+    CHECK(violations == 0);
+}
+
+void testFloodBoundAcrossConsecutiveWindows() {
+    // Aggregate bound: the same 512 identities re-ask in a second
+    // 30-minute window (each exactly one window after its first request,
+    // staggered one per second). The first window's budget only frees one
+    // slot per second as the first requests expire, so the 65th identity's
+    // second request is still declined — at most cap requests may fire in
+    // the second window too.
+    UnknownSourceKeyRequestPolicy policy;
+    const unsigned cap = UnknownSourceKeyRequestPolicy::kMaxTrackedSources;
+    const unsigned long long t0 = 100000;
+    const unsigned flood = 512;
+    unsigned first_window = 0;
+    unsigned second_window = 0;
+    for (unsigned i = 1; i <= flood; ++i) {
+        const std::string src = sourceHex(1000 + i);
+        const unsigned long long w1 = t0 + static_cast<unsigned long long>(i) * 1000;
+        if (policy.should_request(src, w1)) {
+            ++first_window;
+            policy.record_request(src, w1);
+        }
+        const unsigned long long w2 = w1 + UnknownSourceKeyRequestPolicy::kCooldownMillis;
+        if (policy.should_request(src, w2)) {
+            ++second_window;
+            policy.record_request(src, w2);
+        }
+    }
+    CHECK(first_window == cap);
+    CHECK(second_window == cap);
+}
+
+void testWindowExpiryPrunesAndAllows() {
+    UnknownSourceKeyRequestPolicy policy;
+    const std::string a = sourceHex(20);
+    const std::string b = sourceHex(21);
+    policy.record_request(a, 0);
+    policy.record_request(b, 5000);
+    CHECK(!policy.should_request(a, 6000));
+    CHECK(!policy.should_request(b, 6000));
+    // a's window expires before b's; the table prunes a lazily and makes
+    // room for a new source while b stays suppressed.
+    CHECK(policy.should_request(a, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    const std::string c = sourceHex(22);
+    CHECK(policy.should_request(c, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    policy.record_request(c, UnknownSourceKeyRequestPolicy::kCooldownMillis);
+    CHECK(!policy.should_request(b, UnknownSourceKeyRequestPolicy::kCooldownMillis));
+    CHECK(!policy.should_request(c, UnknownSourceKeyRequestPolicy::kCooldownMillis + 1));
+}
+
 void testConstants() {
-    CHECK(UnknownSourceKeyRequestPolicy::kCooldownMillis == 5U * 60U * 1000U);
+    CHECK(UnknownSourceKeyRequestPolicy::kCooldownMillis == 30U * 60U * 1000U);
     CHECK(UnknownSourceKeyRequestPolicy::kMaxTrackedSources == 64U);
 }
 
@@ -132,8 +225,11 @@ int main() {
     testCooldownSuppressesRepeat();
     testReRecordResetsCooldown();
     testSourcesTrackedIndependently();
-    testCapacityCapEvictsOldest();
+    testSaturatedTableDeclinesNewSources();
     testSteadyStateCostIsZero();
+    testFloodBoundWorstCaseAirtime();
+    testFloodBoundAcrossConsecutiveWindows();
+    testWindowExpiryPrunesAndAllows();
     std::cout << "unknown source key request policy: " << passed << " passed, "
               << failures << " failed" << std::endl;
     return failures == 0 ? 0 : 1;

--- a/tests/native/test_unknown_source_key_request.py
+++ b/tests/native/test_unknown_source_key_request.py
@@ -1,0 +1,21 @@
+"""Compile and execute the unknown-source key-request policy test."""
+
+from pathlib import Path
+
+from native_test import compile_and_run
+
+HERE = Path(__file__).resolve().parent
+PYXIS_ROOT = HERE.parent.parent
+
+
+def test_unknown_source_key_request(tmp_path):
+    ran = compile_and_run(
+        tmp_path,
+        name="test_unknown_source_key_request",
+        sources=[HERE / "test_unknown_source_key_request.cpp"],
+        include_dirs=[PYXIS_ROOT / "lib" / "tdeck_ui"],
+        sanitize=True,
+        timeout=60,
+    )
+    assert "unknown source key request policy:" in ran.stdout
+    assert "0 failed" in ran.stdout


### PR DESCRIPTION
## Summary

When an LXMF message is delivered to the T-Deck from a source whose RNS
identity has not been learned, the microLXMF router accepts it (treating
`SOURCE_UNKNOWN` as "will validate later if the identity is learned via
announce", LXMRouter.cpp:1267), but location ingest in
`UIManager::on_message_received` is gated on `signature_validated()` — so
telemetry from a new peer stays unauthenticated until a natural announce
happens to arrive. Nothing in the firmware ever triggered that learning.

This adds the missing trigger: on the first (rate-limited) unvalidated
`SOURCE_UNKNOWN` message from a peer, fire an RNS path request for that
source's delivery hash — the same wire mechanism as Sideband's "Query
Network For Keys" button (`RNS.Transport.request_path`). Any peer that
already holds the source's cached announce (a phone on the same link, a
hub, another node) answers with it; the T-Deck learns the key, and the
next message from that peer validates and reaches location ingest (map
pin).

The trigger is transport-agnostic (LoRa/RNode, TCP) and message-type
agnostic: it covers every LXMF message from an unknown identity, not
just telemetry.

**Not covered (separate PR, per discussion):** messages from a *known*
identity whose signature is *invalid* (bad key / tampered) do not trigger
a request — asking the network for the same key it already has cannot
help. Tampered-message handling is a follow-up.

## Rate limiting (updated per review)

Automatic path requests are limited to **one per 30 minutes per unknown
identity**, plus an **aggregate bound**: at most 64 automatic path
requests per rolling 30-minute window network-wide. The tracking table
no longer evicts an open window to make room — while all 64 slots hold
unexpired windows, never-before-seen identities are deferred (at most
one 30-minute window) instead of dropping someone else's cooldown. This
addresses the Greptile P2 (eviction could reset an open cooldown, so a
flood of distinct bogus identities forced unbounded path requests): a
rotating-identity flood can now only force 64 requests per window, each
of which peers answer only if they actually hold the announce.

## What's in the PR

- `lib/tdeck_ui/UI/LXMF/UnknownSourceKeyRequest.h` — pure, header-only
  rate-limit policy (30-minute per-identity cooldown, 64-request rolling
  budget; open windows are only ever pruned after they expire). No
  ESP/microReticulum dependencies so it is host-testable.
- `lib/tdeck_ui/UI/LXMF/UIManager.cpp` — `request_key_for_unknown_source()`
  (SOURCE_UNKNOWN + PEER_ID_SIZE check + policy gate + the
  `Transport::request_path` side effect) called at the top of
  `on_message_received` for every unvalidated message. The temporary
  per-frame location-ingest diagnostic (peer bytes, coordinates, clock
  skew) is removed — the missing-map-pin investigation is closed.
- `tests/native/test_unknown_source_key_request.{cpp,py}` — 40 checks,
  ASan+UBSan, via the standard `native_test` harness (discovered by the
  existing `pytest tests/build_scripts tests/native` CI job): new-source
  request, 30-min cooldown boundary, re-record resets the window,
  per-source independence, saturated-budget deferral, 512-identity flood
  bound (single window and across consecutive windows), lazy expiry/
  prune, steady-state cost, constant values.

## Verification

- `pio run -e tdeck` — SUCCESS (clean tree of this PR's head, no warnings
  beyond baseline; RAM 23.1%, Flash 92.4%).
- `pytest tests/native/test_unknown_source_key_request.py -v` — 1 passed
  (40/40 internal checks, ASan+UBSan clean).
- `pytest tests/build_scripts tests/native` — 286 passed, 4 skipped; the
  2 failures are environment-only (real-peer gate env vars not set in
  this worktree; CI-PlatformIO shim absent locally), unrelated to this
  change.
- Physical evidence motivating the fix: with a direct LoRa/RNode link
  (hub down), the iPhone client's `lxmf.delivery` announce was learned
  by the T-Deck via natural propagation and its telemetry rendered as a
  map pin — confirming the pipeline end-to-end once the key is known.
  This PR makes the key acquisition proactive instead of waiting for
  announce luck.