### PR TITLE
ui(map): contrast pin labels against active basemap

### DIFF
--- a/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
+++ b/lib/tdeck_ui/UI/LXMF/MapScreen.cpp
@@ -100,6 +100,13 @@ const char* styleLabel(const char* style_id) {
     return "Style";
 }
 
+// The allowlist is otherwise light basemaps (osm-bright, positron, toner).
+// Marker labels sit directly on those tiles with no backing plate, so black
+// reads on light backgrounds and white only on the one dark basemap.
+bool isDarkBasemap(const char* style_id) {
+    return style_id != nullptr && std::strcmp(style_id, "dark-matter") == 0;
+}
+
 }  // namespace
 
 static_assert(sizeof(lv_color_t) == 2U,
@@ -728,6 +735,13 @@ void MapScreen::applyFrame() {
             setPlaceholder(index);
         }
     }
+    // Marker labels float directly over the basemap tiles (no backing plate),
+    // so their ink must contrast the active style: black on light basemaps,
+    // white on the one dark basemap. Re-evaluated every frame so a style
+    // switch re-colors any visible labels on the next applied frame.
+    const lv_color_t marker_label_color =
+        isDarkBasemap(style_selector_.activeId())
+            ? lv_color_white() : lv_color_black();
     for (std::size_t index = 0; index < MARKER_COUNT; ++index) {
         if (index >= frame.marker_count) {
             lv_obj_add_flag(approximation_halos_[index], LV_OBJ_FLAG_HIDDEN);
@@ -764,6 +778,7 @@ void MapScreen::applyFrame() {
                           marker.peer.bytes[Telemetry::PEER_ID_SIZE - 1U]);
         }
         lv_label_set_text(marker_labels_[index], label);
+        lv_obj_set_style_text_color(marker_labels_[index], marker_label_color, 0);
         lv_obj_set_pos(marker_labels_[index], x + 6, y - 7);
         lv_obj_clear_flag(marker_labels_[index], LV_OBJ_FLAG_HIDDEN);
     }

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -275,11 +275,16 @@ def test_marker_labels_contrast_active_basemap_style():
     # The ternary text encodes the contract: dark basemap -> white,
     # otherwise -> black (so black is the default for light basemaps).
     assert "lv_color_white() : lv_color_black()" in frame
-    assert "lv_obj_set_style_text_color(marker_labels_[index], marker_label_color, 0)" in frame
-    # The color is derived once per frame and applied inside the marker loop.
-    derive = frame.index("marker_label_color")
-    apply = frame.index("lv_obj_set_style_text_color(marker_labels_[index], marker_label_color")
-    assert derive < apply
+    # Exactly one label-color call, and it sits in the marker loop's main
+    # branch: after the loop's hidden-marker continue, not in the hide path.
+    apply_marker = "lv_obj_set_style_text_color(marker_labels_[index], marker_label_color"
+    assert frame.count(apply_marker) == 1
+    loop = frame.index("for (std::size_t index = 0; index < MARKER_COUNT; ++index)")
+    loop_branch_continue = frame.index("continue;", loop)
+    apply = frame.index(apply_marker)
+    assert loop < loop_branch_continue < apply
+    # The color itself is derived once, before the loop applies it.
+    assert frame.index("marker_label_color") < apply
 
 
 def test_ui_manager_services_before_lock_and_hides_map_everywhere():

--- a/tests/build_scripts/test_map_screen_contract.py
+++ b/tests/build_scripts/test_map_screen_contract.py
@@ -262,6 +262,26 @@ def test_style_switch_is_bounded_and_worker_owned():
     assert "style_selector_.clearError()" in hide
 
 
+def test_marker_labels_contrast_active_basemap_style():
+    source = text(UI / "MapScreen.cpp")
+    # The allowlist is light basemaps except one dark style, so pin labels are
+    # black by default and white only over the dark basemap.
+    assert "bool isDarkBasemap(const char* style_id)" in source
+    dark = function_body(source, "bool isDarkBasemap(const char* style_id)")
+    assert "std::strcmp(style_id, \"dark-matter\") == 0" in dark
+
+    frame = function_body(source, "void MapScreen::applyFrame()")
+    assert "isDarkBasemap(style_selector_.activeId())" in frame
+    # The ternary text encodes the contract: dark basemap -> white,
+    # otherwise -> black (so black is the default for light basemaps).
+    assert "lv_color_white() : lv_color_black()" in frame
+    assert "lv_obj_set_style_text_color(marker_labels_[index], marker_label_color, 0)" in frame
+    # The color is derived once per frame and applied inside the marker loop.
+    derive = frame.index("marker_label_color")
+    apply = frame.index("lv_obj_set_style_text_color(marker_labels_[index], marker_label_color")
+    assert derive < apply
+
+
 def test_ui_manager_services_before_lock_and_hides_map_everywhere():
     source = text(UI / "UIManager.cpp")
     update = function_body(source, "void UIManager::update()")


### PR DESCRIPTION
## Summary

Map pin (marker) labels previously inherited the app's default text color, which
reads white and disappears on light basemaps. This makes each label's ink
contrast the active basemap: **black by default** (light basemaps
`osm-bright`, `positron`, `toner`) and **white only** on the one dark basemap
(`dark-matter`).

The color is re-evaluated every frame in `applyFrame()` from
`style_selector_.activeId()`, so a style switch re-colors any visible labels
on the next applied frame.

## Changes

- `lib/tdeck_ui/UI/LXMF/MapScreen.cpp`
  - New `isDarkBasemap()` helper (anonymous namespace, next to the existing
    `styleLabel()`): exact-id match on `dark-matter`, the only dark entry in
    the PMAS allowlist.
  - `applyFrame()` derives `marker_label_color` once per frame
    (`white if isDarkBasemap else black`) and applies it via
    `lv_obj_set_style_text_color` on each visible marker label.
- `tests/build_scripts/test_map_screen_contract.py`
  - New `test_marker_labels_contrast_active_basemap_style`: pins the
    dark-basemap detection, the black-default / white-on-dark ternary, and
    that the color is derived once per frame and applied inside the marker
    loop (source-level contract test, per the repo convention for
    LVGL-rendering invariants that are not host-exercisable).

## Verification (host)

- `pytest tests/build_scripts/test_map_screen_contract.py` — 10 passed
  (9 existing + 1 new)
- Full suite `pytest tests/build_scripts tests/native` — 293 passed, 4
  skipped, 1 failed. The single failure is
  `test_nomadnet_x86_real_peer_flow`, the mandatory real-peer gate whose
  `PYXIS_NOMADNET_*` env vars are unset in this environment; identical on
  `origin/main` (52b844b), not a regression.
- `pio run -e tdeck` — SUCCESS, Flash 92.4%, RAM 23.1%

## Device (physical)

Built `902df65`, embedded version `0.3.7-10-g902df65`, 2,907,120 bytes,
sha256 `eedf1c321c6d5d7c729f15d1476cd6b12ea9d72bc36c2e3140185f6542eec20c`.
App-only flash to T-Deck app0 @ 0x10000: all six non-target regions
(partition table, NVS, otadata, alternate slot, filesystem, coredump) read
back byte-identical; app0 read-back sha256 + byte-for-byte verified; boot
`COMPLETE total=13692ms`, identity and 9 conversations preserved, no crash
signatures.

**Visual acceptance pending:** open Maps on a light style (labels black),
cycle Style to Dark (labels white), and confirm the switch tracks live.
