### PR TITLE
fix(lxmf): drop SIGNATURE_INVALID inbound messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,14 @@ jobs:
 
       # microReticulum native17 vendors libbz2 sources but link_bz2.py
       # links against system libbz2 — needs libbz2-dev on Ubuntu.
+      # apt-get update first: the ubuntu-latest runner's apt index can be
+      # stale, and installing the pinned libbz2-dev from a stale index 404s
+      # against the security mirror (the pyxis-pytest job above already
+      # updates before its install).
       - name: Install libbz2-dev
-        run: sudo apt-get install -y libbz2-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libbz2-dev
 
       # Run only suites that build cleanly under native17 in the fork.
       # Erroring suites (test_ble, test_tdeck, test_lxmf, test_ratchets, etc.)

--- a/lib/tdeck_ui/UI/LXMF/UIManager.cpp
+++ b/lib/tdeck_ui/UI/LXMF/UIManager.cpp
@@ -1649,6 +1649,28 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
     // Arduino loop's `UIManager::update()` would assert at the 5s
     // LVGL_LOCK timeout (LVGLLock.h:45), tipping pyxis into a panic
     // reset. Scope the lock to ONLY the UI mutations below.
+    // Drop messages whose source identity is KNOWN but whose signature
+    // fails to validate (spoofed or malicious — an attacker forging a
+    // legitimate peer's hash). The opportunistic (on_packet) and direct
+    // (on_resource_concluded) router paths already reject these, but the
+    // propagated (store-and-forward) path — process_propagated_lxmf —
+    // queues them without a signature check, so this handler is the only
+    // choke point that covers all three. Drop before anything else: no
+    // key request, no location ingest, no persistence, no render, no
+    // notification.
+    //
+    // SOURCE_UNKNOWN is NOT dropped here: a first-contact peer's message
+    // may be legitimate and the key is still being learned (key request
+    // below), so those render as today.
+    if (!message.signature_validated() &&
+        message.unverified_reason() ==
+            ::LXMF::Type::Message::SIGNATURE_INVALID) {
+        WARNING(("Dropping message with invalid signature from " +
+                 message.source_hash().toHex().substr(0, 8) +
+                 "...").c_str());
+        return;
+    }
+
     std::string source_hex = message.source_hash().toHex().substr(0, 8);
     std::string msg = "Message received from " + source_hex + "...";
     INFO(msg.c_str());
@@ -1657,10 +1679,12 @@ void UIManager::on_message_received(::LXMF::LXMessage& message) {
     pyxis_test_hook_record_rx(message);
 #endif
 
-    // Diagnostic: unauthenticated messages are accepted by the router but
-    // skipped below for location ingest. Ask the network for the source's
-    // key (Sideband "request keys" equivalent) so the NEXT message from
-    // this peer can validate and be plotted.
+    // First-contact key learning: unauthenticated messages from a source
+    // whose identity has not been learned yet (SOURCE_UNKNOWN) are accepted
+    // by the router but skipped below for location ingest. Ask the network
+    // for the source's key (Sideband "request keys" equivalent) so the NEXT
+    // message from this peer can validate and be plotted. Signature-invalid
+    // messages were already dropped above.
     if (!message.signature_validated()) {
         request_key_for_unknown_source(message);
     }

--- a/tests/build_scripts/test_inbound_signature_drop.py
+++ b/tests/build_scripts/test_inbound_signature_drop.py
@@ -1,0 +1,105 @@
+"""Source-level contract for inbound SIGNATURE_INVALID drop in on_message_received.
+
+The microLXMF router rejects SIGNATURE_INVALID on the opportunistic and direct
+paths, but the propagated (store-and-forward) path queues them unchecked, so
+UIManager::on_message_received is the single choke point that must drop them
+before ANY side effect. These checks lock in that ordering and the enum
+specificity (drop SIGNATURE_INVALID only, never SOURCE_UNKNOWN or validated).
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CPP = ROOT / "lib/tdeck_ui/UI/LXMF/UIManager.cpp"
+
+
+def handler_body(source: str) -> str:
+    start = source.index("void UIManager::on_message_received(")
+    end = source.index("void UIManager::on_message_delivered(", start)
+    return source[start:end]
+
+
+def test_drop_gate_precedes_all_side_effects():
+    source = CPP.read_text()
+    handler = handler_body(source)
+
+    # The drop gate is keyed on the SIGNATURE_INVALID enum inside an "if"
+    # condition. Locate that condition (the only place the handler checks
+    # the enum); its position is the gate's entry point.
+    drop = handler.index("::LXMF::Type::Message::SIGNATURE_INVALID")
+    gate_if = handler.rfind("if (!message.signature_validated() &&", 0, drop)
+    assert gate_if >= 0, "drop gate must be an if(!validated && reason==SIGNATURE_INVALID)"
+
+    # Every side effect of a received message must come AFTER the drop gate,
+    # so a spoofed message triggers none of them.
+    for label, marker in [
+        ("initial log", '"Message received from "'),
+        ("test-hook record", "pyxis_test_hook_record_rx(message)"),
+        ("key request", "request_key_for_unknown_source(message)"),
+        ("location ingest", "_peer_locations.apply"),
+        ("persistence", "if (!_store.save_message(message))"),
+        ("chat render", "_chat_screen->add_message(message, false)"),
+        ("notification", "tone_play("),
+    ]:
+        pos = handler.index(marker)
+        assert drop < pos, f"drop gate must precede {label}"
+
+
+def test_drop_gate_is_specific_to_signature_invalid():
+    source = CPP.read_text()
+    handler = handler_body(source)
+
+    drop = handler.index("::LXMF::Type::Message::SIGNATURE_INVALID")
+
+    # The gate must be a single if(!validated && reason==SIGNATURE_INVALID)
+    # block that logs and returns. A validated message short-circuits on the
+    # first term; a SOURCE_UNKNOWN message short-circuits on the second.
+    gate_start = handler.rfind("if (!message.signature_validated() &&", 0, drop)
+    assert gate_start >= 0
+    gate_end = handler.index("return;", drop)
+    gate = handler[gate_start:gate_end]
+    assert "!message.signature_validated() &&" in gate
+    assert "message.unverified_reason() ==\n            ::LXMF::Type::Message::SIGNATURE_INVALID" in gate
+    # It must log before the return (so a dropped spoof is observable in the
+    # serial log without leaking message content).
+    assert "Dropping message with invalid signature from" in gate
+    # The return immediately follows the log (the gate returns, it does not
+    # fall through to the side effects).
+    assert handler[gate_end:gate_end + len("return;")] == "return;"
+    assert gate.index("Dropping message with invalid signature from") > gate.index(
+        "SIGNATURE_INVALID"
+    )
+
+
+def test_source_unknown_still_reaches_key_request():
+    source = CPP.read_text()
+    handler = handler_body(source)
+
+    # A SOURCE_UNKNOWN message passes the drop gate (its reason is not
+    # SIGNATURE_INVALID) and must still reach the key request, which fires a
+    # path request so the peer's announce can be learned. The key-request
+    # call sits AFTER the drop gate and is gated only on
+    # !signature_validated(), so first-contact traffic is unaffected.
+    drop = handler.index("::LXMF::Type::Message::SIGNATURE_INVALID)")
+    key = handler.index("request_key_for_unknown_source(message)")
+    assert drop < key
+    # The key-request call is guarded by !signature_validated() (the
+    # first-contact case), not by SIGNATURE_INVALID.
+    guard = handler[handler.rfind("if (", 0, key):key]
+    assert "!message.signature_validated()" in guard
+    assert "SIGNATURE_INVALID" not in guard
+
+
+def test_validated_messages_are_not_affected():
+    source = CPP.read_text()
+    handler = handler_body(source)
+
+    # The drop gate's first term is !signature_validated(), so a message that
+    # validated short-circuits and skips the drop entirely — it proceeds to
+    # the (unchanged) location ingest and persistence.
+    drop = handler.index("::LXMF::Type::Message::SIGNATURE_INVALID)")
+    gate = handler[handler.rfind("if (", 0, drop):drop]
+    assert gate.index("!message.signature_validated()") >= 0
+    # Persistence and render remain present for the happy path.
+    assert "if (!_store.save_message(message))" in handler
+    assert "_chat_screen->add_message(message, false)" in handler


### PR DESCRIPTION
## Summary

When an LXMF message arrives whose **source identity is known** but whose
Ed25519 signature **fails to validate** (`SIGNATURE_INVALID`), the message
is spoofed or malicious — an attacker forging a legitimate peer's hash.
Pyxis should drop it entirely: no persistence, no render, no notification.

**The gap this closes:** the microLXMF router already rejects
`SIGNATURE_INVALID` on the opportunistic (`on_packet`) and direct
(`on_resource_concluded`) delivery paths, but the **propagated
(store-and-forward) path** — `process_propagated_lxmf` (LXMRouter.cpp:2359)
— queues unpacked messages **without a signature check**. All three paths
funnel into the same pending queue → `process_inbound` → the app's
`UIManager::on_message_received`, which today saves
(`_store.save_message`, line 1772) and renders
(`_chat_screen->add_message`) unconditionally. So a spoofed message
arriving via propagation was previously saved to conversation history and
displayed.

## The fix

Drop at the top of `UIManager::on_message_received` — the single choke
point covering all three router paths:

```cpp
if (!message.signature_validated() &&
    message.unverified_reason() ==
        ::LXMF::Type::Message::SIGNATURE_INVALID) {
    WARNING("Dropping message with invalid signature from ...");
    return;
}
```

- Drops **before** every side effect: initial log, test-hook record, key
  request, location ingest, persistence, chat render, notification beep.
- `SOURCE_UNKNOWN` (first contact, identity not yet learned) is **not
  dropped** — those still render and still trigger the bounded key request
  from PR #92 (which already no-ops on `SIGNATURE_INVALID`, so no path
  request is fired for a spoofed identity).
- Validated messages: unaffected.
- No microLXMF pin change; app-only. (Fixing the propagated path in the
  router itself would also be correct, but the app is the choke point that
  guarantees the invariant regardless of router internals.)


## CI note: this branch also carries one independent CI fix

- `.github/workflows/test.yml` — add the missing `apt-get update` before `apt-get install -y libbz2-dev` in the microReticulum native17 job (commit d73a48f). Pre-existing flake: the install ran against a stale runner apt index and 404'd the pinned package, failing the job before any test ran (main's PR #92 merge commit failed identically). Separately committed so it can be reviewed/reverted on its own.

## What's in the PR

- `lib/tdeck_ui/UI/LXMF/UIManager.cpp` — the drop gate in
  `on_message_received` + updated comment on the key-request block.
- `tests/build_scripts/test_inbound_signature_drop.py` — source-level
  contract (the same style as `test_message_persistence_contract.py` /
  `test_location_message_policy_integration.py`): the gate precedes all
  side effects; the gate is specifically
  `!signature_validated() && reason == SIGNATURE_INVALID` and logs then
  returns; `SOURCE_UNKNOWN` still reaches the key request; validated
  messages are unaffected.

## Verification

- `pio run -e tdeck` — SUCCESS (RAM 23.1%, Flash 92.4%); firmware.bin
  sha256 `fbd71e5db809c030c43bcb7b1d21413794dd4b3037d9198eb50305673360dd3c`
  (2,907,040 bytes).
- `pytest tests/build_scripts tests/native` — 290 passed, 4 skipped; the
  1 failure + 2 errors are environment-only (real-peer gate env vars and
  CI-PlatformIO shim absent locally), same as on PR #92's head.
- Existing invariants hold: `test_message_persistence_contract.py`
  (save-before-display for the happy path) and
  `test_location_message_policy_integration.py` both pass unchanged.
- Physical validation: **pending** — needs a device run: with a known
  peer, corrupt/tamper one message's content (or replay a mutated frame)
  and confirm the serial log shows "Dropping message with invalid
  signature from ..." and the message never appears in the chat or the
  conversation list.